### PR TITLE
Add a .dockerignore file to skip the CMake cache.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+release/


### PR DESCRIPTION
Fixes #159 