### PR TITLE
Bug 1458734 - Test schemas against real sampled data using edge-validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: docker:18.02.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: docker build -t mps .
+      - run:
+          name: Test Code
+          command: docker run mps
+
+workflows:
+    version: 2
+    build:
+        jobs:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 version: 2
 jobs:
   test:
     docker:
-      - image: docker:18.02.0-ce-git
+      - image: docker:stable-git
     steps:
       - checkout
       - setup_remote_docker
@@ -12,9 +16,41 @@ jobs:
       - run:
           name: Test Code
           command: docker run mps
+  integrate:
+    docker:
+      - image: mozilla/edge-validator:1.3
+    steps:
+      - checkout
+      - run:
+          name: Checkout upstream
+          command: |
+            git remote add upstream git@github.com:mozilla-services/mozilla-pipeline-schemas.git
+            git fetch --all
+      - setup_remote_docker
+      - run:
+          name: Run a comparison report
+          command: |
+            # Get the revisions for comparison. This will compare the tip of
+            # the PR against the upstream mozilla:dev.
+            head_short_id=$(git rev-parse --short HEAD)
+            upstream_short_id=$(git rev-parse --short upstream/dev)
+
+            # The `checkout` step defaults to $HOME/project (/app/project).
+            # Replace the container's submodule with the current state of this repo.
+            cd .. && rm -r mozilla-pipeline-schemas && mv project mozilla-pipeline-schemas
+
+            # Run the comparison report and store the artifacts for future viewing.
+            pipenv run \
+              python integration.py compare \
+                --report-path test-reports \
+                $upstream_short_id $head_short_id
+      - store_artifacts:
+          path: /app/test-reports
+          destination: /app/test-results
 
 workflows:
     version: 2
     build:
         jobs:
             - test
+            - integrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-services:
-  - docker
-before_install:
-- docker build -t mps .
-script:
-- docker run mps


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1458734#c1)

This PR tests schemas against real, sampled data. A report is generated between the `HEAD` of the PR and `mozilla:dev`. The sampled data (`sanitized-landfill-sample`) is generated by a scheduled batch job under a stricter IAM role with access to landfill data. The CI takes advantage of a script included in the `mozilla/edge-validator` docker image to generate integration reports and diffs between two revisions of mozilla-pipeline-schemas. If there is a change in the report (e.g. a decrease in validation errors on a doctype), a diff is generated and added as a test artifact that can be reviewed.

This moves from TravisCI to CircleCI to support more complex workflows. I wrote some test cases in [this PR on my local repository](https://github.com/acmiyaguchi/mozilla-pipeline-schemas/pull/1). I've copied and pasted the diffs into a comment. They can be retrieved clicking on the CI checkbox > integration` details` link > `Artifacts` tab > `app/test-reports` tree. 
![image](https://user-images.githubusercontent.com/3304040/44935239-bdd3c380-ad24-11e8-80cf-b6cde242b680.png)

The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` need to be set in CircleCI in order to fetch the samples from S3. The samples do not contain any sensitive information and are limited to 1000 documents per doctype a day. The resulting report data only contains information about the namespace, doctype, version, and validation exceptions. I've been able to run CircleCI images with ssh enabled to debug, which means that the scope of the keys should probably be limited in scope. I think CircleCI limits access to the ssh functionality through Github teams though. 

The report takes between 3-6 minutes to run a report depending on the day. I would like to decrease the time by generating a gzip'ed archive for each submission date, which are improvements that need to be made against the landfill sampler and edge-validator image.

I've also included this mermaid graph for a high level overview of the feedback loop I want to introduce for schema development. 
![image](https://user-images.githubusercontent.com/3304040/44934645-70eeed80-ad22-11e8-9c08-08bca4bd5aae.png)
