### PR TITLE
Make shield-study Date header metadata optional

### DIFF
--- a/schemas/telemetry/shield-study-addon/shield-study-addon.3.parquetmr.txt
+++ b/schemas/telemetry/shield-study-addon/shield-study-addon.3.parquetmr.txt
@@ -99,7 +99,7 @@ message shield-study-addon {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);

--- a/schemas/telemetry/shield-study-error/shield-study-error.3.parquetmr.txt
+++ b/schemas/telemetry/shield-study-error/shield-study-error.3.parquetmr.txt
@@ -109,7 +109,7 @@ message shield-study-error {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);

--- a/schemas/telemetry/shield-study/shield-study.3.parquetmr.txt
+++ b/schemas/telemetry/shield-study/shield-study.3.parquetmr.txt
@@ -101,7 +101,7 @@ message shield-study {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);

--- a/templates/telemetry/shield-study-addon/shield-study-addon.3.parquetmr.txt
+++ b/templates/telemetry/shield-study-addon/shield-study-addon.3.parquetmr.txt
@@ -99,7 +99,7 @@ message shield-study-addon {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);

--- a/templates/telemetry/shield-study-error/shield-study-error.3.parquetmr.txt
+++ b/templates/telemetry/shield-study-error/shield-study-error.3.parquetmr.txt
@@ -109,7 +109,7 @@ message shield-study-error {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);

--- a/templates/telemetry/shield-study/shield-study.3.parquetmr.txt
+++ b/templates/telemetry/shield-study/shield-study.3.parquetmr.txt
@@ -101,7 +101,7 @@ message shield-study {
   required group metadata {
     required int64 Timestamp;
     required binary submissionDate (UTF8);
-    required binary Date (UTF8);
+    optional binary Date (UTF8);
     required binary normalizedChannel (UTF8);
     required binary geoCountry (UTF8);
     required binary geoCity (UTF8);


### PR DESCRIPTION
This is optional everywhere else and we see occasionally clients sending data without this header.