### PR TITLE
Support core ping version 1 or higher

### DIFF
--- a/telemetry/core.schema.json
+++ b/telemetry/core.schema.json
@@ -34,7 +34,7 @@
     },
     "v" : {
       "type" : "integer",
-      "enum" : [ 1 ]
+      "minimum": 1
     }
   },
   "required" : ["arch", "clientId", "device", "locale", "os", "osversion", "seq", "v"]


### PR DESCRIPTION
In reality, core pings are already up to version 7.