### PR TITLE
Use `[0-9]` instead of `\d` in histograms

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -986,7 +986,7 @@
               "values": {
                 "additionalProperties": false,
                 "patternProperties": {
-                  "^\\d+$": {
+                  "^[0-9]+$": {
                     "minimum": 0,
                     "type": "integer"
                   }
@@ -1049,7 +1049,7 @@
                 "values": {
                   "additionalProperties": false,
                   "patternProperties": {
-                    "^\\d+$": {
+                    "^[0-9]+$": {
                       "minimum": 0,
                       "type": "integer"
                     }
@@ -1261,7 +1261,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1312,7 +1312,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }
@@ -1538,7 +1538,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1589,7 +1589,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }
@@ -1815,7 +1815,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1866,7 +1866,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }

--- a/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -69,7 +69,7 @@
                 "values": {
                   "additionalProperties": false,
                   "patternProperties": {
-                    "^\\d+$": {
+                    "^[0-9]+$": {
                       "minimum": 0,
                       "type": "integer"
                     }
@@ -120,7 +120,7 @@
                   "values": {
                     "additionalProperties": false,
                     "patternProperties": {
-                      "^\\d+$": {
+                      "^[0-9]+$": {
                         "minimum": 0,
                         "type": "integer"
                       }

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -986,7 +986,7 @@
               "values": {
                 "additionalProperties": false,
                 "patternProperties": {
-                  "^\\d+$": {
+                  "^[0-9]+$": {
                     "minimum": 0,
                     "type": "integer"
                   }
@@ -1049,7 +1049,7 @@
                 "values": {
                   "additionalProperties": false,
                   "patternProperties": {
-                    "^\\d+$": {
+                    "^[0-9]+$": {
                       "minimum": 0,
                       "type": "integer"
                     }
@@ -1261,7 +1261,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1312,7 +1312,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }
@@ -1538,7 +1538,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1589,7 +1589,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }
@@ -1815,7 +1815,7 @@
                       "values": {
                         "additionalProperties": false,
                         "patternProperties": {
-                          "^\\d+$": {
+                          "^[0-9]+$": {
                             "minimum": 0,
                             "type": "integer"
                           }
@@ -1866,7 +1866,7 @@
                         "values": {
                           "additionalProperties": false,
                           "patternProperties": {
-                            "^\\d+$": {
+                            "^[0-9]+$": {
                               "minimum": 0,
                               "type": "integer"
                             }

--- a/templates/include/telemetry/histogram.1.schema.json
+++ b/templates/include/telemetry/histogram.1.schema.json
@@ -34,7 +34,7 @@
     "values": {
       "type": "object",
       "patternProperties": {
-        "^\\d+$": {
+        "^[0-9]+$": {
           "type": "integer",
           "minimum": 0
         }


### PR DESCRIPTION
This uses the more strict subset of regex that's recommended in [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) tutorial.

The python wrapper for rapidjson doesn't include the `std::regex` at compile time to support `\d`, but square brackets suffice. This should make the schemas more widely compatible and will fix the validation errors in the `edge-validator` server. 