### PR TITLE
Add mozza event parquet output

### DIFF
--- a/schemas/mozza/event/event.1.parquetmr.txt
+++ b/schemas/mozza/event/event.1.parquetmr.txt
@@ -1,0 +1,30 @@
+message event {
+  required group metadata {
+    required binary documentId (UTF8);
+    required int64  Timestamp;
+    required binary Date (UTF8);
+    required binary geoCountry (UTF8);
+    required binary geoCity (UTF8);
+  }
+  optional binary browser (UTF8);
+  optional binary browser_version (UTF8);
+  optional binary os (UTF8);
+  optional binary os_version (UTF8);
+  optional binary domain (UTF8);
+  optional binary request_uri (UTF8);
+  required binary property (UTF8);
+  required group event (TUPLE) {
+  required int64 timestamp;
+  required binary category (UTF8);
+  required binary method (UTF8);
+  required binary object (UTF8);
+  optional binary value (UTF8);
+  optional group extra (MAP) {
+    repeated group key_value {
+      required binary key (UTF8);
+      optional binary value (UTF8);
+    }
+  }
+}
+
+}

--- a/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -27,18 +27,19 @@ message focus_event {
   required group events (LIST) {
     repeated group list {
       required group element (TUPLE) {
-        required int64 timestamp;
-        required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
-        optional group extra (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            optional binary value (UTF8);
-          }
-        }
-      }
+  required int64 timestamp;
+  required binary category (UTF8);
+  required binary method (UTF8);
+  required binary object (UTF8);
+  optional binary value (UTF8);
+  optional group extra (MAP) {
+    repeated group key_value {
+      required binary key (UTF8);
+      optional binary value (UTF8);
+    }
+  }
+}
+
     }
   }
 }

--- a/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -30,18 +30,19 @@ message mobile_event {
   required group events (LIST) {
     repeated group list {
       required group element (TUPLE) {
-        required int64 timestamp;
-        required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
-        optional group extra (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            optional binary value (UTF8);
-          }
-        }
-      }
+  required int64 timestamp;
+  required binary category (UTF8);
+  required binary method (UTF8);
+  required binary object (UTF8);
+  optional binary value (UTF8);
+  optional group extra (MAP) {
+    repeated group key_value {
+      required binary key (UTF8);
+      optional binary value (UTF8);
+    }
+  }
+}
+
     }
   }
 }

--- a/templates/include/common/event.1.parquetmr.txt
+++ b/templates/include/common/event.1.parquetmr.txt
@@ -1,0 +1,13 @@
+(TUPLE) {
+  required int64 timestamp;
+  required binary category (UTF8);
+  required binary method (UTF8);
+  required binary object (UTF8);
+  optional binary value (UTF8);
+  optional group extra (MAP) {
+    repeated group key_value {
+      required binary key (UTF8);
+      optional binary value (UTF8);
+    }
+  }
+}

--- a/templates/mozza/event/event.1.parquetmr.txt
+++ b/templates/mozza/event/event.1.parquetmr.txt
@@ -1,0 +1,17 @@
+message event {
+  required group metadata {
+    required binary documentId (UTF8);
+    required int64  Timestamp;
+    required binary Date (UTF8);
+    required binary geoCountry (UTF8);
+    required binary geoCity (UTF8);
+  }
+  optional binary browser (UTF8);
+  optional binary browser_version (UTF8);
+  optional binary os (UTF8);
+  optional binary os_version (UTF8);
+  optional binary domain (UTF8);
+  optional binary request_uri (UTF8);
+  required binary property (UTF8);
+  required group event @COMMON_EVENT_1_TXT@
+}

--- a/templates/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/templates/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -26,19 +26,7 @@ message focus_event {
   }
   required group events (LIST) {
     repeated group list {
-      required group element (TUPLE) {
-        required int64 timestamp;
-        required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
-        optional group extra (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            optional binary value (UTF8);
-          }
-        }
-      }
+      required group element @COMMON_EVENT_1_TXT@
     }
   }
 }

--- a/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -29,19 +29,7 @@ message mobile_event {
   }
   required group events (LIST) {
     repeated group list {
-      required group element (TUPLE) {
-        required int64 timestamp;
-        required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
-        optional group extra (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            optional binary value (UTF8);
-          }
-        }
-      }
+      required group element @COMMON_EVENT_1_TXT@
     }
   }
 }


### PR DESCRIPTION
:whd, just want to make sure that d2p for moz_ingest will work similarly. It seems all of those metadata fields are available. Feel free to reassign reviewers if you're busy.