### PR TITLE
Bug 1353796 - Add Focus events ping schema

### DIFF
--- a/telemetry/focus-event.parquetmr.txt
+++ b/telemetry/focus-event.parquetmr.txt
@@ -1,0 +1,33 @@
+message focus_event {
+    required int64 v;
+    required binary clientId (UTF8);
+    required int64 seq;
+    required binary locale (UTF8);
+    required binary os (UTF8);
+    required binary osversion (UTF8);
+    required int64 created;
+    optional int64 tz;
+    required group settings (MAP) {
+        repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+        }
+    }
+    required group events (LIST) {
+        repeated group list {
+            required group element (TUPLE) {
+                required int64 timestamp;
+                required binary category (UTF8);
+                required binary method (UTF8);
+                required binary object (UTF8);
+                optional binary value (UTF8);
+                optional group extra (MAP) {
+                    repeated group key_value {
+                        required binary key (UTF8);
+                        required binary value (UTF8);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/telemetry/focus-event.schema.json
+++ b/telemetry/focus-event.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "type" : "object",
+  "title" : "focus_event",
+  "properties" : {
+    "v" : {
+      "type" : "integer",
+      "minimum" : 1
+    },
+    "clientId" : {
+      "type" : "string",
+      "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "seq" : {
+      "type" : "integer",
+      "minimum" : 0
+    },
+    "locale" : {
+      "type" : "string"
+    },
+    "os" : {
+      "type" : "string"
+    },
+    "osversion" : {
+      "type" : "string"
+    },
+    "created" : {
+      "type" : "integer"
+    },
+    "tz" : {
+      "type" : "integer"
+    },
+    "settings" : {
+      "type" : "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "events" : {
+      "type" : "array",
+      "items": {
+        "type" : "array",
+        "items" : [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ],
+        "minItems": 4,
+        "maxItems": 6
+      }
+    }
+  },
+  "required" : ["v", "clientId", "seq", "locale", "os", "osversion", "created", "settings", "events"]
+}

--- a/validation/telemetry/focus_event_v1.json
+++ b/validation/telemetry/focus_event_v1.json
@@ -1,0 +1,78 @@
+{
+  "tz": 120,
+  "seq": 21,
+  "created": 1490698413319,
+  "locale": "en-US",
+  "settings": {
+    "pref_privacy_block_ads": "false",
+    "pref_privacy_block_social": "true",
+    "pref_search_engine": "DuckDuckGo",
+    "pref_privacy_block_analytics": "true",
+    "pref_performance_block_webfonts": "true",
+    "pref_privacy_block_other": "true"
+  },
+  "clientId": "f0d6f5ff-ca2e-4059-9fad-1ee0f9124cca",
+  "v": 1,
+  "osversion": "25",
+  "os": "Android",
+  "events": [
+    [
+      0,
+      "action",
+      "type_url",
+      "search_bar"
+    ],
+    [
+      5237,
+      "action",
+      "change",
+      "setting",
+      "pref_privacy_block_ads",
+      {
+        "to": "false"
+      }
+    ],
+    [
+      6508,
+      "action",
+      "change",
+      "setting",
+      "pref_privacy_block_social",
+      {
+        "to": "true"
+      }
+    ],
+    [
+      7006,
+      "action",
+      "change",
+      "setting",
+      "pref_privacy_block_other",
+      {
+        "to": "true"
+      }
+    ],
+    [
+      12008,
+      "action",
+      "change",
+      "setting",
+      "pref_search_engine",
+      {
+        "to": "DuckDuckGo"
+      }
+    ],
+    [
+      14622,
+      "action",
+      "click",
+      "erase_button"
+    ],
+    [
+      20699,
+      "action",
+      "type_query",
+      "search_bar"
+    ]
+  ]
+}


### PR DESCRIPTION
I've tested the JSON with a schema validator. I've tested the parquet on hsadmin. Both look good, parquet output is readable in Spark and contains all columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/mozilla-pipeline-schemas/43)
<!-- Reviewable:end -->
