### PR TITLE
Bug 1455385 - Move mobile-event 'os' to partitions

### DIFF
--- a/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/schemas/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -15,7 +15,6 @@ message mobile_event {
   required binary clientId (UTF8);
   required int64 seq;
   required binary locale (UTF8);
-  required binary os (UTF8);
   required binary osversion (UTF8);
   optional binary device (UTF8);
   optional binary arch (UTF8);

--- a/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
+++ b/templates/telemetry/mobile-event/mobile-event.1.parquetmr.txt
@@ -15,7 +15,6 @@ message mobile_event {
   required binary clientId (UTF8);
   required int64 seq;
   required binary locale (UTF8);
-  required binary os (UTF8);
   required binary osversion (UTF8);
   optional binary device (UTF8);
   optional binary arch (UTF8);


### PR DESCRIPTION
co-dependent on mozilla-services/puppet-config#2725