### PR TITLE
Update CircleCI and document edge-validator integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+ commands:
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing credentials.
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
+
 version: 2
 jobs:
   test:
@@ -20,6 +34,7 @@ jobs:
     docker:
       - image: mozilla/edge-validator:1.3
     steps:
+      - early_return_for_forked_pull_requests
       - checkout
       - run:
           name: Checkout upstream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
- commands:
+version: 2
+
+commands:
   early_return_for_forked_pull_requests:
     description: >-
       If this build is from a fork, stop executing the current job and return success.
@@ -16,7 +18,6 @@
               circleci step halt
             fi
 
-version: 2
 jobs:
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-version: 2
+version: 2.1
 
 commands:
   early_return_for_forked_pull_requests:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Follow the CMake Build Instructions above, then:
     make # this sets up the tests in the release directory
     ctest -V -C hindsight # loads all the schemas and tests the inputs in the validation directory against them
 
+The following docker command will generate a report against a sample of data from the ingestion system given proper credentials. Running this is recommended when making modifications to many schemas or during review.
+
+    docker run \
+        -e AWS_ACCESS_KEY_ID \
+        -e AWS_SECRET_ACCESS_KEY \
+        -v "$(pwd)":/app/mozilla-pipeline-schemas \
+        -it mozilla/edge-validator:latest \
+            make report
+
+It is also possible to directly compare between two revisions, refer to `.circleci/config.yml` for a reference. For more documentation, see [mozilla-services/edge-validator](https://github.com/mozilla-services/edge-validator).
+
 ## Releases
 
 * The master branch is the current release and is considered stable at all


### PR DESCRIPTION
This shortcuts the CircleCI integrate step to fix currently broken tests. This also documents how to manually run integration tests against real data using the working directory. 