### PR TITLE
Update core.schema with new Firefox for iOS fields

### DIFF
--- a/telemetry/core.schema.json
+++ b/telemetry/core.schema.json
@@ -35,6 +35,15 @@
     "v" : {
       "type" : "integer",
       "minimum" : 1
+    },
+    "defaultSearch": {
+      "type" : "string"
+    },
+    "defaultMailClient": {
+      "type" : "string"
+    },
+    "defaultNewTabExperience": {
+      "type" : "string"
     }
   },
   "required" : ["arch", "clientId", "device", "locale", "os", "osversion", "seq", "v"]


### PR DESCRIPTION
This patch introduces three fields for Firefox for iOS:

* `defaultSearch` - The search engine that the user has selected
* `defaultMailClient` - The mail client that the user prefers to use
* `defaultNewTabExperience` - What the user prefers to see when opening a new tab

The `defaultSearch` field was actually introduced in the iOS Core Ping earlier this year. The `core.schema.json` was never updated for it though.