### PR TITLE
WIP: mozza events

### DIFF
--- a/schemas/mozza/event/event.1.schema.json
+++ b/schemas/mozza/event/event.1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "browser": {
+      "type": "string"
+    },
+    "browser_version": {
+      "type": "string"
+    },
+    "domain": {
+      "type": "string"
+    },
+    "event": {
+      "items": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      ],
+      "maxItems": 6,
+      "minItems": 4,
+      "type": "array"
+    },
+    "os": {
+      "type": "string"
+    },
+    "os_version": {
+      "type": "string"
+    },
+    "property": {
+      "enum": [
+        "tmo"
+      ],
+      "type": "string"
+    },
+    "request_uri": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "property",
+    "event"
+  ],
+  "title": "event",
+  "type": "object"
+}

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -12,6 +12,7 @@
       "items": {
         "items": [
           {
+            "minimum": 0,
             "type": "integer"
           },
           {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -934,7 +934,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1120,7 +1123,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1291,7 +1297,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1464,7 +1473,10 @@
                               },
                               {
                                 "additionalProperties": {
-                                  "type": "string"
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
                                 },
                                 "type": [
                                   "object",

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -12,6 +12,7 @@
       "items": {
         "items": [
           {
+            "minimum": 0,
             "type": "integer"
           },
           {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -934,7 +934,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1120,7 +1123,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1291,7 +1297,10 @@
                           },
                           {
                             "additionalProperties": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "type": [
                               "object",
@@ -1464,7 +1473,10 @@
                               },
                               {
                                 "additionalProperties": {
-                                  "type": "string"
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
                                 },
                                 "type": [
                                   "object",

--- a/templates/include/common/event.1.schema.json
+++ b/templates/include/common/event.1.schema.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": [
+  {
+    "type": "integer",
+    "minimum": 0
+  },
+  {
+    "type": "string"
+  },
+  {
+    "type": "string"
+  },
+  {
+    "type": "string"
+  },
+  {
+    "type": [ "string", "null" ]
+  },
+  {
+    "type": [ "object", "null" ],
+    "additionalProperties": {
+      "type": [ "string", "null" ]
+    }
+  }
+    ],
+  "minItems": 4,
+  "maxItems": 6
+}

--- a/templates/include/telemetry/mobileEvent.1.schema.json
+++ b/templates/include/telemetry/mobileEvent.1.schema.json
@@ -31,34 +31,7 @@
   },
   "events": {
     "type": "array",
-    "items": {
-      "type": "array",
-      "items": [
-      {
-        "type": "integer"
-      },
-      {
-        "type": "string"
-      },
-      {
-        "type": "string"
-      },
-      {
-        "type": "string"
-      },
-      {
-        "type": [ "string", "null" ]
-      },
-      {
-        "type": [ "object", "null" ],
-        "additionalProperties": {
-          "type": [ "string", "null" ]
-        }
-      }
-        ],
-      "minItems": 4,
-      "maxItems": 6
-    }
+    "items": @COMMON_EVENT_1_JSON@
   }
 },
 "required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "settings", "events" ]

--- a/templates/include/telemetry/processData.1.schema.json
+++ b/templates/include/telemetry/processData.1.schema.json
@@ -39,35 +39,7 @@
     "events": {
       "type": "array",
       "items": {
-        "event": {
-          "type": "array",
-          "items": [
-          {
-            "type": "integer",
-            "minimum": 0
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": [ "string", "null" ]
-          },
-          {
-            "type": [ "object", "null" ],
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-            ],
-          "minItems": 4,
-          "maxItems": 6
-        }
+        "event": @COMMON_EVENT_1_JSON@
       }
     },
     "gc": {

--- a/templates/mozza/event/event.1.schema.json
+++ b/templates/mozza/event/event.1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "event",
+  "properties": {
+    "property": {
+      "type": "string",
+      "enum": ["tmo"]
+    },
+    "domain": {
+      "type": "string"
+    },
+    "request_uri": {
+      "type": "string"
+    },
+    "os": {
+      "type": "string"
+    },
+    "os_version": {
+      "type": "string"
+    },
+    "browser": {
+      "type": "string"
+    },
+    "browser_version": {
+      "type": "string"
+    },
+    "event": @COMMON_EVENT_1_JSON@
+  },
+  "required": [ "property", "event" ]
+}

--- a/validation/mozza/event.1.sample.json
+++ b/validation/mozza/event.1.sample.json
@@ -1,0 +1,15 @@
+{
+  "property": "tmo",
+  "domain": "https://telemetry.mozilla.org",
+  "request_uri": "/new-pipeline/evo.html",
+  "os": "Windows_NT",
+  "os_version": "6.1",
+  "browser": "Firefox",
+  "browser_version": "57.0",
+  "event": [
+    651407847,
+    "interaction",
+    "click",
+    "datepicker"
+  ]
+}


### PR DESCRIPTION
Considerations:
- The partitioning column will be `property`, e.g. "which web property is sending this data?" but I'm not attached to that name. Alternatives could be simply partitioning by base URL.
- We could add more dimensional information; a good one might be some sort of user or session id (for eventual funnel analyses)
- Moved to a common event JSON schema
- The parquet schema will be written when we finalize what this data will look like