### PR TITLE
Drop normalizedChannel from telemetry_duplicates

### DIFF
--- a/schemas/heka/telemetry/telemetry_duplicates.1.parquetmr.txt
+++ b/schemas/heka/telemetry/telemetry_duplicates.1.parquetmr.txt
@@ -8,7 +8,6 @@ message telemetry_duplicates {
     required binary docType (UTF8);
     required binary documentId (UTF8);
     required int32  duplicateDelta (UINT_8);
-    required binary normalizedChannel (UTF8);
     optional binary geoCity (UTF8);
     optional binary geoCountry (UTF8);
   }

--- a/templates/heka/telemetry/telemetry_duplicates.1.parquetmr.txt
+++ b/templates/heka/telemetry/telemetry_duplicates.1.parquetmr.txt
@@ -8,7 +8,6 @@ message telemetry_duplicates {
     required binary docType (UTF8);
     required binary documentId (UTF8);
     required int32  duplicateDelta (UINT_8);
-    required binary normalizedChannel (UTF8);
     optional binary geoCity (UTF8);
     optional binary geoCountry (UTF8);
   }


### PR DESCRIPTION
We can remove it like this or make it optional to keep schema compatibility. As the data was kind of mucked up anyway before this week I'm not sure if it matters.