### PR TITLE
Bug 1382223 - Allow null values in focus-event ping

### DIFF
--- a/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -19,7 +19,7 @@ message focus_event {
   required group settings (MAP) {
     repeated group key_value {
       required binary key (UTF8);
-      required binary value (UTF8);
+      optional binary value (UTF8);
     }
   }
   required group events (LIST) {
@@ -33,7 +33,7 @@ message focus_event {
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);
-            required binary value (UTF8);
+            optional binary value (UTF8);
           }
         }
       }

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -24,13 +24,13 @@
             "type": "string"
           },
           {
-            "type": "string"
+            "type": [ "string", "null" ]
           },
           {
             "additionalProperties": {
-              "type": "string"
+              "type": [ "string", "null" ]
             },
-            "type": "object"
+            "type": [ "object", "null" ]
           }
         ],
         "maxItems": 6,
@@ -54,7 +54,7 @@
     },
     "settings": {
       "additionalProperties": {
-        "type": "string"
+        "type": [ "string", "null" ]
       },
       "type": "object"
     },

--- a/validation/telemetry/focus-event.1.error.json
+++ b/validation/telemetry/focus-event.1.error.json
@@ -1,0 +1,69 @@
+{
+  "v": 1,
+  "clientId": "c7f15825-04a7-473b-9279-f4a33c618dbe",
+  "seq": 8,
+  "locale": "en-US",
+  "os": "Android",
+  "osversion": "26",
+  "created": 1500472261867,
+  "tz": 120,
+  "settings": {
+    "pref_privacy_block_social": "true",
+    "pref_performance_block_webfonts": null,
+    "pref_locale": "",
+    "pref_secure": "false",
+    "pref_default_browser": "true",
+    "pref_search_engine": "Google",
+    "pref_privacy_block_analytics": "true",
+    "pref_privacy_block_other": "true",
+    "pref_privacy_block_ads": "true"
+  },
+  "events": [
+    [
+      0,
+      "action",
+      "intent_custom_tab",
+      "app",
+      null,
+      {
+        "hasCloseButton": "true",
+        "disablesUrlbarH": "true",
+        "hasToolbarColor": null,
+        "hasPageTitle": "true"
+      }
+    ],
+    [
+      1135,
+      "action",
+      "foreground",
+      "app"
+    ],
+    [
+      11804,
+      "action",
+      "click",
+      "blocking_switch",
+      "false",
+      null
+    ],
+    [
+      13923,
+      "action",
+      "click",
+      "blocking_switch",
+      "true"
+    ],
+    [
+      16334,
+      "action",
+      "click",
+      "custom_tab_close_but"
+    ],
+    [
+      16368,
+      "action",
+      "background",
+      "app"
+    ]
+  ]
+} 


### PR DESCRIPTION
This allows null values in 3 places:
1. As values in the settings map
2. As values in the Events list
3. As values in the extra field of the Events list

The schema validates against the example. @trink can you take a peek at the parquet schema and make sure it seems correct?