### PR TITLE
Bug 1400934 - Rename landfill_errors, make fields optional

### DIFF
--- a/schemas/heka/telemetry/telemetry_errors.1.parquetmr.txt
+++ b/schemas/heka/telemetry/telemetry_errors.1.parquetmr.txt
@@ -1,12 +1,12 @@
-message landfill_errors {
+message telemetry_errors {
   required int64 Timestamp;
   required group Fields {
     required binary submissionDate (UTF8);
-    required binary docType (UTF8);
-    required binary appName (UTF8);
-    required binary appVersion (UTF8);
-    required binary appUpdateChannel (UTF8);
-    required binary appBuildId (UTF8);
+    optional binary docType (UTF8);
+    optional binary appName (UTF8);
+    optional binary appVersion (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary appBuildId (UTF8);
     required binary DecodeErrorType (UTF8);
     required binary DecodeError (UTF8);
     optional binary geoCountry (UTF8);

--- a/templates/heka/telemetry/telemetry_errors.1.parquetmr.txt
+++ b/templates/heka/telemetry/telemetry_errors.1.parquetmr.txt
@@ -1,12 +1,12 @@
-message landfill_errors {
+message telemetry_errors {
   required int64 Timestamp;
   required group Fields {
     required binary submissionDate (UTF8);
-    required binary docType (UTF8);
-    required binary appName (UTF8);
-    required binary appVersion (UTF8);
-    required binary appUpdateChannel (UTF8);
-    required binary appBuildId (UTF8);
+    optional binary docType (UTF8);
+    optional binary appName (UTF8);
+    optional binary appVersion (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary appBuildId (UTF8);
     required binary DecodeErrorType (UTF8);
     required binary DecodeError (UTF8);
     optional binary geoCountry (UTF8);

--- a/tests/hindsight/run/input/test_heka_messages.lua
+++ b/tests/hindsight/run/input/test_heka_messages.lua
@@ -9,7 +9,7 @@
 local messages = {
     {
         Type = "telemetry.error",
-        EnvVersion = "heka.landfill_errors.1", -- schema specification for the test output
+        EnvVersion = "heka.telemetry_errors.1", -- schema specification for the test output
         Fields = {
             submissionDate = "20170622",
             docType = "main",


### PR DESCRIPTION
Rename landfill_errors to telemetry_errors, and make several fields optional.

This still needs to be tested - there appears to be some unrelated test bustage from pioneer stuff.