### PR TITLE
Enable schema validation for environment.experiments

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -316,6 +316,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -320,6 +320,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -320,6 +320,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -320,6 +320,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -320,6 +320,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -320,6 +320,17 @@
           ],
           "type": "object"
         },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
         "partner": {
           "properties": {
             "distributionId": {

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -229,6 +229,17 @@
         "xpcomAbi"
         ]
     },
+    "experiments": {
+      "additionalProperties": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "object"
+    },
     "partner": {
       "type": "object",
       "properties": {

--- a/validation/telemetry/main.4.sample.json
+++ b/validation/telemetry/main.4.sample.json
@@ -304,6 +304,11 @@
       "version": "45.0",
       "xpcomAbi": "x86_64-gcc3"
     },
+    "experiments": {
+      "test_id123": {
+        "branch": "brunch"
+      }
+    },
     "partner": {
       "distributionId": null,
       "distributionVersion": null,


### PR DESCRIPTION
This PR also contains the update schemas and an update main ping sample. The generated schema validates correctly against the example.

I'm not sure why the generation step also changed `focus-event`. Looks like this is reverting the hotfix from 89a43b8? @fbertsch , any clue?