### PR TITLE
Add pioneer study errors parquet schema

### DIFF
--- a/schemas/heka/pioneer-study/pioneer_errors.1.parquetmr.txt
+++ b/schemas/heka/pioneer-study/pioneer_errors.1.parquetmr.txt
@@ -1,0 +1,19 @@
+message pioneer_errors {
+  required int64 Timestamp;
+  required group Fields {
+    optional binary docType (UTF8);
+    optional binary appName (UTF8);
+    optional binary appVersion (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary appBuildId (UTF8);
+    required binary DecodeErrorType (UTF8);
+    required binary DecodeError (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary geoCity (UTF8);
+    optional binary studyName (UTF8);
+    optional binary schemaName (UTF8);
+    optional double schemaVersion;
+    optional binary uri (UTF8);
+    optional binary pioneerId (UTF8);
+  }
+}

--- a/templates/heka/pioneer-study/pioneer_errors.1.parquetmr.txt
+++ b/templates/heka/pioneer-study/pioneer_errors.1.parquetmr.txt
@@ -1,0 +1,19 @@
+message pioneer_errors {
+  required int64 Timestamp;
+  required group Fields {
+    optional binary docType (UTF8);
+    optional binary appName (UTF8);
+    optional binary appVersion (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary appBuildId (UTF8);
+    required binary DecodeErrorType (UTF8);
+    required binary DecodeError (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary geoCity (UTF8);
+    optional binary studyName (UTF8);
+    optional binary schemaName (UTF8);
+    optional double schemaVersion;
+    optional binary uri (UTF8);
+    optional binary pioneerId (UTF8);
+  }
+}


### PR DESCRIPTION
This is the same as the telemetry errors parquet schema but with the omission of submissionDate (legacy telemetry decoder behavior not present in pioneer decoding) and the addition of some optional pioneer-specific fields.