### PR TITLE
Add 'processStartTimestamp' as a required field for mobile-event and an optional field for focus-event.

### DIFF
--- a/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -17,6 +17,7 @@ message focus_event {
   optional binary device (UTF8);
   optional binary arch (UTF8);
   required int64 created;
+  optional int64 processStartTimestamp;
   optional int64 tz;
   required group settings (MAP) {
     repeated group key_value {

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -64,6 +64,9 @@
     "osversion": {
       "type": "string"
     },
+    "processStartTimestamp": {
+      "type": "integer"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"

--- a/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -20,6 +20,7 @@ message mobile_event {
   optional binary device (UTF8);
   optional binary arch (UTF8);
   required int64 created;
+  required int64 processStartTimestamp;
   optional int64 tz;
   required group settings (MAP) {
     repeated group key_value {

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -64,6 +64,9 @@
     "osversion": {
       "type": "string"
     },
+    "processStartTimestamp": {
+      "type": "integer"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"
@@ -93,6 +96,7 @@
     "os",
     "osversion",
     "created",
+    "processStartTimestamp",
     "settings",
     "events"
   ],

--- a/templates/include/telemetry/mobileEvent.1.schema.json
+++ b/templates/include/telemetry/mobileEvent.1.schema.json
@@ -1,40 +1,45 @@
-"v": {
-  "type": "integer",
-  "minimum": 1
-},
-@TELEMETRY_CLIENTID_1_JSON@,
-"seq": {
-  "type": "integer",
-  "minimum": 0
-},
-"locale": {
-  "type": "string"
-},
-"os": {
-  "type": "string"
-},
-"osversion": {
-  "type": "string"
-},
-"device": {
-  "type": "string"
-},
-"arch": {
-  "type": "string"
-},
-"created": {
-  "type": "integer"
-},
-"tz": {
-  "type": "integer"
-},
-"settings": {
-  "type": "object",
-  "additionalProperties": {
-    "type": [ "string", "null" ]
+"properties": {
+  "v": {
+    "type": "integer",
+    "minimum": 1
+  },
+  @TELEMETRY_CLIENTID_1_JSON@,
+  "seq": {
+    "type": "integer",
+    "minimum": 0
+  },
+  "locale": {
+    "type": "string"
+  },
+  "os": {
+    "type": "string"
+  },
+  "osversion": {
+    "type": "string"
+  },
+  "device": {
+    "type": "string"
+  },
+  "arch": {
+    "type": "string"
+  },
+  "created": {
+    "type": "integer"
+  },
+  "processStartTimestamp": {
+    "type": "integer"
+  },
+  "tz": {
+    "type": "integer"
+  },
+  "settings": {
+    "type": "object",
+    "additionalProperties": {
+      "type": [ "string", "null" ]
+    }
+  },
+  "events": {
+    "type": "array",
+    "items": @COMMON_EVENT_1_JSON@
   }
-},
-"events": {
-  "type": "array",
-  "items": @COMMON_EVENT_1_JSON@
 }

--- a/templates/include/telemetry/mobileEvent.1.schema.json
+++ b/templates/include/telemetry/mobileEvent.1.schema.json
@@ -1,43 +1,40 @@
-"properties": {
-  "v": {
-    "type": "integer",
-    "minimum": 1
-  },
-  @TELEMETRY_CLIENTID_1_JSON@,
-  "seq": {
-    "type": "integer",
-    "minimum": 0
-  },
-  "locale": {
-    "type": "string"
-  },
-  "os": {
-    "type": "string"
-  },
-  "osversion": {
-    "type": "string"
-  },
-  "device": {
-    "type": "string"
-  },
-  "arch": {
-    "type": "string"
-  },
-  "created": {
-    "type": "integer"
-  },
-  "tz": {
-    "type": "integer"
-  },
-  "settings": {
-    "type": "object",
-    "additionalProperties": {
-      "type": [ "string", "null" ]
-    }
-  },
-  "events": {
-    "type": "array",
-    "items": @COMMON_EVENT_1_JSON@
+"v": {
+  "type": "integer",
+  "minimum": 1
+},
+@TELEMETRY_CLIENTID_1_JSON@,
+"seq": {
+  "type": "integer",
+  "minimum": 0
+},
+"locale": {
+  "type": "string"
+},
+"os": {
+  "type": "string"
+},
+"osversion": {
+  "type": "string"
+},
+"device": {
+  "type": "string"
+},
+"arch": {
+  "type": "string"
+},
+"created": {
+  "type": "integer"
+},
+"tz": {
+  "type": "integer"
+},
+"settings": {
+  "type": "object",
+  "additionalProperties": {
+    "type": [ "string", "null" ]
   }
 },
-"required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "settings", "events" ]
+"events": {
+  "type": "array",
+  "items": @COMMON_EVENT_1_JSON@
+}

--- a/templates/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/templates/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -17,6 +17,7 @@ message focus_event {
   optional binary device (UTF8);
   optional binary arch (UTF8);
   required int64 created;
+  optional int64 processStartTimestamp;
   optional int64 tz;
   required group settings (MAP) {
     repeated group key_value {

--- a/templates/telemetry/focus-event/focus-event.1.schema.json
+++ b/templates/telemetry/focus-event/focus-event.1.schema.json
@@ -2,5 +2,8 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "focus-event",
-  @TELEMETRY_MOBILEEVENT_1_JSON@
+  "properties": {
+    @TELEMETRY_MOBILEEVENT_1_JSON@
+  },
+  "required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "settings", "events" ]
 }

--- a/templates/telemetry/focus-event/focus-event.1.schema.json
+++ b/templates/telemetry/focus-event/focus-event.1.schema.json
@@ -2,8 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "focus-event",
-  "properties": {
-    @TELEMETRY_MOBILEEVENT_1_JSON@
-  },
+  @TELEMETRY_MOBILEEVENT_1_JSON@,
   "required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "settings", "events" ]
 }

--- a/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -20,6 +20,7 @@ message mobile_event {
   optional binary device (UTF8);
   optional binary arch (UTF8);
   required int64 created;
+  required int64 processStartTimestamp;
   optional int64 tz;
   required group settings (MAP) {
     repeated group key_value {

--- a/templates/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/templates/telemetry/mobile-event/mobile-event.1.schema.json
@@ -2,11 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "mobile-event",
-  "properties": {
-    @TELEMETRY_MOBILEEVENT_1_JSON@,
-    "processStartTimestamp": {
-      "type": "integer"
-    }
-  },
+  @TELEMETRY_MOBILEEVENT_1_JSON@,
   "required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "processStartTimestamp", "settings", "events" ]
 }

--- a/templates/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/templates/telemetry/mobile-event/mobile-event.1.schema.json
@@ -2,5 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "mobile-event",
-  @TELEMETRY_MOBILEEVENT_1_JSON@
+  "properties": {
+    @TELEMETRY_MOBILEEVENT_1_JSON@,
+    "processStartTimestamp": {
+      "type": "integer"
+    }
+  },
+  "required": [ "v", "clientId", "seq", "locale", "os", "osversion", "created", "processStartTimestamp", "settings", "events" ]
 }

--- a/validation/telemetry/mobile-event.1.error.json
+++ b/validation/telemetry/mobile-event.1.error.json
@@ -8,6 +8,7 @@
   "osversion": "11.1.1",
   "os": "iOS",
   "created": 1500472261867,
+  "processStartTimestamp": 1500472261767,
   "tz": 120,
   "settings": {
     "pref_privacy_block_social": "true",

--- a/validation/telemetry/mobile-event.1.sample.json
+++ b/validation/telemetry/mobile-event.1.sample.json
@@ -2,6 +2,7 @@
   "tz": 120,
   "seq": 21,
   "created": 1490698413319,
+  "processStartTimestamp": 1500472261767,
   "locale": "en-US",
   "settings": {
     "pref_privacy_block_ads": "false",


### PR DESCRIPTION
This can be used in reporting to convert event timestamps from being relative to the process start time to being standard absolute timestamps.