### PR TITLE
Add Timestamp to frecency-update

### DIFF
--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -2,6 +2,7 @@ message frecency-update {
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
+    required long Timestamp;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;
@@ -13,7 +14,6 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
-    required long Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -1,8 +1,8 @@
 message frecency-update {
+  required long metadata_Timestamp;
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
-    required long Timestamp;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -13,7 +13,7 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
-    required int32 Timestamp;
+    required long Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -13,6 +13,7 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
+    required int32 Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -2,6 +2,7 @@ message frecency-update {
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
+    required long Timestamp;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;
@@ -13,7 +14,6 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
-    required long Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -1,8 +1,8 @@
 message frecency-update {
+  required long metadata_Timestamp;
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
-    required long Timestamp;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -13,7 +13,7 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
-    required int32 Timestamp;
+    required long Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.parquetmr.txt
@@ -13,6 +13,7 @@ message frecency-update {
     required int32 rank_selected;
     required int32 num_suggestions_displayed;
     required binary study_variation;
+    required int32 Timestamp;
     required group update (LIST) {
       repeated group list {
         required float element;


### PR DESCRIPTION
This PR adds the `Timestamp` field to the Parquet schema, for easier analysis after the study ends.