### PR TITLE
Bug 1357043 - Disallow negative subsessionLength

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -571,7 +571,12 @@
         },
         "info": {
           "type": "object",
-          "properties": {}
+          "properties": {
+            "subsessionLength": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          }
         },
         "keyedHistograms": {
           "type": "object",


### PR DESCRIPTION
Can `subsessionLength` be 0 or null?