### PR TITLE
block-autoplay JSON schema and validation tests.

### DIFF
--- a/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "enum": [
+            "control",
+            "allow-and-notRemember",
+            "deny-and-notRemember",
+            "allow-and-remember",
+            "deny-and-remember"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "payload": {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "counters": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "totalBlockedAudibleMedia": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "totalPagesAM": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "totalPages",
+                    "totalPagesAM",
+                    "totalBlockedAudibleMedia"
+                  ],
+                  "type": "object"
+                },
+                "type": {
+                  "enum": [
+                    "counts"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "counters"
+              ]
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "promptResponse": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "allowAutoplay": {
+                        "type": "boolean"
+                      },
+                      "pageId": {
+                        "type": "string"
+                      },
+                      "rememberCheckbox": {
+                        "type": "boolean"
+                      },
+                      "timestamp": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "pageId",
+                      "timestamp",
+                      "rememberCheckbox",
+                      "allowAutoplay"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "enum": [
+                    "prompt"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "promptResponse"
+              ]
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "settingsChanged": {
+                  "items": {
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "globalSettings": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "allowAutoplay": {
+                                "enum": [
+                                  "allow",
+                                  "block",
+                                  "ask"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "allowAutoplay"
+                            ],
+                            "type": "object"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "globalSettings",
+                          "timestamp"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "pageSpecific": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "allowAutoplay": {
+                                "enum": [
+                                  "allow",
+                                  "block",
+                                  "default"
+                                ],
+                                "type": "string"
+                              },
+                              "pageId": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "pageId",
+                              "allowAutoplay"
+                            ],
+                            "type": "object"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "pageSpecific",
+                          "timestamp"
+                        ]
+                      }
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "enum": [
+                    "settings"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "settingsChanged"
+              ]
+            }
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "branch",
+        "payload"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "block-autoplay"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
+    }
+  },
+  "required": [
+    "type",
+    "id",
+    "creationDate",
+    "version",
+    "application",
+    "clientId",
+    "payload"
+  ],
+  "title": "block-autoplay",
+  "type": "object"
+}

