### PR TITLE
Don't enumerate specific channels for crash pings.

### DIFF
--- a/telemetry/crash.schema.json
+++ b/telemetry/crash.schema.json
@@ -13,13 +13,7 @@
           "$ref": "#/definitions/buildId"
         },
         "channel": {
-          "type": "string",
-          "enum": [
-            "nightly",
-            "aurora",
-            "beta",
-            "release"
-          ]
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -289,13 +283,7 @@
                   "type": "boolean"
                 },
                 "channel": {
-                  "type": "string",
-                  "enum": [
-                    "nightly",
-                    "aurora",
-                    "beta",
-                    "release"
-                  ]
+                  "type": "string"
                 },
                 "enabled": {
                   "type": "boolean"


### PR DESCRIPTION
There are many other valid values for `channel`. Relax this requirement, similar to [this commit](https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/1149cb7a7f356f1a9888c664a805f2434823b7ef) for `main` pings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/23)
<!-- Reviewable:end -->
