### PR TITLE
Remove the "meta" object from the ping schemas

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -520,9 +520,6 @@
     "id": {
       "$ref": "#/definitions/UUID4"
     },
-    "meta": {
-      "type": "object"
-    },
     "payload": {
       "type": "object",
       "properties": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -522,9 +522,6 @@
       "type": "string",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
-    "meta": {
-      "type": "object"
-    },
     "payload": {
       "type": "object",
       "properties": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -522,9 +522,6 @@
       "type": "string",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
-    "meta": {
-      "type": "object"
-    },
     "payload": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
The metadata for each ping is not added on the client, so
we don't need to have a "meta" object in these schemas.