### PR TITLE
Add graphic fields

### DIFF
--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -387,13 +387,25 @@
                   ]
                 },
                 "adapters": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/adapter"
+                  }
                 },
                 "monitors": {
                   "type": [
                     "array",
                     "object"
-                  ]
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/monitor"
+                  }
+                },
+                "features": {
+                  "type": "object",
+                  "items": {
+                    "$ref": "#/definitions/features"
+                  }
                 }
               }
             },
@@ -652,6 +664,90 @@
         }
       }
     },
+    "adapter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": ["string", "null"]
+        },
+        "vendorID": {
+          "type": "string"
+        },
+        "deviceID": {
+          "type": "string"
+        },
+        "subsysID": {
+          "type": ["string", "null"]
+        },
+        "RAM": {
+          "type": ["integer", "null"]
+        },
+        "driver": {
+          "type": ["string", "null"]
+        },
+        "driverVersion": {
+          "type": ["string", "null"]
+        },
+        "driverDate": {
+          "type": ["string", "null"]
+        },
+        "GPUActive": {
+          "type": "boolean"
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "properties": {
+        "compositor": {
+          "type": "string"
+        },
+        "d2d": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "d3d11": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "opengl": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "webgl": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        }
+      }
+    },
+    "feature": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": ["string", "null"]
+        },
+        "failureId": {
+          "type": ["string", "null"]
+        },
+        "version": {
+          "type": ["string", "null"]
+        },
+        "warp": {
+          "type": ["boolean", "null"]
+        },
+        "textureSharing": {
+          "type": ["boolean", "null"]
+        }
+      }
+    },
     "histogram": {
       "type": "object",
       "properties": {
@@ -706,6 +802,26 @@
             "integer",
             "boolean"
           ]
+        }
+      }
+    },
+    "monitor": {
+      "type": "object",
+      "properties": {
+        "screenWidth": {
+          "type": "integer"
+        },
+        "screenHeight": {
+          "type": "integer"
+        },
+        "refreshRate": {
+          "type": "number"
+        },
+        "pseudoDisplay": {
+          "type": "boolean"
+        },
+        "scale": {
+          "type": "number"
         }
       }
     },


### PR DESCRIPTION
This is an improvement. I'm not familiar with this so you might want to review it carefully.

I left opengl/webgl/d2d/d3d11 as object but they will have an optional sub field 'failureId' that I'd really like to get into the dataset. But they also have a lot of other datafields. I think that's what the ["string", "null"] type might be but I wasn't sure.

I'm also not sure how to test this change?