### PR TITLE
Remove focus-event trailing comma

### DIFF
--- a/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
+++ b/schemas/telemetry/focus-event/focus-event.1.parquetmr.txt
@@ -49,5 +49,5 @@ optional group experiments (MAP) {
     required binary value (UTF8);
   }
 }
-,
+
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1383111

The tests don't fail because they regenerate the schemas from templates before running.