### PR TITLE
Add schema for pioneer online-news study

### DIFF
--- a/schemas/pioneer-study/online-news/online-events.1.parquetmr.txt
+++ b/schemas/pioneer-study/online-news/online-events.1.parquetmr.txt
@@ -1,0 +1,13 @@
+message pioneer-study-example {
+  required group metadata {
+    required int64  Timestamp;
+    required binary documentId (UTF8);
+    required binary pioneerId (UTF8);
+    required binary studyName (UTF8);
+    required int64 studyVersion;
+    optional binary geoCity (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary normalizedChannel (UTF8);
+  }
+  required binary eventName (UTF8);
+}

--- a/schemas/pioneer-study/online-news/online-events.1.schema.json
+++ b/schemas/pioneer-study/online-news/online-events.1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "eventName": {
+      "description": "Name of the event",
+      "maxLength": 64,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "eventName"
+  ],
+  "title": "pioneer-study-online-news",
+  "type": "object"
+}

--- a/templates/pioneer-study/online-news/online-news.1.parquetmr.txt
+++ b/templates/pioneer-study/online-news/online-news.1.parquetmr.txt
@@ -1,0 +1,13 @@
+message pioneer-study-online-news {
+  required group metadata {
+    required int64  Timestamp;
+    required binary documentId (UTF8);
+    required binary pioneerId (UTF8);
+    required binary studyName (UTF8);
+    required int64 studyVersion;
+    optional binary geoCity (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary normalizedChannel (UTF8);
+  }
+  required binary eventName (UTF8);
+}

--- a/templates/pioneer-study/online-news/online-news.1.schema.json
+++ b/templates/pioneer-study/online-news/online-news.1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "eventName": {
+      "description": "Name of the event",
+      "maxLength": 64,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "eventName"
+  ],
+  "title": "pioneer-study-online-news",
+  "type": "object"
+}

--- a/validation/pioneer-study/online-news.1.sample.json
+++ b/validation/pioneer-study/online-news.1.sample.json
@@ -1,0 +1,3 @@
+{
+  "eventType" : "enrolled"
+}

--- a/validation/pioneer-study/online-news.1.sample.json
+++ b/validation/pioneer-study/online-news.1.sample.json
@@ -1,3 +1,3 @@
 {
-  "eventType" : "enrolled"
+  "eventName" : "enrolled"
 }


### PR DESCRIPTION
This is for events from [the first real Pioneer study](https://github.com/mozilla/pioneer-study-online-news). This is set up as specific to that one study, but this basic data shape may be useful to multiple studies. Would it be more useful to modify this schema somehow to share it between multiple studies?

I'm primarily basing this off #77 and #89.

See also: https://github.com/mozilla/pioneer-study-online-news/issues/8