### PR TITLE
Bug 1487578 - Add schemas for "coverage" ping

### DIFF
--- a/schemas/coverage/coverage/coverage.1.parquetmr.txt
+++ b/schemas/coverage/coverage/coverage.1.parquetmr.txt
@@ -1,0 +1,10 @@
+message event {
+  optional binary metadata_documentId (UTF8);
+  optional binary metadata_geoCountry (UTF8);
+
+  optional binary appVersion (UTF8);
+  optional binary appUpdateChannel (UTF8);
+  optional binary osName (UTF8);
+  optional binary osVersion (UTF8);
+  optional boolean telemetryEnabled;
+}

--- a/schemas/coverage/coverage/coverage.1.schema.json
+++ b/schemas/coverage/coverage/coverage.1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "description": "See bug 1487578 for more info",
+  "properties": {
+    "appUpdateChannel": {
+      "type": "string"
+    },
+    "appVersion": {
+      "type": "string"
+    },
+    "osName": {
+      "type": "string"
+    },
+    "osVersion": {
+      "type": "string"
+    },
+    "telemetryEnabled": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "appVersion",
+    "appUpdateChannel",
+    "osName",
+    "osVersion",
+    "telemetryEnabled"
+  ],
+  "title": "coverage",
+  "type": "object"
+}

--- a/templates/coverage/coverage/coverage.1.parquetmr.txt
+++ b/templates/coverage/coverage/coverage.1.parquetmr.txt
@@ -1,0 +1,10 @@
+message event {
+  optional binary metadata_documentId (UTF8);
+  optional binary metadata_geoCountry (UTF8);
+
+  optional binary appVersion (UTF8);
+  optional binary appUpdateChannel (UTF8);
+  optional binary osName (UTF8);
+  optional binary osVersion (UTF8);
+  optional boolean telemetryEnabled;
+}

--- a/templates/coverage/coverage/coverage.1.schema.json
+++ b/templates/coverage/coverage/coverage.1.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "coverage",
+  "description": "See bug 1487578 for more info",
+  "properties": {
+    "appVersion": {
+      "type": "string"
+    },
+    "appUpdateChannel": {
+      "type": "string"
+    },
+    "osName": {
+      "type": "string"
+    },
+    "osVersion": {
+      "type": "string"
+    },
+    "telemetryEnabled": {
+      "type": "boolean"
+    }
+  },
+  "required": [ "appVersion", "appUpdateChannel", "osName", "osVersion", "telemetryEnabled" ],
+  "additionalProperties": false
+}

--- a/validation/coverage/coverage.1.extra_field.fail.json
+++ b/validation/coverage/coverage.1.extra_field.fail.json
@@ -1,0 +1,8 @@
+{
+  "appVersion": "63.0a1",
+  "appUpdateChannel": "nightly",
+  "osName": "Darwin",
+  "osVersion": "17.7.0",
+  "telemetryEnabled": true,
+  "dummy": true
+}

--- a/validation/coverage/coverage.1.missing_field.fail.json
+++ b/validation/coverage/coverage.1.missing_field.fail.json
@@ -1,0 +1,6 @@
+{
+  "appVersion": "63.0a1",
+  "appUpdateChannel": "nightly",
+  "osName": "Darwin",
+  "telemetryEnabled": true
+}

--- a/validation/coverage/coverage.1.sample.pass.json
+++ b/validation/coverage/coverage.1.sample.pass.json
@@ -1,0 +1,7 @@
+{
+  "appVersion": "63.0a1",
+  "appUpdateChannel": "nightly",
+  "osName": "Darwin",
+  "osVersion": "17.7.0",
+  "telemetryEnabled": true
+}


### PR DESCRIPTION
See also [the PR for the add-on sending this ping](https://github.com/mozilla/one-off-system-add-ons/pull/123).