### PR TITLE
Allow null for clientId in crash pings.

### DIFF
--- a/telemetry/crash.schema.json
+++ b/telemetry/crash.schema.json
@@ -50,7 +50,8 @@
       "additionalProperties": false
     },
     "clientId": {
-      "$ref": "#/definitions/UUID4"
+      "type": ["string", "null"],
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
     "creationDate": {
       "type": "string",


### PR DESCRIPTION
Some crash pings have a clientId field, but with a value of null.
Relax the schema to allow for these pings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/24)
<!-- Reviewable:end -->
