### PR TITLE
Allow hgpush landingSystem to be null

### DIFF
--- a/schemas/eng-workflow/hgpush/hgpush.1.schema.json
+++ b/schemas/eng-workflow/hgpush/hgpush.1.schema.json
@@ -8,7 +8,10 @@
     },
     "landingSystem": {
       "description": "A string labelling the automated system used to land this changeset in this repository.  May be empty.",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "pushDate": {
       "description": "Timestamp, in Unix time (seconds since the Unix epoch), of when the push to the repository occurred.  This value is obtained from the original repository pushlog.",

--- a/templates/eng-workflow/hgpush/hgpush.1.schema.json
+++ b/templates/eng-workflow/hgpush/hgpush.1.schema.json
@@ -9,7 +9,7 @@
     },
     "landingSystem": {
       "description": "A string labelling the automated system used to land this changeset in this repository.  May be empty.",
-      "type": "string"
+      "type": ["string", "null"]
     },
     "reviewSystemUsed": {
       "description": "A string labelling the code review system used to review this changeset.  Possible values include (but are not limited to): 'mozreview', 'phabricator', 'bmo', 'unknown', and 'not_applicable'.",

--- a/validation/eng-workflow/hgpush.1.landingSystem_null.pass.json
+++ b/validation/eng-workflow/hgpush.1.landingSystem_null.pass.json
@@ -1,0 +1,7 @@
+{
+  "changesetID": "d6c97ab203c79ed0d43fca207c420966156f128e",
+  "landingSystem": null,
+  "reviewSystemUsed": "phabricator",
+  "repository": "https://hg.mozilla.org/mozilla-central/",
+  "pushDate": 1523095052
+}


### PR DESCRIPTION
Allow the hgpush ping schema's landingSystem field to be null.