### PR TITLE
Automatically remove the test container when it exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run the tests:
     docker build -t mps .
 
     # run the tests
-    docker run mps
+    docker run --rm mps
 
 ### Packaging and integration tests (optional)
 


### PR DESCRIPTION
The created container is only used for a single test run and never reused. It however persists on the user's machine until its deleted. Let's just remove it immediately after running the tests.