### PR TITLE
Add application.displayVersion and environment.settings.e10sCohort for "main" pings

### DIFF
--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -27,15 +27,15 @@
         },
         "platformVersion": {
           "type": "string",
-          "pattern": "^\\d{2}\\."
+          "pattern": "^\\d{3}\\."
         },
         "version": {
           "type": "string",
-          "pattern": "^\\d{2}\\."
+          "pattern": "^\\d{3}\\."
         },
         "displayVersion": {
           "type": "string",
-          "pattern": "^\\d{2}\\."
+          "pattern": "^\\d{3}\\."
         },
         "vendor": {
           "type": "string"
@@ -172,14 +172,14 @@
             },
             "version": {
               "type": "string",
-              "pattern": "^\\d{2}\\."
+              "pattern": "^\\d{3}\\."
             },
             "vendor": {
               "type": "string"
             },
             "platformVersion": {
               "type": "string",
-              "pattern": "^\\d{2}\\."
+              "pattern": "^\\d{3}\\."
             },
             "xpcomAbi": {
               "type": "string"

--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -278,6 +278,9 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "e10sCohort": {
+              "type": "string"
+            },
             "locale": {
               "type": "string"
             },

--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -27,15 +27,15 @@
         },
         "platformVersion": {
           "type": "string",
-          "pattern": "^[0-9]{3}\\."
+          "pattern": "^[0-9]{2,3}\\."
         },
         "version": {
           "type": "string",
-          "pattern": "^[0-9]{3}\\."
+          "pattern": "^[0-9]{2,3}\\."
         },
         "displayVersion": {
           "type": "string",
-          "pattern": "^[0-9]{3}\\."
+          "pattern": "^[0-9]{2,3}\\."
         },
         "vendor": {
           "type": "string"
@@ -173,14 +173,14 @@
             },
             "version": {
               "type": "string",
-              "pattern": "^[0-9]{3}\\."
+              "pattern": "^[0-9]{2,3}\\."
             },
             "vendor": {
               "type": "string"
             },
             "platformVersion": {
               "type": "string",
-              "pattern": "^[0-9]{3}\\."
+              "pattern": "^[0-9]{2,3}\\."
             },
             "xpcomAbi": {
               "type": "string"

--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -33,6 +33,10 @@
           "type": "string",
           "pattern": "^\\d{2}\\."
         },
+        "displayVersion": {
+          "type": "string",
+          "pattern": "^\\d{2}\\."
+        },
         "vendor": {
           "type": "string"
         },

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -7,7 +7,7 @@
     "platformVersion": "45.0",
     "vendor": "Mozilla",
     "version": "45.0",
-    "version": "45.0b6",
+    "displayVersion": "45.0b6",
     "xpcomAbi": "x86_64-gcc3"
   },
   "clientId": "6fd3eb50-8bec-4b9c-8778-59406171312a",

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -325,6 +325,7 @@
         "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8"
       },
       "e10sEnabled": true,
+      "e10sCohort": "unknown",
       "isDefaultBrowser": true,
       "isInOptoutSample": false,
       "locale": "en-US",

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -2,11 +2,12 @@
   "application": {
     "architecture": "x86-64",
     "buildId": "20151103030248",
-    "channel": "nightly",
+    "channel": "beta",
     "name": "Firefox",
-    "platformVersion": "45.0a1",
+    "platformVersion": "45.0",
     "vendor": "Mozilla",
-    "version": "45.0a1",
+    "version": "45.0",
+    "version": "45.0b6",
     "xpcomAbi": "x86_64-gcc3"
   },
   "clientId": "6fd3eb50-8bec-4b9c-8778-59406171312a",
@@ -288,7 +289,7 @@
         "scope": 4,
         "updateDay": 16742,
         "userDisabled": false,
-        "version": "45.0a1"
+        "version": "45.0"
       }
     },
     "build": {
@@ -298,9 +299,9 @@
       "architecturesInBinary": "i386-x86_64",
       "buildId": "20151103030248",
       "hotfixVersion": "20150225.01",
-      "platformVersion": "45.0a1",
+      "platformVersion": "45.0",
       "vendor": "Mozilla",
-      "version": "45.0a1",
+      "version": "45.0",
       "xpcomAbi": "x86_64-gcc3"
     },
     "partner": {
@@ -330,7 +331,7 @@
       "telemetryEnabled": true,
       "update": {
         "autoDownload": true,
-        "channel": "nightly",
+        "channel": "beta",
         "enabled": true
       },
       "userPrefs": {
@@ -15890,7 +15891,7 @@
       }
     },
     "info": {
-      "addons": "masspasswordreset%40johnathan.nightingale:1.05.1-signed,foxyproxy%40eric.h.jung:4.5.5,eliteproxyswitcher%40my-proxy.com:1.2.0.2.1-signed,%7B972ce4c6-7e08-4474-a285-3208198ce6fd%7D:45.0a1,fxos_2_1_simulator%40mozilla.org:2.1.20141223.1-signed,fxos_1_4_simulator%40mozilla.org:1.4.20140506.1-signed,adbhelper%40mozilla.org:0.8.5,fxdevtools-adapters%40mozilla.org:0.3.3",
+      "addons": "masspasswordreset%40johnathan.nightingale:1.05.1-signed,foxyproxy%40eric.h.jung:4.5.5,eliteproxyswitcher%40my-proxy.com:1.2.0.2.1-signed,%7B972ce4c6-7e08-4474-a285-3208198ce6fd%7D:45.0,fxos_2_1_simulator%40mozilla.org:2.1.20141223.1-signed,fxos_1_4_simulator%40mozilla.org:1.4.20140506.1-signed,adbhelper%40mozilla.org:0.8.5,fxdevtools-adapters%40mozilla.org:0.3.3",
       "asyncPluginInit": false,
       "flashVersion": "19.0.0.226",
       "previousBuildId": "20151102030241",


### PR DESCRIPTION
This adds the application.displayVersion property; leaving it optional
for now until we figure out versioning.

This also updates the validation sample to show-case the difference in
version numbers.