### PR TITLE
Add a Dockerfile to run tests with.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.DS_Store
+.dockerignore
+.git
+.gitignore
+Dockerfile
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mozilla/hindsight
+
+USER root
+RUN yum -y install \
+    cmake3 \
+    jq \
+    make \
+    && yum -y clean all
+
+COPY . /schemas
+RUN chown -R app:app /schemas
+
+USER app
+RUN mkdir /schemas/release
+WORKDIR /schemas/release
+
+RUN cmake -Wno-dev .. && \
+    cpack -G TGZ
+
+CMD make && ctest -V -C hindsight

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: all build clean shell test
+
+IMAGE_ID = mozilla-services/mozilla-pipeline-schemas
+
+all: build
+
+build:
+	docker build -t $(IMAGE_ID) .
+
+clean:
+	docker rmi -f $(IMAGE_ID)
+
+shell: build
+	docker run -it --rm $(IMAGE_ID) /bin/bash
+
+test: build
+	docker run -it --rm $(IMAGE_ID)


### PR DESCRIPTION
This is based on the latest hindsight docker container, which already installs most tools and libraries.

The Makefile is a convinience, so one can run `make` or `make test` without having to remember the full docker invocations.

Currently tests fail with two different errors, one has to do with the treat json null as parquet null change, the other failure is in the validation telemetry.focus-event.1 test.

@trink thoughts on the dockerfile and makefile?