### PR TITLE
Restrict event extra values to strings

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -858,7 +858,10 @@
           "type": ["string", "null"]
         },
         {
-          "type": ["object", "null"]
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       ],
       "minItems": 4,

--- a/validation/telemetry/sample_v4_ping.json
+++ b/validation/telemetry/sample_v4_ping.json
@@ -10824,7 +10824,39 @@
             "key1": false,
             "key2": true
           }
-        }
+        },
+        "events": [
+          [
+            12141232,
+            "navigation",
+            "search",
+            "searchbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ],
+          [
+            12144813,
+            "navigation",
+            "search",
+            "searchbar",
+            "oneoff",
+            {
+              "engine": "amazondotcom"
+            }
+          ],
+          [
+            12152377,
+            "navigation",
+            "search",
+            "urlbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ]
+        ]
       },
       "content": {
         "histograms": {


### PR DESCRIPTION
This is per https://bugzilla.mozilla.org/show_bug.cgi?id=1339195#c3

Extra objects for events are restricted to string keys and string
values.