### PR TITLE
Add gpu process histograms to main ping schema

### DIFF
--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -586,6 +586,25 @@
                   }
                 }
               }
+            },
+            "gpu": {
+              "type": "object",
+              "properties": {
+                "histograms": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/histogram"
+                  }
+                },
+                "keyedHistograms": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "$ref": "#/definitions/histogram"
+                    }
+                  }
+                }
+              }
             }
           },
           "required": [

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -15917,6 +15917,28 @@
           "WEAVE_ENGINE_SYNC_ERRORS": {},
           "WEAVE_STORAGE_AUTH_ERRORS": {}
         }
+      },
+      "gpu": {
+        "histograms": {
+          "A11Y_INSTANTIATED_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        },
+        "keyedHistograms": {
+          "ADDON_SHIM_USAGE": {}
+        }
       }
     },
     "info": {


### PR DESCRIPTION
This addresses bug 1314231:
https://bugzilla.mozilla.org/show_bug.cgi?id=1314231

Bug 1304494 added support for Telemetry accumulations from the GPU
process, this adds them to the main ping schema:
https://bugzilla.mozilla.org/show_bug.cgi?id=1304494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/17)
<!-- Reviewable:end -->
