### PR TITLE
Make environment, payload and clientId mandatory

### DIFF
--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -551,8 +551,11 @@
   },
   "required": [
     "application",
+    "clientId",
     "creationDate",
+    "environment",
     "id",
+    "payload",
     "type",
     "version"
   ],


### PR DESCRIPTION
This is the final demonstration that copy/pasting does not solve all the problems in the world.