### PR TITLE
Store events as we do on desktop

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -96,41 +96,45 @@
       ]
     },
     "events": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/base"
-        },
-        {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "extra": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "propertyNames": {
-                  "$ref": "#/definitions/very_short_id"
-                },
-                "type": "object"
-              },
-              "object": {
-                "$ref": "#/definitions/very_short_id"
-              },
-              "timestamp": {
-                "type": "integer"
-              },
-              "value": {
-                "type": "string"
-              }
+      "items": {
+        "items": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "required": [
-              "timestamp",
-              "object"
-            ],
-            "type": "object"
+            "type": [
+              "object",
+              "null"
+            ]
           }
-        }
-      ]
+        ],
+        "maxItems": 6,
+        "minItems": 4,
+        "type": "array"
+      },
+      "type": "array"
     },
     "experiments": {
       "additionalProperties": {

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -346,41 +346,8 @@
       "additionalProperties": false
     },
     "events": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/base"
-        },
-        {
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "timestamp": {
-                "type": "integer"
-              },
-              "object": {
-                "$ref": "#/definitions/very_short_id"
-              },
-              "value": {
-                "type": "string"
-              },
-              "extra": {
-                "type": "object",
-                "propertyNames": {
-                  "$ref": "#/definitions/very_short_id"
-                },
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "timestamp",
-              "object"
-            ]
-          }
-        }
-      ]
+        "type": "array",
+        "items": @COMMON_EVENT_1_JSON@
     },
     "experiments": {
       "propertyNames": {

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -96,17 +96,6 @@
       "examples.uuid_example": "c3757f87-7bcb-453d-87ba-567157e38e0d"
     }
   },
-  "events": {
-    "examples.event_example": {
-      "timestamp": 123456789,
-      "object": "button",
-      "value": "42",
-      "extra": {
-        "metadata1": "extra",
-        "metadata2": "more extra"
-      }
-    }
-  },
   "experiments": {
     "experiment1": {
       "branch": "branch_a"
@@ -117,5 +106,9 @@
         "type": "experiment_type"
       }
     }
-  }
+  },
+  "events": [
+    [123456789, "examples", "event_example", "button", "42", {"metadata1": "extra", "metadata2": "more_extra"}],
+    [123456791, "examples", "event_example", "button2", "45"]
+  ]
 }

--- a/validation/glean/baseline.1.core.pass.json
+++ b/validation/glean/baseline.1.core.pass.json
@@ -93,15 +93,7 @@
       "examples.rate_example": 23
     }
   },
-  "events": {
-    "examples.event_example": {
-      "timestamp": 123456789,
-      "object": "button",
-      "value": "42",
-      "extra": {
-        "metadata1": "extra",
-        "metadata2": "more extra"
-      }
-    }
-  }
+  "events": [
+    [123456789, "examples", "event_example", "button", "42", {"metadata1": "extra", "metadata2": "more_extra"}]
+  ]
 }


### PR DESCRIPTION
This changes how events are stored in the glean ping to follow [how they are on desktop](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format)