### PR TITLE
Add a couple more histogram validation examples.

### DIFF
--- a/validation/telemetry/main.4.good_histogram.pass.json
+++ b/validation/telemetry/main.4.good_histogram.pass.json
@@ -15,19 +15,15 @@
   "version": 4,
   "payload": {
     "histograms": {
-      "INVALID_BUCKET_TYPE": {
-        "bucket_count": 3,
-        "histogram_type": 3,
-        "range": [
-          1,
-          2
-        ],
-        "sum": 0,
-        "sum_squares_hi": 0,
-        "sum_squares_lo": 0,
+      "TEST": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [1,10],
+        "sum": 10,
         "values": {
-          "foo": 1,
-          "bar": 0
+          "0": 0,
+          "1": 10,
+          "2": 0
         }
       }
     }

--- a/validation/telemetry/main.4.negative_count.fail.json
+++ b/validation/telemetry/main.4.negative_count.fail.json
@@ -15,19 +15,16 @@
   "version": 4,
   "payload": {
     "histograms": {
-      "INVALID_BUCKET_TYPE": {
-        "bucket_count": 3,
-        "histogram_type": 3,
-        "range": [
-          1,
-          2
-        ],
-        "sum": 0,
-        "sum_squares_hi": 0,
-        "sum_squares_lo": 0,
+      "NEGATIVE_COUNT": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [1,10],
+        "sum": 10,
         "values": {
-          "foo": 1,
-          "bar": 0
+          "0": 0,
+          "1": 10,
+          "2": -1000,
+          "3": 0
         }
       }
     }


### PR DESCRIPTION
Add a minimal passing histogram, a failure due to a negative count, and simplify the failure case for an invalid bucket key pattern.