### PR TITLE
Add regex validation to Telemetry events

### DIFF
--- a/telemetry/main.schema.json
+++ b/telemetry/main.schema.json
@@ -846,13 +846,16 @@
           "minimum": 0
         },
         {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9_.]*[a-zA-Z0-9]$"
         },
         {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9_.]*[a-zA-Z0-9]$"
         },
         {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9_.]*[a-zA-Z0-9]$"
         },
         {
           "type": ["string", "null"]

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -10824,7 +10824,15 @@
             "key1": false,
             "key2": true
           }
-        }
+        },
+        "events": [
+          [2147, "ui", "click", "back_button"],
+          [2213, "ui", "search", "search_bar", "google"],
+          [2892, "ui", "completion", "search_bar", "yahoo",
+            {"querylen": "7", "results": "23"}],
+          [5434, "dom", "load", "frame", null,
+            {"prot": "https", "src": "script"}]
+        ]
       },
       "content": {
         "histograms": {


### PR DESCRIPTION
This PR adds validation to Telemetry events by adding the regex pattern
to be matched for the following event fields: category, method, object.
The pattern to be matched was defined in Bug 1337022 at the link
https://bugzilla.mozilla.org/show_bug.cgi?id=1337022

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/34)
<!-- Reviewable:end -->
