### PR TITLE
add attributes `interact` and `responseTime` in `promptResponse` object.

### DIFF
--- a/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -122,26 +122,70 @@
               "properties": {
                 "promptResponse": {
                   "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "allowAutoplay": {
-                        "type": "boolean"
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "allowAutoplay": {
+                            "type": "boolean"
+                          },
+                          "interact": {
+                            "enum": [
+                              "interact"
+                            ],
+                            "type": "string"
+                          },
+                          "pageId": {
+                            "type": "string"
+                          },
+                          "rememberCheckbox": {
+                            "type": "boolean"
+                          },
+                          "responseTime": {
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "pageId",
+                          "timestamp",
+                          "responseTime",
+                          "interact",
+                          "rememberCheckbox",
+                          "allowAutoplay"
+                        ]
                       },
-                      "pageId": {
-                        "type": "string"
-                      },
-                      "rememberCheckbox": {
-                        "type": "boolean"
-                      },
-                      "timestamp": {
-                        "type": "integer"
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "interact": {
+                            "enum": [
+                              "escape",
+                              "ignore"
+                            ],
+                            "type": "string"
+                          },
+                          "pageId": {
+                            "type": "string"
+                          },
+                          "responseTime": {
+                            "minimum": 0,
+                            "type": "number"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "pageId",
+                          "timestamp",
+                          "responseTime",
+                          "interact"
+                        ]
                       }
-                    },
-                    "required": [
-                      "pageId",
-                      "timestamp",
-                      "rememberCheckbox",
-                      "allowAutoplay"
                     ],
                     "type": "object"
                   },

--- a/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -73,40 +73,86 @@
               ]
             },
             {
+              "additionalProperties": false,
               "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [ "prompt" ]
-                },
                 "promptResponse": {
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "allowAutoplay": {
-                        "type": "boolean"
+                    "oneOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "pageId": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          },
+                          "responseTime": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "interact": {
+                            "type": "string",
+                            "enum": [
+                              "interact"
+                            ]
+                          },
+                          "allowAutoplay": {
+                            "type": "boolean"
+                          },
+                          "rememberCheckbox": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pageId",
+                          "timestamp",
+                          "responseTime",
+                          "interact",
+                          "rememberCheckbox",
+                          "allowAutoplay"
+                        ]
                       },
-                      "pageId": {
-                        "type": "string"
-                      },
-                      "rememberCheckbox": {
-                        "type": "boolean"
-                      },
-                      "timestamp": {
-                        "type": "integer"
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "pageId": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "integer"
+                          },
+                          "responseTime": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "interact": {
+                            "type": "string",
+                            "enum": [
+                              "escape",
+                              "ignore"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "pageId",
+                          "timestamp",
+                          "responseTime",
+                          "interact"
+                        ]
                       }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                      "pageId",
-                      "timestamp",
-                      "rememberCheckbox",
-                      "allowAutoplay"
-                    ]
+                    ],
+                    "type": "object"
                   },
                   "type": "array"
+                },
+                "type": {
+                  "enum": [
+                    "prompt"
+                  ],
+                  "type": "string"
                 }
               },
-              "additionalProperties": false,
               "required": [
                 "type",
                 "promptResponse"

--- a/validation/telemetry/block-autoplay.1.prompt.pass.json
+++ b/validation/telemetry/block-autoplay.1.prompt.pass.json
@@ -22,22 +22,24 @@
       "type": "prompt",
       "promptResponse": [
         {
-          "pageId": "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
+          "pageId": "cwnvsc7gllrdfgwssnpo",
           "timestamp": 1532567717284,
-          "rememberCheckbox": false,
-          "allowAutoplay": false
+          "responseTime": 1.5,
+          "interact": "interact",
+          "allowAutoplay": false,
+          "rememberCheckbox": false
         },
         {
-          "pageId": "a8252bd8ac60de9f901001773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
-          "timestamp": 1532567719828,
-          "rememberCheckbox": true,
-          "allowAutoplay": true
+          "pageId": "cwnvsc7gllrdfgwssnpo",
+          "timestamp": 1535489632269,
+          "responseTime": 0,
+          "interact": "escape"
         },
         {
-          "pageId": "a8252bd8ae60de9f901gy1773db53cf5e4dddf9bd9c056d0b00cb749f81b649a",
-          "timestamp": 1532567819828,
-          "rememberCheckbox": false,
-          "allowAutoplay": true
+          "pageId": "cwnvsc7gllrdfgwssnpo",
+          "timestamp": 1535489636047,
+          "responseTime": 5,
+          "interact": "ignore"
         }
       ]
     }


### PR DESCRIPTION
After discussed with our data scientist, adding two new attributes `interact` and `responseTime` in `promptResponse` object.

`interact` is used to answer how user interacts with the prompt.
`responseTime` is the total showing time before the promp dismiss.

See the full explanation document [here](https://github.com/alastor0325/autoplay-shield-study/blob/develop/docs/TELEMETRY.md#block-autoplay-pings-specific-to-this-study).
