### PR TITLE
Ensure that sections of the schema are being used

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -925,251 +925,40 @@
         "keyedHistograms": {
           "additionalProperties": {
             "additionalProperties": {
+              "additionalProperties": false,
               "properties": {
-                "events": {
-                  "items": {
-                    "items": [
-                      {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "type": [
-                          "object",
-                          "null"
-                        ]
-                      }
-                    ],
-                    "maxItems": 6,
-                    "minItems": 4,
-                    "type": "array"
-                  },
+                "bucket_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "log_sum": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "log_sum_squares": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "range": {
                   "type": "array"
                 },
-                "gc": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "random": {
-                      "items": {
-                        "additionalProperties": {
-                          "type": [
-                            "number",
-                            "string",
-                            "null",
-                            "boolean"
-                          ]
-                        },
-                        "maxProperties": 25,
-                        "properties": {
-                          "slices": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 15,
-                              "properties": {
-                                "times": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 4,
-                            "type": "array"
-                          },
-                          "totals": {
-                            "maxProperties": 65,
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "maxItems": 2,
-                      "type": "array"
-                    },
-                    "worst": {
-                      "items": {
-                        "additionalProperties": {
-                          "type": [
-                            "number",
-                            "string",
-                            "null",
-                            "boolean"
-                          ]
-                        },
-                        "maxProperties": 25,
-                        "properties": {
-                          "slices": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 15,
-                              "properties": {
-                                "times": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 4,
-                            "type": "array"
-                          },
-                          "totals": {
-                            "maxProperties": 65,
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "maxItems": 2,
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
+                "sum": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "histograms": {
-                  "additionalProperties": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "bucket_count": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "histogram_type": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "log_sum": {
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      "log_sum_squares": {
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      "range": {
-                        "type": "array"
-                      },
-                      "sum": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "sum_squares_hi": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "sum_squares_lo": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "values": {
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "type": "object"
+                "sum_squares_hi": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "keyedHistograms": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "bucket_count": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "histogram_type": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "log_sum": {
-                          "minimum": 0,
-                          "type": "number"
-                        },
-                        "log_sum_squares": {
-                          "minimum": 0,
-                          "type": "number"
-                        },
-                        "range": {
-                          "type": "array"
-                        },
-                        "sum": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "sum_squares_hi": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "sum_squares_lo": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "values": {
-                          "type": "object"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  },
-                  "type": "object"
+                "sum_squares_lo": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "keyedScalars": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "type": [
-                        "integer",
-                        "string",
-                        "boolean"
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "type": "object"
-                },
-                "scalars": {
-                  "additionalProperties": {
-                    "type": [
-                      "integer",
-                      "string",
-                      "boolean"
-                    ]
-                  },
+                "values": {
                   "type": "object"
                 }
               },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -925,49 +925,44 @@
         "keyedHistograms": {
           "additionalProperties": {
             "additionalProperties": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
-                        "type": "array"
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
                       }
-                    },
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
                     "type": "array"
                   },
                   "gc": {
@@ -1064,7 +1059,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1104,86 +1102,35 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"
@@ -1201,49 +1148,44 @@
         "processes": {
           "properties": {
             "content": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
-                        "type": "array"
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
                       }
-                    },
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
                     "type": "array"
                   },
                   "gc": {
@@ -1340,7 +1282,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1380,129 +1325,119 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             },
             "gpu": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "array"
@@ -1601,7 +1536,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1641,134 +1579,89 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             },
             "parent": {
-              "allOf": [
-                {
-                  "processData": {
-                    "properties": {
-                      "events": {
-                        "items": {
-                          "event": {
-                            "items": [
-                              {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              {
-                                "additionalProperties": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ]
-                                },
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            ],
-                            "maxItems": 6,
-                            "minItems": 4,
-                            "type": "array"
-                          }
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         },
-                        "type": "array"
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "gc": {
                         "additionalProperties": false,
@@ -1864,133 +1757,110 @@
                         },
                         "type": "object"
                       },
-                      "histograms": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
                       },
-                      "keyedHistograms": {
-                        "additionalProperties": {
-                          "additionalProperties": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "bucket_count": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "histogram_type": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "log_sum": {
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "log_sum_squares": {
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "range": {
-                                "type": "array"
-                              },
-                              "sum": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "sum_squares_hi": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "sum_squares_lo": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "values": {
-                                "type": "object"
-                              }
-                            },
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
                       },
-                      "keyedScalars": {
-                        "additionalProperties": {
-                          "keyedScalar": {
-                            "additionalProperties": {
-                              "scalar": {
-                                "type": [
-                                  "integer",
-                                  "string",
-                                  "boolean"
-                                ]
-                              }
-                            },
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
+                      "range": {
+                        "type": "array"
                       },
-                      "scalars": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
                         "type": "object"
                       }
                     },
                     "type": "object"
-                  }
+                  },
+                  "type": "object"
                 },
-                {
-                  "required": [
-                    "scalars"
-                  ]
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
                 }
-              ]
+              },
+              "required": [
+                "scalars"
+              ],
+              "type": "object"
             }
           },
           "required": [

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -965,96 +965,139 @@
                     "minItems": 4,
                     "type": "array"
                   },
-                  "gc": {
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
                     "additionalProperties": false,
                     "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
                       },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -1188,96 +1231,139 @@
                     "minItems": 4,
                     "type": "array"
                   },
-                  "gc": {
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
                     "additionalProperties": false,
                     "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
                       },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -1399,6 +1485,97 @@
                   "type": "array"
                 },
                 "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
                   "type": "object"
                 },
                 "histograms": {
@@ -1438,100 +1615,6 @@
                       },
                       "values": {
                         "type": "object"
-                      }
-                    },
-                    "type": "array"
-                  },
-                  "gc": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
-                      },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
                       }
                     },
                     "type": "object"
@@ -1653,6 +1736,97 @@
                   "type": "array"
                 },
                 "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
                   "type": "object"
                 },
                 "histograms": {
@@ -1663,99 +1837,9 @@
                         "minimum": 0,
                         "type": "integer"
                       },
-                      "gc": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "random": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 25,
-                              "properties": {
-                                "slices": {
-                                  "items": {
-                                    "additionalProperties": {
-                                      "type": [
-                                        "number",
-                                        "string",
-                                        "null",
-                                        "boolean"
-                                      ]
-                                    },
-                                    "maxProperties": 15,
-                                    "properties": {
-                                      "times": {
-                                        "maxProperties": 65,
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "maxItems": 4,
-                                  "type": "array"
-                                },
-                                "totals": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 2,
-                            "type": "array"
-                          },
-                          "worst": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 25,
-                              "properties": {
-                                "slices": {
-                                  "items": {
-                                    "additionalProperties": {
-                                      "type": [
-                                        "number",
-                                        "string",
-                                        "null",
-                                        "boolean"
-                                      ]
-                                    },
-                                    "maxProperties": 15,
-                                    "properties": {
-                                      "times": {
-                                        "maxProperties": 65,
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "maxItems": 4,
-                                  "type": "array"
-                                },
-                                "totals": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 2,
-                            "type": "array"
-                          }
-                        },
-                        "type": "object"
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "log_sum": {
                         "minimum": 0,

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -869,46 +869,44 @@
         },
         "histograms": {
           "additionalProperties": {
-            "histogram": {
-              "additionalProperties": false,
-              "properties": {
-                "bucket_count": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "histogram_type": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "log_sum": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "log_sum_squares": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "range": {
-                  "type": "array"
-                },
-                "sum": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "sum_squares_hi": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "sum_squares_lo": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "values": {
-                  "type": "object"
-                }
+            "additionalProperties": false,
+            "properties": {
+              "bucket_count": {
+                "minimum": 0,
+                "type": "integer"
               },
-              "type": "object"
-            }
+              "histogram_type": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "log_sum": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "log_sum_squares": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "range": {
+                "type": "array"
+              },
+              "sum": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_hi": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_lo": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "values": {
+                "type": "object"
+              }
+            },
+            "type": "object"
           },
           "type": "object"
         },
@@ -1068,7 +1066,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1107,53 +1148,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1348,7 +1342,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1387,53 +1424,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1613,7 +1603,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1652,53 +1685,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1880,7 +1866,50 @@
                       },
                       "histograms": {
                         "additionalProperties": {
-                          "histogram": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bucket_count": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "histogram_type": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "log_sum": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "log_sum_squares": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "range": {
+                              "type": "array"
+                            },
+                            "sum": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "sum_squares_hi": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "sum_squares_lo": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "values": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "object"
+                      },
+                      "keyedHistograms": {
+                        "additionalProperties": {
+                          "additionalProperties": {
                             "additionalProperties": false,
                             "properties": {
                               "bucket_count": {
@@ -1919,53 +1948,6 @@
                               }
                             },
                             "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "keyedHistograms": {
-                        "additionalProperties": {
-                          "additionalProperties": {
-                            "histogram": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "bucket_count": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "histogram_type": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "log_sum": {
-                                  "minimum": 0,
-                                  "type": "number"
-                                },
-                                "log_sum_squares": {
-                                  "minimum": 0,
-                                  "type": "number"
-                                },
-                                "range": {
-                                  "type": "array"
-                                },
-                                "sum": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "sum_squares_hi": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "sum_squares_lo": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "values": {
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            }
                           }
                         },
                         "type": "object"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -925,251 +925,40 @@
         "keyedHistograms": {
           "additionalProperties": {
             "additionalProperties": {
+              "additionalProperties": false,
               "properties": {
-                "events": {
-                  "items": {
-                    "items": [
-                      {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "type": [
-                          "object",
-                          "null"
-                        ]
-                      }
-                    ],
-                    "maxItems": 6,
-                    "minItems": 4,
-                    "type": "array"
-                  },
+                "bucket_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "log_sum": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "log_sum_squares": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "range": {
                   "type": "array"
                 },
-                "gc": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "random": {
-                      "items": {
-                        "additionalProperties": {
-                          "type": [
-                            "number",
-                            "string",
-                            "null",
-                            "boolean"
-                          ]
-                        },
-                        "maxProperties": 25,
-                        "properties": {
-                          "slices": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 15,
-                              "properties": {
-                                "times": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 4,
-                            "type": "array"
-                          },
-                          "totals": {
-                            "maxProperties": 65,
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "maxItems": 2,
-                      "type": "array"
-                    },
-                    "worst": {
-                      "items": {
-                        "additionalProperties": {
-                          "type": [
-                            "number",
-                            "string",
-                            "null",
-                            "boolean"
-                          ]
-                        },
-                        "maxProperties": 25,
-                        "properties": {
-                          "slices": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 15,
-                              "properties": {
-                                "times": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 4,
-                            "type": "array"
-                          },
-                          "totals": {
-                            "maxProperties": 65,
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "maxItems": 2,
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
+                "sum": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "histograms": {
-                  "additionalProperties": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "bucket_count": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "histogram_type": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "log_sum": {
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      "log_sum_squares": {
-                        "minimum": 0,
-                        "type": "number"
-                      },
-                      "range": {
-                        "type": "array"
-                      },
-                      "sum": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "sum_squares_hi": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "sum_squares_lo": {
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      "values": {
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "type": "object"
+                "sum_squares_hi": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "keyedHistograms": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "bucket_count": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "histogram_type": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "log_sum": {
-                          "minimum": 0,
-                          "type": "number"
-                        },
-                        "log_sum_squares": {
-                          "minimum": 0,
-                          "type": "number"
-                        },
-                        "range": {
-                          "type": "array"
-                        },
-                        "sum": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "sum_squares_hi": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "sum_squares_lo": {
-                          "minimum": 0,
-                          "type": "integer"
-                        },
-                        "values": {
-                          "type": "object"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  },
-                  "type": "object"
+                "sum_squares_lo": {
+                  "minimum": 0,
+                  "type": "integer"
                 },
-                "keyedScalars": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "type": [
-                        "integer",
-                        "string",
-                        "boolean"
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "type": "object"
-                },
-                "scalars": {
-                  "additionalProperties": {
-                    "type": [
-                      "integer",
-                      "string",
-                      "boolean"
-                    ]
-                  },
+                "values": {
                   "type": "object"
                 }
               },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -925,49 +925,44 @@
         "keyedHistograms": {
           "additionalProperties": {
             "additionalProperties": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
-                        "type": "array"
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
                       }
-                    },
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
                     "type": "array"
                   },
                   "gc": {
@@ -1064,7 +1059,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1104,86 +1102,35 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"
@@ -1201,49 +1148,44 @@
         "processes": {
           "properties": {
             "content": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
-                        "type": "array"
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
                       }
-                    },
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
                     "type": "array"
                   },
                   "gc": {
@@ -1340,7 +1282,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1380,129 +1325,119 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             },
             "gpu": {
-              "processData": {
-                "properties": {
-                  "events": {
-                    "items": {
-                      "event": {
-                        "items": [
-                          {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          {
-                            "additionalProperties": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "object",
-                              "null"
-                            ]
-                          }
-                        ],
-                        "maxItems": 6,
-                        "minItems": 4,
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "array"
@@ -1601,7 +1536,10 @@
                     },
                     "type": "object"
                   },
-                  "histograms": {
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
                     "additionalProperties": {
                       "additionalProperties": false,
                       "properties": {
@@ -1641,134 +1579,89 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "type": "object"
+                    }
                   },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "bucket_count": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "histogram_type": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "log_sum": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "log_sum_squares": {
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "range": {
-                            "type": "array"
-                          },
-                          "sum": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_hi": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "sum_squares_lo": {
-                            "minimum": 0,
-                            "type": "integer"
-                          },
-                          "values": {
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedScalars": {
-                    "additionalProperties": {
-                      "keyedScalar": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "scalars": {
-                    "additionalProperties": {
-                      "scalar": {
-                        "type": [
-                          "integer",
-                          "string",
-                          "boolean"
-                        ]
-                      }
-                    },
-                    "type": "object"
-                  }
+                  "type": "object"
                 },
-                "type": "object"
-              }
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             },
             "parent": {
-              "allOf": [
-                {
-                  "processData": {
-                    "properties": {
-                      "events": {
-                        "items": {
-                          "event": {
-                            "items": [
-                              {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              {
-                                "additionalProperties": {
-                                  "type": [
-                                    "string",
-                                    "null"
-                                  ]
-                                },
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
-                            ],
-                            "maxItems": 6,
-                            "minItems": 4,
-                            "type": "array"
-                          }
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         },
-                        "type": "array"
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "gc": {
                         "additionalProperties": false,
@@ -1864,133 +1757,110 @@
                         },
                         "type": "object"
                       },
-                      "histograms": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
                       },
-                      "keyedHistograms": {
-                        "additionalProperties": {
-                          "additionalProperties": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "bucket_count": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "histogram_type": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "log_sum": {
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "log_sum_squares": {
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "range": {
-                                "type": "array"
-                              },
-                              "sum": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "sum_squares_hi": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "sum_squares_lo": {
-                                "minimum": 0,
-                                "type": "integer"
-                              },
-                              "values": {
-                                "type": "object"
-                              }
-                            },
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
                       },
-                      "keyedScalars": {
-                        "additionalProperties": {
-                          "keyedScalar": {
-                            "additionalProperties": {
-                              "scalar": {
-                                "type": [
-                                  "integer",
-                                  "string",
-                                  "boolean"
-                                ]
-                              }
-                            },
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
+                      "range": {
+                        "type": "array"
                       },
-                      "scalars": {
-                        "additionalProperties": {
-                          "scalar": {
-                            "type": [
-                              "integer",
-                              "string",
-                              "boolean"
-                            ]
-                          }
-                        },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
                         "type": "object"
                       }
                     },
                     "type": "object"
-                  }
+                  },
+                  "type": "object"
                 },
-                {
-                  "required": [
-                    "scalars"
-                  ]
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
                 }
-              ]
+              },
+              "required": [
+                "scalars"
+              ],
+              "type": "object"
             }
           },
           "required": [

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -965,96 +965,139 @@
                     "minItems": 4,
                     "type": "array"
                   },
-                  "gc": {
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
                     "additionalProperties": false,
                     "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
                       },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -1188,96 +1231,139 @@
                     "minItems": 4,
                     "type": "array"
                   },
-                  "gc": {
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
                     "additionalProperties": false,
                     "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
                         "type": "array"
                       },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -1399,6 +1485,97 @@
                   "type": "array"
                 },
                 "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
                   "type": "object"
                 },
                 "histograms": {
@@ -1438,100 +1615,6 @@
                       },
                       "values": {
                         "type": "object"
-                      }
-                    },
-                    "type": "array"
-                  },
-                  "gc": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "random": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
-                      },
-                      "worst": {
-                        "items": {
-                          "additionalProperties": {
-                            "type": [
-                              "number",
-                              "string",
-                              "null",
-                              "boolean"
-                            ]
-                          },
-                          "maxProperties": 25,
-                          "properties": {
-                            "slices": {
-                              "items": {
-                                "additionalProperties": {
-                                  "type": [
-                                    "number",
-                                    "string",
-                                    "null",
-                                    "boolean"
-                                  ]
-                                },
-                                "maxProperties": 15,
-                                "properties": {
-                                  "times": {
-                                    "maxProperties": 65,
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "maxItems": 4,
-                              "type": "array"
-                            },
-                            "totals": {
-                              "maxProperties": 65,
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "maxItems": 2,
-                        "type": "array"
                       }
                     },
                     "type": "object"
@@ -1653,6 +1736,97 @@
                   "type": "array"
                 },
                 "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 25,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 65,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 65,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
                   "type": "object"
                 },
                 "histograms": {
@@ -1663,99 +1837,9 @@
                         "minimum": 0,
                         "type": "integer"
                       },
-                      "gc": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "random": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 25,
-                              "properties": {
-                                "slices": {
-                                  "items": {
-                                    "additionalProperties": {
-                                      "type": [
-                                        "number",
-                                        "string",
-                                        "null",
-                                        "boolean"
-                                      ]
-                                    },
-                                    "maxProperties": 15,
-                                    "properties": {
-                                      "times": {
-                                        "maxProperties": 65,
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "maxItems": 4,
-                                  "type": "array"
-                                },
-                                "totals": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 2,
-                            "type": "array"
-                          },
-                          "worst": {
-                            "items": {
-                              "additionalProperties": {
-                                "type": [
-                                  "number",
-                                  "string",
-                                  "null",
-                                  "boolean"
-                                ]
-                              },
-                              "maxProperties": 25,
-                              "properties": {
-                                "slices": {
-                                  "items": {
-                                    "additionalProperties": {
-                                      "type": [
-                                        "number",
-                                        "string",
-                                        "null",
-                                        "boolean"
-                                      ]
-                                    },
-                                    "maxProperties": 15,
-                                    "properties": {
-                                      "times": {
-                                        "maxProperties": 65,
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "maxItems": 4,
-                                  "type": "array"
-                                },
-                                "totals": {
-                                  "maxProperties": 65,
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "maxItems": 2,
-                            "type": "array"
-                          }
-                        },
-                        "type": "object"
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "log_sum": {
                         "minimum": 0,

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -869,46 +869,44 @@
         },
         "histograms": {
           "additionalProperties": {
-            "histogram": {
-              "additionalProperties": false,
-              "properties": {
-                "bucket_count": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "histogram_type": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "log_sum": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "log_sum_squares": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "range": {
-                  "type": "array"
-                },
-                "sum": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "sum_squares_hi": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "sum_squares_lo": {
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "values": {
-                  "type": "object"
-                }
+            "additionalProperties": false,
+            "properties": {
+              "bucket_count": {
+                "minimum": 0,
+                "type": "integer"
               },
-              "type": "object"
-            }
+              "histogram_type": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "log_sum": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "log_sum_squares": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "range": {
+                "type": "array"
+              },
+              "sum": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_hi": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_lo": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "values": {
+                "type": "object"
+              }
+            },
+            "type": "object"
           },
           "type": "object"
         },
@@ -1068,7 +1066,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1107,53 +1148,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1348,7 +1342,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1387,53 +1424,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1613,7 +1603,50 @@
                   },
                   "histograms": {
                     "additionalProperties": {
-                      "histogram": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "keyedHistograms": {
+                    "additionalProperties": {
+                      "additionalProperties": {
                         "additionalProperties": false,
                         "properties": {
                           "bucket_count": {
@@ -1652,53 +1685,6 @@
                           }
                         },
                         "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "keyedHistograms": {
-                    "additionalProperties": {
-                      "additionalProperties": {
-                        "histogram": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "bucket_count": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "histogram_type": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "log_sum": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "log_sum_squares": {
-                              "minimum": 0,
-                              "type": "number"
-                            },
-                            "range": {
-                              "type": "array"
-                            },
-                            "sum": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_hi": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "sum_squares_lo": {
-                              "minimum": 0,
-                              "type": "integer"
-                            },
-                            "values": {
-                              "type": "object"
-                            }
-                          },
-                          "type": "object"
-                        }
                       }
                     },
                     "type": "object"
@@ -1880,7 +1866,50 @@
                       },
                       "histograms": {
                         "additionalProperties": {
-                          "histogram": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bucket_count": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "histogram_type": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "log_sum": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "log_sum_squares": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "range": {
+                              "type": "array"
+                            },
+                            "sum": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "sum_squares_hi": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "sum_squares_lo": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "values": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "object"
+                      },
+                      "keyedHistograms": {
+                        "additionalProperties": {
+                          "additionalProperties": {
                             "additionalProperties": false,
                             "properties": {
                               "bucket_count": {
@@ -1919,53 +1948,6 @@
                               }
                             },
                             "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "keyedHistograms": {
-                        "additionalProperties": {
-                          "additionalProperties": {
-                            "histogram": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "bucket_count": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "histogram_type": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "log_sum": {
-                                  "minimum": 0,
-                                  "type": "number"
-                                },
-                                "log_sum_squares": {
-                                  "minimum": 0,
-                                  "type": "number"
-                                },
-                                "range": {
-                                  "type": "array"
-                                },
-                                "sum": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "sum_squares_hi": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "sum_squares_lo": {
-                                  "minimum": 0,
-                                  "type": "integer"
-                                },
-                                "values": {
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object"
-                            }
                           }
                         },
                         "type": "object"

--- a/templates/include/common/event.1.schema.json
+++ b/templates/include/common/event.1.schema.json
@@ -1,29 +1,29 @@
 {
   "type": "array",
   "items": [
-  {
-    "type": "integer",
-    "minimum": 0
-  },
-  {
-    "type": "string"
-  },
-  {
-    "type": "string"
-  },
-  {
-    "type": "string"
-  },
-  {
-    "type": [ "string", "null" ]
-  },
-  {
-    "type": [ "object", "null" ],
-    "additionalProperties": {
+    {
+      "type": "integer",
+      "minimum": 0
+    },
+    {
+      "type": "string"
+    },
+    {
+      "type": "string"
+    },
+    {
+      "type": "string"
+    },
+    {
       "type": [ "string", "null" ]
+    },
+    {
+      "type": [ "object", "null" ],
+      "additionalProperties": {
+        "type": [ "string", "null" ]
+      }
     }
-  }
-    ],
+  ],
   "minItems": 4,
   "maxItems": 6
 }

--- a/templates/include/telemetry/histogram.1.schema.json
+++ b/templates/include/telemetry/histogram.1.schema.json
@@ -1,4 +1,3 @@
-"histogram": {
   "type": "object",
   "properties": {
     "bucket_count": {
@@ -37,4 +36,3 @@
     }
   },
   "additionalProperties": false
-}

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -53,7 +53,7 @@
       "type": "object",
       "additionalProperties": {
         "additionalProperties": {
-          @TELEMETRY_PROCESSDATA_1_JSON@
+          @TELEMETRY_HISTOGRAM_1_JSON@
         }
       }
     },

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -30,10 +30,8 @@
       "type": "object",
       "properties": {
         "parent": {
-          "allOf": [
-          { @TELEMETRY_PROCESSDATA_1_JSON@ },
-          { "required": [ "scalars" ] }
-            ]
+          @TELEMETRY_PROCESSDATA_1_JSON@ ,
+          "required": [ "scalars" ]
         },
         "content": { @TELEMETRY_PROCESSDATA_1_JSON@ },
         "gpu": { @TELEMETRY_PROCESSDATA_1_JSON@ }

--- a/templates/include/telemetry/processData.1.schema.json
+++ b/templates/include/telemetry/processData.1.schema.json
@@ -1,24 +1,17 @@
-"processData": {
   "type": "object",
   "properties": {
     "scalars": {
       "type": "object",
       "additionalProperties": {
-        "scalar": {
-          "type": [ "integer", "string", "boolean" ]
-        }
+        "type": [ "integer", "string", "boolean" ]
       }
     },
     "keyedScalars": {
       "type": "object",
       "additionalProperties": {
-        "keyedScalar": {
-          "type": "object",
-          "additionalProperties": {
-            "scalar": {
-              "type": [ "integer", "string", "boolean" ]
-            }
-          }
+        "type": "object",
+        "additionalProperties": {
+          "type": [ "integer", "string", "boolean" ]
         }
       }
     },
@@ -38,10 +31,7 @@
     },
     "events": {
       "type": "array",
-      "items": {
-        "event": @COMMON_EVENT_1_JSON@
-      }
+      "items": @COMMON_EVENT_1_JSON@
     },
     "gc": @TELEMETRY_GC_1_JSON@
   }
-}


### PR DESCRIPTION
There were a few sub-sections that had extra key names and such that resulted in them not properly being applied (so any "object" data would pass validation).

This PR ensures that `events`, `histograms`, and `scalars` sections are validated.

There is risk with this change, as we are effectively making the validation significantly more strict.