### PR TITLE
Bug 1237610: add schemas for build system telemetry

### DIFF
--- a/schemas/eng-workflow/build/build.1.parquetmr.txt
+++ b/schemas/eng-workflow/build/build.1.parquetmr.txt
@@ -1,0 +1,44 @@
+message build {
+  required group metadata {
+    required binary documentId (UTF8);
+    required int64  Timestamp;
+    optional binary Date (UTF8);
+  }
+  required group argv (LIST) {
+    repeated group list {
+      required binary element (UTF8);
+    }
+  }
+  required group build_opts {
+    optional boolean artifact;
+    optional boolean ccache;
+    optional binary compiler (UTF8);
+    optional boolean debug;
+    optional boolean icecream;
+    optional boolean opt;
+    optional boolean sccache;
+  }
+  required binary client_id (UTF8);
+  required binary command (UTF8);
+  required int64 duration_ms;
+  required boolean success;
+  required group system {
+    required binary os (UTF8);
+    optional binary cpu_brand (UTF8);
+    optional boolean drive_is_ssd;
+    optional int64 logical_cores;
+    optional int64 memory_gb;
+    optional int64 physical_cores;
+    optional boolean virtual_machine;
+  }
+  required binary time (UTF8);
+  optional binary exception (UTF8);
+  optional group file_types_changed (LIST) {
+    repeated group list {
+      required group element {
+        required int64 count;
+        required binary ext (UTF8);
+      }
+    }
+  }
+}

