### PR TITLE
Core schema update

### DIFF
--- a/telemetry/core.schema.json
+++ b/telemetry/core.schema.json
@@ -3,21 +3,17 @@
   "type" : "object",
   "name" : "core",
   "properties" : {
-    "arch" : {
-      "type" : "string"
+    "v" : {
+      "type" : "integer",
+      "minimum" : 1
     },
     "clientId" : {
       "type" : "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
-    "device" : {
-      "type" : "string"
-    },
-    "experiments" : {
-      "type" : "array",
-      "items" : {
-        "type" : "string"
-      }
+    "seq" : {
+      "type" : "integer",
+      "minimum" : 0
     },
     "locale" : {
       "type" : "string"
@@ -28,23 +24,45 @@
     "osversion" : {
       "type" : "string"
     },
-    "seq" : {
-      "type" : "integer",
-      "minimum": 0
+    "device" : {
+      "type" : "string"
     },
-    "v" : {
-      "type" : "integer",
-      "minimum" : 1
+    "arch" : {
+      "type" : "string"
     },
-    "defaultSearch": {
+    "profileDate" : {
+      "type" : "integer"
+    },
+    "defaultSearch" : {
       "type" : ["string", "null"]
     },
-    "defaultMailClient": {
+    "distributionId" : {
       "type" : "string"
     },
-    "defaultNewTabExperience": {
+    "created" : {
       "type" : "string"
+    },
+    "tz" : {
+      "type" : "integer"
+    },
+    "sessions" : {
+      "type" : "integer"
+    },
+    "durations" : {
+      "type" : "integer"
+    },
+    "searches" : {
+      "type" : "object"
+    },
+    "experiments" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string"
+      }
+    },
+    "flashUsage" : {
+      "type" : "integer"
     }
   },
-  "required" : ["arch", "clientId", "device", "locale", "os", "osversion", "seq", "v"]
+  "required" : ["v", "clientId", "seq", "arch", "device", "locale", "os", "osversion"]
 }

--- a/validation/telemetry/core_v7_ping.json
+++ b/validation/telemetry/core_v7_ping.json
@@ -1,0 +1,25 @@
+{
+  "tz" : 480,
+  "seq" : 21,
+  "sessions" : 1,
+  "locale" : "en-US",
+  "os" : "Android",
+  "durations" : 11,
+  "created" : "2017-03-16",
+  "clientId" : "6763e028-d9b2-49a9-b221-a82d62465322",
+  "profileDate" : 17240,
+  "experiments" : [
+    "download-content-catalog-sync",
+    "offline-cache",
+    "promote-add-to-homescreen",
+    "triple-readerview-bookmark-prompt",
+    "hls-video-playback",
+    "bookmark-history-menu",
+    "onboarding3-c"
+  ],
+  "defaultSearch" : "google-nocodes",
+  "v" : 7,
+  "device" : "LGE-Nexus 5",
+  "osversion" : "23",
+  "arch" : "armeabi-v7a"
+}


### PR DESCRIPTION
This seems to have fallen behind the current core ping version. Ordering is the same as the docs [0].

[0] https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/core-ping.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/37)
<!-- Reviewable:end -->
