### PR TITLE
Make mozza date header optional

### DIFF
--- a/schemas/mozza/event/event.1.parquetmr.txt
+++ b/schemas/mozza/event/event.1.parquetmr.txt
@@ -2,7 +2,7 @@ message event {
   required group metadata {
     required binary documentId (UTF8);
     required int64  Timestamp;
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);
   }

--- a/templates/mozza/event/event.1.parquetmr.txt
+++ b/templates/mozza/event/event.1.parquetmr.txt
@@ -2,7 +2,7 @@ message event {
   required group metadata {
     required binary documentId (UTF8);
     required int64  Timestamp;
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);
   }


### PR DESCRIPTION
The date header is not supported in either fetch or sendBeacon.