--- a/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "block-autoplay",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [ "block-autoplay" ]
+    },
+    @TELEMETRY_ID_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    "version": {
+      "type": "number",
+      "maximum": 4,
+      "minimum": 4
+    },
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CLIENTID_1_JSON@,
+    "payload": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "control",
+            "allow-and-notRemember",
+            "deny-and-notRemember",
+            "allow-and-remember",
+            "deny-and-remember"
+          ]
+        },
+        "payload": {
+          "type": "object",
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [ "counts"]
+                },
+                "counters": {
+                  "type": "object",
+                  "properties": {
+                    "totalBlockedAudibleMedia": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "totalPagesAM": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "totalPages",
+                    "totalPagesAM",
+                    "totalBlockedAudibleMedia"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "counters"
+              ]
+            },
+            {
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [ "prompt" ]
+                },
+                "promptResponse": {
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "allowAutoplay": {
+                        "type": "boolean"
+                      },
+                      "pageId": {
+                        "type": "string"
+                      },
+                      "rememberCheckbox": {
+                        "type": "boolean"
+                      },
+                      "timestamp": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "pageId",
+                      "timestamp",
+                      "rememberCheckbox",
+                      "allowAutoplay"
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "promptResponse"
+              ]
+            },
+            {
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [ "settings" ]
+                },
+                "settingsChanged": {
+                  "items": {
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "globalSettings": {
+                            "type": "object",
+                            "properties": {
+                              "allowAutoplay": {
+                                "type": "string",
+                                "enum": [
+                                  "allow",
+                                  "block",
+                                  "ask"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "allowAutoplay"
+                            ]
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "globalSettings",
+                          "timestamp"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "pageSpecific": {
+                            "type": "object",
+                            "properties": {
+                              "allowAutoplay": {
+                                "type": "string",
+                                "enum": [
+                                  "allow",
+                                  "block",
+                                  "default"
+                                ]
+                              },
+                              "pageId": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "pageId",
+                              "allowAutoplay"
+                            ]
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "pageSpecific",
+                          "timestamp"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "settingsChanged"
+              ]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "branch",
+        "payload"
+      ]
+    }
+  },
+  "required": [
+    "type",
+    "id",
+    "creationDate",
+    "version",
+    "application",
+    "clientId",
+    "payload"
+  ]
+}

--- a/validation/telemetry/block-autoplay.1.counters.pass.json
+++ b/validation/telemetry/block-autoplay.1.counters.pass.json
@@ -1,0 +1,30 @@
+{
+  "type": "block-autoplay",
+  "id": "36d2c19a-30d0-f441-88cf-5c477de3275e",
+  "creationDate": "2018-08-21T21:25:43.172Z",
+  "version": 4,
+  "clientId": "71b6cac2-b7fb-f04e-9768-366ab51d3cfa",
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20180821100053",
+    "name": "Firefox",
+    "version": "63.0a1",
+    "displayVersion": "63.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "63.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "payload": {
+    "id": 15,
+    "branch": "control",
+    "payload": {
+      "type": "counts",
+      "counters": {
+        "totalPages": 300,
+        "totalPagesAM": 100,
+        "totalBlockedAudibleMedia": 50
+      }
+    }
+  }
+}

--- a/validation/telemetry/block-autoplay.1.prompt.pass.json
+++ b/validation/telemetry/block-autoplay.1.prompt.pass.json
@@ -1,0 +1,45 @@
+{
+  "type": "block-autoplay",
+  "id": "36d2c19a-30d0-f441-88cf-5c477de3275e",
+  "creationDate": "2018-08-21T21:25:43.172Z",
+  "version": 4,
+  "clientId": "71b6cac2-b7fb-f04e-9768-366ab51d3cfa",
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20180821100053",
+    "name": "Firefox",
+    "version": "63.0a1",
+    "displayVersion": "63.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "63.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "payload": {
+    "id": 10,
+    "branch": "allow-and-notRemember",
+    "payload": {
+      "type": "prompt",
+      "promptResponse": [
+        {
+          "pageId": "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+          "timestamp": 1532567717284,
+          "rememberCheckbox": false,
+          "allowAutoplay": false
+        },
+        {
+          "pageId": "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+          "timestamp": 1532567719828,
+          "rememberCheckbox": true,
+          "allowAutoplay": true
+        },
+        {
+          "pageId": "a8252bd8ae60de9f901gy1773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+          "timestamp": 1532567819828,
+          "rememberCheckbox": false,
+          "allowAutoplay": true
+        }
+      ]
+    }
+  }
+}

--- a/validation/telemetry/block-autoplay.1.settings.pass.json
+++ b/validation/telemetry/block-autoplay.1.settings.pass.json
@@ -1,0 +1,66 @@
+{
+  "type": "block-autoplay",
+  "id": "36d2c19a-30d0-f441-88cf-5c477de3275e",
+  "creationDate": "2018-08-21T21:25:43.172Z",
+  "version": 4,
+  "clientId": "71b6cac2-b7fb-f04e-9768-366ab51d3cfa",
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20180821100053",
+    "name": "Firefox",
+    "version": "63.0a1",
+    "displayVersion": "63.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "63.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "payload": {
+    "id": 20,
+    "branch": "allow-and-remember",
+    "payload": {
+      "type": "settings",
+      "settingsChanged": [
+        {
+          "timestamp": 1532567696509,
+          "globalSettings": {
+            "allowAutoplay": "allow"
+          }
+        },
+        {
+          "timestamp":1532567697598,
+          "globalSettings":{
+            "allowAutoplay": "ask"
+          }
+        },
+        {
+          "timestamp":1532567697798,
+          "globalSettings":{
+            "allowAutoplay": "block"
+          }
+        },
+        {
+          "timestamp": 1532567700984,
+          "pageSpecific":  {
+            "pageId":  "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+            "allowAutoplay": "allow"
+          }
+        },
+        {
+          "timestamp": 1532567800984,
+          "pageSpecific":  {
+            "pageId":  "a8252befec60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+            "allowAutoplay": "default"
+          }
+        },
+        {
+          "timestamp": 1532587800984,
+          "pageSpecific":  {
+            "pageId":  "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b6ekoi",
+            "allowAutoplay": "block"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
We would send the custom telemetry ping from block-autoplay shield-study extension [1] which is used to analysis the user behavior when they interact with the block-autoplay prompt and setting.

This custom ping also pass the data review [2].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1475099
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1479589