--- a/schemas/eng-workflow/build/build.1.schema.json
+++ b/schemas/eng-workflow/build/build.1.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "argv": {
+      "description": "Full mach commandline. If the commandline contains absolute paths they will be sanitized.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "build_opts": {
+      "description": "Selected build options",
+      "properties": {
+        "artifact": {
+          "description": "true if --enable-artifact-builds",
+          "type": "boolean"
+        },
+        "ccache": {
+          "description": "true if ccache is in use (--with-ccache)",
+          "type": "boolean"
+        },
+        "compiler": {
+          "description": "The compiler type in use (CC_TYPE)",
+          "enum": [
+            "clang",
+            "clang-cl",
+            "gcc",
+            "msvc"
+          ]
+        },
+        "debug": {
+          "description": "true if build is debug (--enable-debug)",
+          "type": "boolean"
+        },
+        "icecream": {
+          "description": "true if icecream in use",
+          "type": "boolean"
+        },
+        "opt": {
+          "description": "true if build is optimized (--enable-optimize)",
+          "type": "boolean"
+        },
+        "sccache": {
+          "description": "true if ccache in use is sccache",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "client_id": {
+      "description": "A UUID to uniquely identify a client",
+      "type": "string"
+    },
+    "command": {
+      "description": "The mach command that was invoked",
+      "type": "string"
+    },
+    "duration_ms": {
+      "description": "Command duration in milliseconds",
+      "type": "number"
+    },
+    "exception": {
+      "description": "If a Python exception was encountered during the execution of the command, this value contains the result of calling `repr` on the exception object.",
+      "type": "string"
+    },
+    "file_types_changed": {
+      "description": "This array contains a list of objects with {ext, count} properties giving the count of files changed since the last invocation grouped by file type",
+      "items": {
+        "properties": {
+          "count": {
+            "description": "Count of changed files with this extension",
+            "type": "number"
+          },
+          "ext": {
+            "description": "File extension",
+            "type": "string"
+          }
+        },
+        "required": [
+          "count",
+          "ext"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "description": "true if the command succeeded",
+      "type": "boolean"
+    },
+    "system": {
+      "properties": {
+        "cpu_brand": {
+          "description": "CPU brand string from CPUID",
+          "type": "string"
+        },
+        "drive_is_ssd": {
+          "description": "true if the source directory is on a solid-state disk",
+          "type": "boolean"
+        },
+        "logical_cores": {
+          "description": "Number of logical CPU cores present",
+          "type": "number"
+        },
+        "memory_gb": {
+          "description": "System memory in GB",
+          "type": "number"
+        },
+        "os": {
+          "description": "Operating system",
+          "enum": [
+            "windows",
+            "macos",
+            "linux",
+            "other"
+          ]
+        },
+        "physical_cores": {
+          "description": "Number of physical CPU cores present",
+          "type": "number"
+        },
+        "virtual_machine": {
+          "description": "true if the OS appears to be running in a virtual machine",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "os"
+      ],
+      "type": "object"
+    },
+    "time": {
+      "description": "Time at which this event happened",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "argv",
+    "build_opts",
+    "client_id",
+    "command",
+    "duration_ms",
+    "success",
+    "system",
+    "time"
+  ],
+  "type": "object"
+}

--- a/templates/eng-workflow/build/build.1.parquetmr.txt
+++ b/templates/eng-workflow/build/build.1.parquetmr.txt
@@ -1,0 +1,44 @@
+message build {
+  required group metadata {
+    required binary documentId (UTF8);
+    required int64  Timestamp;
+    optional binary Date (UTF8);
+  }
+  required group argv (LIST) {
+    repeated group list {
+      required binary element (UTF8);
+    }
+  }
+  required group build_opts {
+    optional boolean artifact;
+    optional boolean ccache;
+    optional binary compiler (UTF8);
+    optional boolean debug;
+    optional boolean icecream;
+    optional boolean opt;
+    optional boolean sccache;
+  }
+  required binary client_id (UTF8);
+  required binary command (UTF8);
+  required int64 duration_ms;
+  required boolean success;
+  required group system {
+    required binary os (UTF8);
+    optional binary cpu_brand (UTF8);
+    optional boolean drive_is_ssd;
+    optional int64 logical_cores;
+    optional int64 memory_gb;
+    optional int64 physical_cores;
+    optional boolean virtual_machine;
+  }
+  required binary time (UTF8);
+  optional binary exception (UTF8);
+  optional group file_types_changed (LIST) {
+    repeated group list {
+      required group element {
+        required int64 count;
+        required binary ext (UTF8);
+      }
+    }
+  }
+}

--- a/templates/eng-workflow/build/build.1.schema.json
+++ b/templates/eng-workflow/build/build.1.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#", 
+  "properties": {
+    "argv": {
+      "description": "Full mach commandline. If the commandline contains absolute paths they will be sanitized.", 
+      "items": {
+        "type": "string"
+      }, 
+      "type": "array"
+    }, 
+    "build_opts": {
+      "description": "Selected build options", 
+      "properties": {
+        "artifact": {
+          "description": "true if --enable-artifact-builds", 
+          "type": "boolean"
+        }, 
+        "ccache": {
+          "description": "true if ccache is in use (--with-ccache)", 
+          "type": "boolean"
+        }, 
+        "compiler": {
+          "description": "The compiler type in use (CC_TYPE)", 
+          "enum": [
+            "clang", 
+            "clang-cl", 
+            "gcc", 
+            "msvc"
+          ]
+        }, 
+        "debug": {
+          "description": "true if build is debug (--enable-debug)",
+          "type": "boolean"
+        },
+        "icecream": {
+          "description": "true if icecream in use",
+          "type": "boolean"
+        },
+        "opt": {
+          "description": "true if build is optimized (--enable-optimize)",
+          "type": "boolean"
+        },
+        "sccache": {
+          "description": "true if ccache in use is sccache",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "client_id": {
+      "description": "A UUID to uniquely identify a client",
+      "type": "string"
+    },
+    "command": {
+      "description": "The mach command that was invoked",
+      "type": "string"
+    },
+    "duration_ms": {
+      "description": "Command duration in milliseconds",
+      "type": "number"
+    },
+    "exception": {
+      "description": "If a Python exception was encountered during the execution of the command, this value contains the result of calling `repr` on the exception object.",
+      "type": "string"
+    },
+    "file_types_changed": {
+      "description": "This array contains a list of objects with {ext, count} properties giving the count of files changed since the last invocation grouped by file type",
+      "items": {
+        "properties": {
+          "count": {
+            "description": "Count of changed files with this extension",
+            "type": "number"
+          },
+          "ext": {
+            "description": "File extension",
+            "type": "string"
+          }
+        },
+        "required": [
+          "count",
+          "ext"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "description": "true if the command succeeded",
+      "type": "boolean"
+    },
+    "system": {
+      "properties": {
+        "cpu_brand": {
+          "description": "CPU brand string from CPUID",
+          "type": "string"
+        },
+        "drive_is_ssd": {
+          "description": "true if the source directory is on a solid-state disk",
+          "type": "boolean"
+        },
+        "logical_cores": {
+          "description": "Number of logical CPU cores present",
+          "type": "number"
+        },
+        "memory_gb": {
+          "description": "System memory in GB",
+          "type": "number"
+        },
+        "os": {
+          "description": "Operating system",
+          "enum": [
+            "windows",
+            "macos",
+            "linux",
+            "other"
+          ]
+        },
+        "physical_cores": {
+          "description": "Number of physical CPU cores present",
+          "type": "number"
+        },
+        "virtual_machine": {
+          "description": "true if the OS appears to be running in a virtual machine",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "os"
+      ],
+      "type": "object"
+    },
+    "time": {
+      "description": "Time at which this event happened",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "argv",
+    "build_opts",
+    "client_id",
+    "command",
+    "duration_ms",
+    "success",
+    "system",
+    "time"
+  ],
+  "type": "object"
+}

--- a/validation/eng-workflow/build.1.sample.pass.json
+++ b/validation/eng-workflow/build.1.sample.pass.json
@@ -1,0 +1,23 @@
+{
+  "argv": ["./mach", "build"], 
+  "build_opts": {
+    "artifact": false,
+    "ccache": true, 
+    "compiler": "clang", 
+    "debug": true, 
+    "opt": false, 
+    "sccache": true
+  }, 
+  "client_id": "c890ef1c-c6d8-4bc5-8859-f27e346cda8b", 
+  "command": "build", 
+  "duration_ms": 301020, 
+  "success": true, 
+  "system": {
+    "cpu_brand": "Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz", 
+    "logical_cores": 8, 
+    "memory_gb": 32, 
+    "os": "linux", 
+    "physical_cores": 4
+  }, 
+  "time": "2018-08-09T20:50:12.356679Z"
+}


### PR DESCRIPTION
This commit adds a schema for build system telemetry data
collection in both json-schema and Parquet formats. The
schema is added under the eng-workflow namespace. The
datareview+ for this new ping was received in bug 1291053.