### PR TITLE
Add a schema for the 'new-profile' ping

### DIFF
--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1,0 +1,777 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "new-profile",
+  "properties": {
+    "application": {
+      "type": "object",
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "type": "string",
+          "pattern": "^[0-9]{10}"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "type": "string",
+          "pattern": "^[0-9]{2,3}\\."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]{2,3}\\."
+        },
+        "displayVersion": {
+          "type": "string",
+          "pattern": "^[0-9]{2,3}\\."
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "additionalProperties": false
+    },
+    "clientId": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "creationDate": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "type": "object",
+          "properties": {
+            "activeAddons": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/addon"
+              }
+            },
+            "activeExperiment": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "branch": {
+                  "type": "string"
+                }
+              }
+            },
+            "activeGMPlugins": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/gmPlugin"
+              }
+            },
+            "activePlugins": {
+              "type": ["array", "object"],
+              "items": {
+                "$ref": "#/definitions/plugin"
+              }
+            },
+            "persona": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "blocklisted": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": ["string", "null"]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "userDisabled": {
+                  "type": "boolean"
+                },
+                "appDisabled": {
+                  "type": "boolean"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "integer"
+                },
+                "foreignInstall": {
+                  "type": ["boolean", "integer"]
+                },
+                "hasBinaryComponents": {
+                  "type": "boolean"
+                },
+                "installDay": {
+                  "type": ["integer", "null"],
+                  "minimum": 0
+                },
+                "updateDay": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        },
+        "build": {
+          "type": "object",
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            },
+            "applicationName": {
+              "type": "string"
+            },
+            "architecture": {
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "type": "string"
+            },
+            "buildId": {
+              "type": "string",
+              "pattern": "^[0-9]{10}"
+            },
+            "hotfixVersion": {
+              "type": ["string", "null"]
+            },
+            "version": {
+              "type": "string",
+              "pattern": "^[0-9]{2,3}\\."
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "platformVersion": {
+              "type": "string",
+              "pattern": "^[0-9]{2,3}\\."
+            },
+            "xpcomAbi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ]
+        },
+        "partner": {
+          "type": "object",
+          "properties": {
+            "distributionId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "type": [
+                "array",
+                "object"
+              ]
+            }
+          }
+        },
+        "profile": {
+          "type": "object",
+          "properties": {
+            "creationDate": {
+              "type": "number"
+            },
+            "resetDate": {
+              "type": "number"
+            }
+          }
+        },
+        "settings": {
+          "type": "object",
+          "properties": {
+            "attribution": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "medium": {
+                  "type": "string"
+                },
+                "campaign": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                }
+              }
+            },
+            "blocklistEnabled": {
+              "type": "boolean"
+            },
+            "isDefaultBrowser": {
+              "type": ["boolean", "null"]
+            },
+            "defaultSearchEngine": {
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "loadPath": {
+                  "type": ["string", "null"]
+                },
+                "submissionURL": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                }
+              }
+            },
+            "e10sEnabled": {
+              "type": "boolean"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "locale": {
+              "type": "string"
+            },
+            "telemetryEnabled": {
+              "type": "boolean"
+            },
+            "update": {
+              "type": "object",
+              "properties": {
+                "autoDownload": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "userPrefs": {
+              "type": "object"
+            }
+          }
+        },
+        "system": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "object",
+              "properties": {
+                "cores": {
+                  "type": ["integer", "null"],
+                  "minimum": 1,
+                  "maximum": 2048
+                },
+                "count": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 1024
+                },
+                "extensions": {
+                  "type": "array"
+                },
+                "family": {
+                  "type": ["integer", "null"]
+                },
+                "l2cacheKB": {
+                  "type": ["number", "null"]
+                },
+                "l3cacheKB": {
+                  "type": ["number", "null"]
+                },
+                "model": {
+                  "type": ["integer", "null"]
+                },
+                "speedMHz": {
+                  "type": ["number", "null"]
+                },
+                "stepping": {
+                  "type": ["integer", "null"]
+                },
+                "vendor": {
+                  "type": ["string", "null"]
+                }
+              }
+            },
+            "device": {
+              "model": {
+                "type": "string"
+              },
+              "manufacturer": {
+                "type": "string"
+              },
+              "hardware": {
+                "type": "string"
+              },
+              "isTablet": {
+                "type": "boolean"
+              }
+            },
+            "gfx": {
+              "type": "object",
+              "properties": {
+                "D2DEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "adapters": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/adapter"
+                  }
+                },
+                "monitors": {
+                  "type": [
+                    "array",
+                    "object"
+                  ],
+                  "items": {
+                    "$ref": "#/definitions/monitor"
+                  }
+                },
+                "features": {
+                  "type": "object",
+                  "items": {
+                    "$ref": "#/definitions/features"
+                  }
+                }
+              }
+            },
+            "hdd": {
+              "type": "object",
+              "properties": {
+                "profile": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "binary": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "system": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "isWow64": {
+              "type": "boolean"
+            },
+            "memoryMB": {
+              "type": "number"
+            },
+            "os": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": ["string", "integer"]
+                },
+                "kernelVersion": {
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "type": "number"
+                },
+                "windowsBuildNumber": {
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "type": ["number", "null"]
+                },
+                "installYear": {
+                  "type": "number"
+                },
+                "locale": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "meta": {
+      "type": "object"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "shutdown",
+            "startup"
+          ]
+        }
+      },
+      "required": [
+        "reason"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "new-profile"
+      ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
+    }
+  },
+  "required": [
+    "application",
+    "creationDate",
+    "id",
+    "type",
+    "version"
+  ],
+  "definitions": {
+    "addon": {
+      "type": "object",
+      "properties": {
+        "blocklisted": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": ["string", "null"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "userDisabled": {
+          "type": ["boolean", "integer"]
+        },
+        "appDisabled": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": ["string", "number"]
+        },
+        "scope": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "foreignInstall": {
+          "type": [
+            "integer",
+            "boolean"
+          ]
+        },
+        "hasBinaryComponents": {
+          "type": "boolean"
+        },
+        "installDay": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "updateDay": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "signedState": {
+          "type": "integer"
+        },
+        "isSystem": {
+          "type": "boolean"
+        }
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": ["string", "null"]
+        },
+        "vendorID": {
+          "type": ["string", "null"]
+        },
+        "deviceID": {
+          "type": ["string", "null"]
+        },
+        "subsysID": {
+          "type": ["string", "null"]
+        },
+        "RAM": {
+          "type": ["integer", "null"]
+        },
+        "driver": {
+          "type": ["string", "null"]
+        },
+        "driverVersion": {
+          "type": ["string", "null"]
+        },
+        "driverDate": {
+          "type": ["string", "null"]
+        },
+        "GPUActive": {
+          "type": "boolean"
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "properties": {
+        "compositor": {
+          "type": "string"
+        },
+        "d2d": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "d3d11": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "opengl": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "webgl": {
+          "type": ["object", "null"],
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "gpuProcess": {
+          "type": ["object", "null"],
+          "properties": {
+            "status": {
+              "type": ["string", "null"]
+            }
+          }
+        }
+      }
+    },
+    "feature": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": ["string", "null"]
+        },
+        "failureId": {
+          "type": ["string", "null"]
+        },
+        "version": {
+          "type": ["string", "null"]
+        },
+        "warp": {
+          "type": ["boolean", "null"]
+        },
+        "textureSharing": {
+          "type": ["boolean", "null"]
+        }
+      }
+    },
+    "gmPlugin": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": ["string", "null"]
+        },
+        "userDisabled": {
+          "type": "boolean"
+        },
+        "applyBackgroundUpdates": {
+          "type": [
+            "integer",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "monitor": {
+      "type": "object",
+      "properties": {
+        "screenWidth": {
+          "type": "integer"
+        },
+        "screenHeight": {
+          "type": "integer"
+        },
+        "refreshRate": {
+          "type": "number"
+        },
+        "pseudoDisplay": {
+          "type": "boolean"
+        },
+        "scale": {
+          "type": "number"
+        }
+      }
+    },
+    "plugin": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "blocklisted": {
+          "type": "boolean"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "clicktoplay": {
+          "type": "boolean"
+        },
+        "mimeTypes": {
+          "type": ["array", "object"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "updateDay": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/validation/telemetry/new-profile_v4_ping.json
+++ b/validation/telemetry/new-profile_v4_ping.json
@@ -1,0 +1,334 @@
+{
+  "type" : "new-profile",
+  "id" : "fe6298db-27df-4be2-87b9-43fdc539dca2",
+  "creationDate" : "2017-05-11T08:48:58.908Z",
+  "version" : 4,
+  "application" : {
+    "architecture" : "x86-64",
+    "buildId" : "20170501085442",
+    "name" : "Firefox",
+    "version" : "55.0a1",
+    "displayVersion" : "55.0a1",
+    "vendor" : "Mozilla",
+    "platformVersion" : "55.0a1",
+    "xpcomAbi" : "x86_64-gcc3",
+    "channel" : "default"
+  },
+  "payload" : {
+    "reason" : "shutdown"
+  },
+  "clientId" : "f7bb4848-17ca-4e5d-bec8-e8905a8ea35e",
+  "environment" : {
+    "build" : {
+      "applicationId" : "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName" : "Firefox",
+      "architecture" : "x86-64",
+      "buildId" : "20170501085442",
+      "version" : "55.0a1",
+      "vendor" : "Mozilla",
+      "platformVersion" : "55.0a1",
+      "xpcomAbi" : "x86_64-gcc3",
+      "hotfixVersion" : null
+    },
+    "partner" : {
+      "distributionId" : null,
+      "distributionVersion" : null,
+      "partnerId" : null,
+      "distributor" : null,
+      "distributorChannel" : null,
+      "partnerNames" : []
+    },
+    "system" : {
+      "memoryMB" : 8603,
+      "virtualMaxMB" : null,
+      "cpu" : {
+        "count" : 4,
+        "cores" : 4,
+        "vendor" : "GenuineIntel",
+        "family" : 6,
+        "model" : 60,
+        "stepping" : 3,
+        "l2cacheKB" : 256,
+        "l3cacheKB" : 8192,
+        "speedMHz" : null,
+        "extensions" : ["hasMMX", "hasSSE", "hasSSE2", "hasSSE3", "hasSSSE3", "hasSSE4_1", "hasSSE4_2", "hasAVX"]
+      },
+      "os" : {
+        "name" : "Linux",
+        "version" : "4.4.0-66-generic",
+        "locale" : "en-US"
+      },
+      "hdd" : {
+        "profile" : {
+          "model" : null,
+          "revision" : null
+        },
+        "binary" : {
+          "model" : null,
+          "revision" : null
+        },
+        "system" : {
+          "model" : null,
+          "revision" : null
+        }
+      },
+      "gfx" : {
+        "D2DEnabled" : null,
+        "DWriteEnabled" : null,
+        "ContentBackend" : "Skia",
+        "adapters" : [{
+            "description" : "Humper -- Chromium",
+            "vendorID" : "Humper",
+            "deviceID" : "Chromium",
+            "subsysID" : null,
+            "RAM" : null,
+            "driver" : null,
+            "driverVersion" : "2.1 Chromium 1.9",
+            "driverDate" : null,
+            "GPUActive" : true
+          }
+        ],
+        "monitors" : [],
+        "features" : {
+          "compositor" : "basic",
+          "gpuProcess" : {
+            "status" : "unused"
+          }
+        }
+      }
+    },
+    "settings" : {
+      "blocklistEnabled" : true,
+      "e10sEnabled" : true,
+      "e10sMultiProcesses" : 4,
+      "e10sCohort" : "unsupportedChannel",
+      "telemetryEnabled" : false,
+      "locale" : "en-US",
+      "update" : {
+        "channel" : "default",
+        "enabled" : true,
+        "autoDownload" : true
+      },
+      "userPrefs" : {
+        "browser.cache.disk.capacity" : 358400,
+        "browser.newtabpage.enhanced" : true
+      },
+      "addonCompatibilityCheckEnabled" : true,
+      "isDefaultBrowser" : false,
+      "defaultSearchEngine" : "google",
+      "defaultSearchEngineData" : {
+        "name" : "Google",
+        "loadPath" : "[app]/chrome/en-US/locale/browser/searchplugins/google.xml",
+        "origin" : "default",
+        "submissionURL" : "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b"
+      }
+    },
+    "profile" : {
+      "creationDate" : 17280
+    },
+    "addons" : {
+      "activeAddons" : {
+        "screenshots@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : null,
+          "name" : "Firefox Screenshots",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "6.3.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17280,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "e10srollout@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Staged rollout of Firefox multi-process feature.",
+          "name" : "Multi-process staged rollout",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.15",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "webcompat@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Urgent post-release fixes for web compatibility.",
+          "name" : "Web Compat",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.1",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "presentation@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Discover nearby devices in the browser",
+          "name" : "Presentation",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "shield-recipe-client@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Client to download and run recipes for SHIELD, Heartbeat, etc.",
+          "name" : "Shield Recipe Client",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "activity-stream@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "A rich visual history feed and a reimagined home page make it easier than ever to find exactly what ",
+          "name" : "Activity Stream",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "0.0.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "firefox@getpocket.com" : {
+          "blocklisted" : false,
+          "description" : "When you find something you want to view later, put it in Pocket.",
+          "name" : "Pocket",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0.5",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "flyweb@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Discover nearby services in the browser",
+          "name" : "FlyWeb",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "aushelper@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Sets value(s) in the update url based on custom checks.",
+          "name" : "Application Update Service Helper",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "2.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "formautofill@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Autofill forms with saved profiles",
+          "name" : "Form Autofill",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        },
+        "webcompat-reporter@mozilla.org" : {
+          "blocklisted" : false,
+          "description" : "Report site compatibility issues on webcompat.com.",
+          "name" : "WebCompat Reporter",
+          "userDisabled" : false,
+          "appDisabled" : false,
+          "version" : "1.0.0",
+          "scope" : 1,
+          "type" : "extension",
+          "foreignInstall" : false,
+          "hasBinaryComponents" : false,
+          "installDay" : 17280,
+          "updateDay" : 17287,
+          "isSystem" : true,
+          "isWebExtension" : false
+        }
+      },
+      "theme" : {
+        "id" : "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+        "blocklisted" : false,
+        "description" : "The default theme.",
+        "name" : "Default",
+        "userDisabled" : false,
+        "appDisabled" : false,
+        "version" : "55.0a1",
+        "scope" : 4,
+        "foreignInstall" : false,
+        "hasBinaryComponents" : false,
+        "installDay" : 17280,
+        "updateDay" : 17287
+      },
+      "activePlugins" : [],
+      "activeGMPlugins" : {
+        "gmp-gmpopenh264" : {
+          "version" : "1.6",
+          "userDisabled" : false,
+          "applyBackgroundUpdates" : 1
+        }
+      },
+      "activeExperiment" : {},
+      "persona" : null
+    }
+  }
+}

--- a/validation/telemetry/validate_main.py
+++ b/validation/telemetry/validate_main.py
@@ -35,6 +35,12 @@ class Test_validate(unittest.TestCase):
         for path in MODULES_PING_PATHS:
             self.do_test_ping(MODULES_SCHEMA_PATH, path)
 
+    def test_new_profile(self):
+        SAMPLE_PING_PATH = os.path.join(LOCAL, 'new-profile_v4_ping.json')
+        SCHEMA_PATH =\
+            os.path.join(LOCAL, '../../schemas/telemetry/new-profile/new-profile.4.schema.json')
+        self.do_test_ping(SCHEMA_PATH, SAMPLE_PING_PATH)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This just checks in the schema using the "old" process, bringing in a copy of the environment in the schema. The 'new-profile' ping is being deployed, so I'm not sure we should block on #47 or #46 .