### PR TITLE
Add defaultSearchEngineData.origin

### DIFF
--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -272,6 +272,9 @@
                 },
                 "submissionURL": {
                   "type": "string"
+                },
+                "origin": {
+                  "type": "string"
                 }
               }
             },

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -322,7 +322,8 @@
       "defaultSearchEngineData": {
         "loadPath": "jar:[app]/omni.ja!browser/google.xml",
         "name": "Google",
-        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8"
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8",
+        "origin": "default"
       },
       "e10sEnabled": true,
       "e10sCohort": "unknown",


### PR DESCRIPTION
Bug 1259139 [0] adds an origin property to
environment.settings.defaultSearchSearchEngineData, this updates the
main ping schema for it.