### PR TITLE
Bug 1435827: Adding JSON and Parquet schemas

### DIFF
--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
@@ -174,10 +174,10 @@ message untrusted-modules {
         }
       }
     }
-    required group addons {
+    optional group addons {
       optional binary persona (UTF8);
-      required group theme {
-        required binary id (UTF8);
+      optional group theme {
+        optional binary id (UTF8);
         optional boolean blocklisted;
         optional binary description (UTF8);
         optional binary name (UTF8);
@@ -189,44 +189,44 @@ message untrusted-modules {
         optional int64 installDay (UINT_64);
         optional int64 updateDay (UINT_64);
       }
-      required group activeAddons (MAP) {
+      optional group activeAddons (MAP) {
         repeated group key_value {
           required binary key (UTF8);
           required group value {
-            required boolean blocklisted;
-            required binary name (UTF8);
+            optional boolean blocklisted;
+            optional binary name (UTF8);
             optional binary description (UTF8);
-            required boolean appDisabled;
-            required int64 scope;
-            required binary type (UTF8);
-            required boolean hasBinaryComponents;
-            required int64 installDay (UINT_64);
-            required int64 updateDay (UINT_64);
+            optional boolean appDisabled;
+            optional int64 scope;
+            optional binary type (UTF8);
+            optional boolean hasBinaryComponents;
+            optional int64 installDay (UINT_64);
+            optional int64 updateDay (UINT_64);
             optional int64 signedState;
-            required boolean isSystem;
+            optional boolean isSystem;
           }
         }
       }
-      required group activeGMPlugins (MAP) {
+      optional group activeGMPlugins (MAP) {
         repeated group key_value {
           required binary key (UTF8);
           required group value {
-            required binary version (UTF8);
-            required boolean userDisabled;
+            optional binary version (UTF8);
+            optional boolean userDisabled;
           }
         }
       }
-      required group activePlugins (LIST) {
+      optional group activePlugins (LIST) {
         repeated group list {
           required group element {
-            required binary name (UTF8);
-            required binary version (UTF8);
-            required binary description (UTF8);
-            required boolean blocklisted;
-            required boolean disabled;
-            required boolean clicktoplay;
-            required int64 updateDay;
-            required group mimeTypes (LIST) {
+            optional binary name (UTF8);
+            optional binary version (UTF8);
+            optional binary description (UTF8);
+            optional boolean blocklisted;
+            optional boolean disabled;
+            optional boolean clicktoplay;
+            optional int64 updateDay;
+            optional group mimeTypes (LIST) {
               repeated group list {
                 required binary element (UTF8);
               }

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
@@ -1,0 +1,313 @@
+message untrusted-modules {
+  optional group environment {
+    optional group profile {
+      optional int64 creationDate;
+      optional int64 resetDate;
+    }
+    required group settings {
+      optional boolean isDefaultBrowser;
+      optional boolean addonCompatibilityCheckEnabled;
+      optional binary locale (UTF8);
+      optional boolean e10sEnabled;
+      optional boolean blocklistEnabled;
+      optional binary defaultSearchEngine (UTF8);
+      optional boolean telemetryEnabled;
+      optional binary e10sCohort (UTF8);
+      optional binary searchCohort (UTF8);
+      optional int64 e10sMultiProcesses;
+      optional group defaultSearchEngineData {
+        optional binary name (UTF8);
+        optional binary loadPath (UTF8);
+        optional binary submissionURL (UTF8);
+        optional binary origin (UTF8);
+      }
+      optional group update {
+        optional boolean autoDownload;
+        optional binary channel (UTF8);
+        optional boolean enabled;
+      }
+      optional group sandbox {
+        optional int64 effectiveContentProcessLevel;
+      }
+    }
+    required group system {
+      optional boolean isWow64;
+      optional int64 memoryMB;
+      optional int64 virtualMaxMB (UINT_64);
+      optional binary appleModelId (UTF8);
+      optional group os {
+        optional binary name (UTF8);
+        optional binary locale (UTF8);
+        optional int64 windowsUBR;
+        optional int64 installYear;
+        optional int64 servicePackMajor;
+        optional int64 windowsBuildNumber;
+        optional int64 servicePackMinor;
+      }
+    }
+    optional group gfx {
+      optional group features {
+        optional group advancedLayers {
+          optional binary status (UTF8);
+        }
+        optional group webrender {
+          optional binary status (UTF8);
+        }
+        optional group wrQualified {
+          optional binary status (UTF8);
+        }
+        optional binary compositor (UTF8);
+        optional group d3d11 {
+          optional binary status (UTF8);
+          optional boolean textureSharing;
+          optional int64 version;
+          optional boolean blacklisted;
+          optional boolean warp;
+        }
+        optional group gpuProcess {
+          optional binary status (UTF8);
+        }
+        optional group d2d {
+          optional binary status (UTF8);
+          optional binary version (UTF8);
+        }
+      }
+      optional boolean DWriteEnabled;
+      optional boolean D2DEnabled;
+      optional binary ContentBackend (UTF8);
+      optional group adapters (LIST) {
+        repeated group list {
+          required group element {
+            optional binary description (UTF8);
+            optional binary vendorID (UTF8);
+            optional binary deviceID (UTF8);
+            optional binary subsysID (UTF8);
+            optional int64 RAM (UINT_64);
+            optional binary driver (UTF8);
+            optional binary driverVersion (UTF8);
+            optional binary driverDate (UTF8);
+            optional boolean GPUActive;
+          }
+        }
+      }
+      optional group monitors (LIST) {
+        repeated group list {
+          required group element {
+            optional int64 refreshRate (UINT_64);
+            optional int64 screenHeight (UINT_64);
+            optional int64 screenWidth (UINT_64);
+            optional boolean pseudoDisplay;
+          }
+        }
+      }
+    }
+    optional group sec {
+      optional group firewall (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+      optional group antispyware (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+      optional group antivirus (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+    }
+    optional group hdd {
+      optional group profile {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+      optional group binary {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+      optional group system {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+    }
+    optional group cpu {
+      optional int64 cores;
+      optional int64 count;
+      optional int64 family (UINT_64);
+      optional int64 l2cacheKB (UINT_64);
+      optional int64 l3cacheKB (UINT_64);
+      optional int64 model (UINT_64);
+      optional int64 speedMHz (UINT_64);
+      optional int64 stepping (UINT_64);
+      optional binary vendor (UTF8);
+      optional group extensions (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+    }
+    required group build {
+      required binary applicationId (UTF8);
+      required binary applicationName (UTF8);
+      required binary architecture (UTF8);
+      optional binary architecturesInBinary (UTF8);
+      required binary buildId (UTF8);
+      optional binary hotfixVersion (UTF8);
+      required binary version (UTF8);
+      required binary vendor (UTF8);
+      optional binary displayVersion (UTF8);
+      required binary platformVersion (UTF8);
+      optional boolean updaterAvailable;
+      required binary xpcomAbi (UTF8);
+    }
+    required group partner {
+      optional binary distributionId (UTF8);
+      optional binary distributionVersion (UTF8);
+      optional binary partnerId (UTF8);
+      optional binary distributor (UTF8);
+      optional binary distributorChannel (UTF8);
+      optional group partnerNames (LIST) {
+        repeated group list {
+          optional binary element (UTF8);
+        }
+      }
+    }
+    required group addons {
+      optional binary persona (UTF8);
+      required group theme {
+        required binary id (UTF8);
+        optional boolean blocklisted;
+        optional binary description (UTF8);
+        optional binary name (UTF8);
+        optional boolean userDisabled;
+        optional boolean appDisabled;
+        optional binary version (UTF8);
+        optional int64 scope;
+        optional boolean hasBinaryComponents;
+        optional int64 installDay (UINT_64);
+        optional int64 updateDay (UINT_64);
+      }
+      required group activeAddons (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            required boolean blocklisted;
+            required binary name (UTF8);
+            optional binary description (UTF8);
+            required boolean appDisabled;
+            required int64 scope;
+            required binary type (UTF8);
+            required boolean hasBinaryComponents;
+            required int64 installDay (UINT_64);
+            required int64 updateDay (UINT_64);
+            optional int64 signedState;
+            required boolean isSystem;
+          }
+        }
+      }
+      required group activeGMPlugins (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            required binary version (UTF8);
+            required boolean userDisabled;
+          }
+        }
+      }
+      required group activePlugins (LIST) {
+        repeated group list {
+          required group element {
+            required binary name (UTF8);
+            required binary version (UTF8);
+            required binary description (UTF8);
+            required boolean blocklisted;
+            required boolean disabled;
+            required boolean clicktoplay;
+            required int64 updateDay;
+            required group mimeTypes (LIST) {
+              repeated group list {
+                required binary element (UTF8);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  optional binary clientId (UTF8);
+  required binary creationDate (UTF8);
+  required binary id (UTF8);
+  required binary type (UTF8);
+  required double version;
+  required group payload {
+    required group combinedStacks {
+      required group memoryMap (LIST) {
+        repeated group list {
+          required group element (TUPLE) {
+            required binary moduleName (UTF8);
+            required binary debugId (UTF8);
+          }
+        }
+      }
+      required group stacks (LIST) {
+        repeated group list {
+          required group element (LIST) {
+            repeated group list {
+              required group element (TUPLE) {
+                required int64 moduleIndex;
+                required int64 moduleOffset (UINT_64);
+              }
+            }
+          }
+        }
+      }
+    }
+    required int64 structVersion (UINT_64);
+    required int64 errorModules (UINT_64);
+    required group events (LIST) {
+      repeated group list {
+        required group element {
+          optional int64 processUptimeMS;
+          required boolean isStartup;
+          optional binary threadName (UTF8);
+          optional int64 threadID (UINT_64);
+          required group modules (LIST) {
+            repeated group list {
+              required group element {
+                required binary baseAddress (UTF8);
+                required binary moduleName (UTF8);
+                optional binary fileVersion (UTF8);
+                optional binary loaderName (UTF8);
+                required int64 moduleTrustFlags (UINT_64);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  required group application {
+  required binary architecture (UTF8);
+  required binary buildId (UTF8);
+  required binary channel (UTF8);
+  required binary name (UTF8);
+  required binary platformVersion (UTF8);
+  required binary version (UTF8);
+  optional binary displayVersion (UTF8);
+  required binary vendor (UTF8);
+  required binary xpcomAbi (UTF8);
+}
+
+  required group metadata {
+    required int64 Timestamp;
+    required binary submissionDate (UTF8);
+    optional binary Date (UTF8);
+    required binary normalizedChannel (UTF8);
+    required binary geoCountry (UTF8);
+    required binary geoCity (UTF8);
+    required binary appVersion (UTF8);
+    required binary appBuildId (UTF8);
+  }
+}

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1,0 +1,1074 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "properties": {
+            "activeAddons": {
+              "additionalProperties": {
+                "properties": {
+                  "appDisabled": {
+                    "type": "boolean"
+                  },
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "foreignInstall": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "hasBinaryComponents": {
+                    "type": "boolean"
+                  },
+                  "installDay": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "isSystem": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "integer"
+                  },
+                  "signedState": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "userDisabled": {
+                    "type": [
+                      "boolean",
+                      "integer"
+                    ]
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activeExperiment": {
+              "properties": {
+                "branch": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "activeGMPlugins": {
+              "additionalProperties": {
+                "properties": {
+                  "applyBackgroundUpdates": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activePlugins": {
+              "items": {
+                "properties": {
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "clicktoplay": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "mimeTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": [
+                      "array",
+                      "object"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "type": "integer"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": [
+                "array",
+                "object"
+              ]
+            },
+            "persona": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "properties": {
+                "appDisabled": {
+                  "type": "boolean"
+                },
+                "blocklisted": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "foreignInstall": {
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                },
+                "hasBinaryComponents": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "installDay": {
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "integer"
+                },
+                "updateDay": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "userDisabled": {
+                  "type": "boolean"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "build": {
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            },
+            "applicationName": {
+              "type": "string"
+            },
+            "architecture": {
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "type": "string"
+            },
+            "buildId": {
+              "pattern": "^[0-9]{10}",
+              "type": "string"
+            },
+            "displayVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "hotfixVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platformVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "updaterAvailable": {
+              "type": "boolean"
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "version": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "xpcomAbi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ],
+          "type": "object"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "partner": {
+          "properties": {
+            "distributionId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "type": [
+                "array",
+                "object"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "type": "number"
+            },
+            "firstUseDate": {
+              "type": "number"
+            },
+            "isStubProfile": {
+              "type": "boolean"
+            },
+            "resetDate": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "addonCompatibilityCheckEnabled": {
+              "type": "boolean"
+            },
+            "attribution": {
+              "properties": {
+                "campaign": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "medium": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "blocklistEnabled": {
+              "type": "boolean"
+            },
+            "defaultSearchEngine": {
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "e10sEnabled": {
+              "type": "boolean"
+            },
+            "isDefaultBrowser": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "locale": {
+              "type": "string"
+            },
+            "sandbox": {
+              "properties": {
+                "effectiveContentProcessLevel": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "searchCohort": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "telemetryEnabled": {
+              "type": "boolean"
+            },
+            "update": {
+              "properties": {
+                "autoDownload": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "userPrefs": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "system": {
+          "properties": {
+            "appleModelId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu": {
+              "properties": {
+                "cores": {
+                  "maximum": 2048,
+                  "minimum": 1,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "maximum": 1024,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "extensions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "family": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "l2cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "l3cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "model": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "speedMHz": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "stepping": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "vendor": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "device": {
+              "properties": {
+                "hardware": {
+                  "type": "string"
+                },
+                "isTablet": {
+                  "type": "boolean"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "gfx": {
+              "properties": {
+                "D2DEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "adapters": {
+                  "items": {
+                    "properties": {
+                      "GPUActive": {
+                        "type": "boolean"
+                      },
+                      "RAM": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVersion": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "subsysID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "vendorID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "features": {
+                  "properties": {
+                    "advancedLayers": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "compositor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "d2d": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "d3d11": {
+                      "properties": {
+                        "blacklisted": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "textureSharing": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "warp": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "gpuProcess": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "monitors": {
+                  "items": {
+                    "properties": {
+                      "pseudoDisplay": {
+                        "type": "boolean"
+                      },
+                      "refreshRate": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": "number"
+                      },
+                      "screenHeight": {
+                        "type": "integer"
+                      },
+                      "screenWidth": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": [
+                    "array",
+                    "object"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "hdd": {
+              "properties": {
+                "binary": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "profile": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "system": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "isWow64": {
+              "type": "boolean"
+            },
+            "memoryMB": {
+              "type": "number"
+            },
+            "os": {
+              "properties": {
+                "installYear": {
+                  "type": "number"
+                },
+                "kernelVersion": {
+                  "type": "string"
+                },
+                "locale": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "type": "number"
+                },
+                "version": {
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                },
+                "windowsBuildNumber": {
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "sec": {
+              "properties": {
+                "antispyware": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "antivirus": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "firewall": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "virtualMaxMB": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ]
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "combinedStacks": {
+          "properties": {
+            "memoryMap": {
+              "items": {
+                "items": [
+                  {
+                    "$comment": "// PDB filename, e.g. mozglue.pdb",
+                    "type": "string"
+                  },
+                  {
+                    "$comment": "// DLL Debug ID, e.g. 2403397A44447F1E42C7089B974E2DD48",
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "stacks": {
+              "items": {
+                "$comment": "// Stack object, an array of frames",
+                "items": {
+                  "$comment": "// Frame tuple",
+                  "items": [
+                    {
+                      "$comment": "// Module index",
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "$comment": "// Module offset",
+                      "minimum": 0,
+                      "type": "number"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "errorModules": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "events": {
+          "items": {
+            "properties": {
+              "isStartup": {
+                "type": "boolean"
+              },
+              "modules": {
+                "items": {
+                  "properties": {
+                    "baseAddress": {
+                      "type": "string"
+                    },
+                    "fileVersion": {
+                      "type": "string"
+                    },
+                    "loaderName": {
+                      "type": "string"
+                    },
+                    "moduleName": {
+                      "type": "string"
+                    },
+                    "moduleTrustFlags": {
+                      "minimum": 0,
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "minItems": 1,
+                "required": [
+                  "baseAddress",
+                  "moduleName",
+                  "moduleTrustFlags"
+                ],
+                "type": "array"
+              },
+              "processUptimeMS": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "threadID": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "threadName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "isStartup",
+              "modules"
+            ],
+            "type": "object"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "structVersion": {
+          "maximum": 1,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "errorModules",
+        "events",
+        "structVersion",
+        "combinedStacks"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "untrustedModules"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
+    }
+  },
+  "required": [
+    "payload",
+    "application",
+    "creationDate",
+    "id",
+    "type",
+    "version"
+  ],
+  "title": "untrusted-modules",
+  "type": "object"
+}

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -932,11 +932,17 @@
               "items": {
                 "items": [
                   {
-                    "$comment": "// PDB filename, e.g. mozglue.pdb",
+                    "description": "The filename of the PDB symbol file",
+                    "examples": [
+                      "mozglue.pdb"
+                    ],
                     "type": "string"
                   },
                   {
-                    "$comment": "// DLL Debug ID, e.g. 2403397A44447F1E42C7089B974E2DD48",
+                    "description": "The debug ID of the DLL",
+                    "examples": [
+                      "2403397A44447F1E42C7089B974E2DD48"
+                    ],
                     "type": "string"
                   }
                 ],
@@ -948,17 +954,17 @@
             },
             "stacks": {
               "items": {
-                "$comment": "// Stack object, an array of frames",
+                "description": "Stack object, an array of frames",
                 "items": {
-                  "$comment": "// Frame tuple",
+                  "description": "Stack frame object, a tuple<int,int>",
                   "items": [
                     {
-                      "$comment": "// Module index",
+                      "description": "Module index, an index into the combinedStacks/memoryMap array",
                       "minimum": 0,
                       "type": "number"
                     },
                     {
-                      "$comment": "// Module offset",
+                      "description": "Module offset, the RVA of the program counter for this stack frame.",
                       "minimum": 0,
                       "type": "number"
                     }

--- a/templates/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
+++ b/templates/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
@@ -174,10 +174,10 @@ message untrusted-modules {
         }
       }
     }
-    required group addons {
+    optional group addons {
       optional binary persona (UTF8);
-      required group theme {
-        required binary id (UTF8);
+      optional group theme {
+        optional binary id (UTF8);
         optional boolean blocklisted;
         optional binary description (UTF8);
         optional binary name (UTF8);
@@ -189,44 +189,44 @@ message untrusted-modules {
         optional int64 installDay (UINT_64);
         optional int64 updateDay (UINT_64);
       }
-      required group activeAddons (MAP) {
+      optional group activeAddons (MAP) {
         repeated group key_value {
           required binary key (UTF8);
           required group value {
-            required boolean blocklisted;
-            required binary name (UTF8);
+            optional boolean blocklisted;
+            optional binary name (UTF8);
             optional binary description (UTF8);
-            required boolean appDisabled;
-            required int64 scope;
-            required binary type (UTF8);
-            required boolean hasBinaryComponents;
-            required int64 installDay (UINT_64);
-            required int64 updateDay (UINT_64);
+            optional boolean appDisabled;
+            optional int64 scope;
+            optional binary type (UTF8);
+            optional boolean hasBinaryComponents;
+            optional int64 installDay (UINT_64);
+            optional int64 updateDay (UINT_64);
             optional int64 signedState;
-            required boolean isSystem;
+            optional boolean isSystem;
           }
         }
       }
-      required group activeGMPlugins (MAP) {
+      optional group activeGMPlugins (MAP) {
         repeated group key_value {
           required binary key (UTF8);
           required group value {
-            required binary version (UTF8);
-            required boolean userDisabled;
+            optional binary version (UTF8);
+            optional boolean userDisabled;
           }
         }
       }
-      required group activePlugins (LIST) {
+      optional group activePlugins (LIST) {
         repeated group list {
           required group element {
-            required binary name (UTF8);
-            required binary version (UTF8);
-            required binary description (UTF8);
-            required boolean blocklisted;
-            required boolean disabled;
-            required boolean clicktoplay;
-            required int64 updateDay;
-            required group mimeTypes (LIST) {
+            optional binary name (UTF8);
+            optional binary version (UTF8);
+            optional binary description (UTF8);
+            optional boolean blocklisted;
+            optional boolean disabled;
+            optional boolean clicktoplay;
+            optional int64 updateDay;
+            optional group mimeTypes (LIST) {
               repeated group list {
                 required binary element (UTF8);
               }

--- a/templates/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
+++ b/templates/telemetry/untrusted-modules/untrusted-modules.4.parquetmr.txt
@@ -1,0 +1,302 @@
+message untrusted-modules {
+  optional group environment {
+    optional group profile {
+      optional int64 creationDate;
+      optional int64 resetDate;
+    }
+    required group settings {
+      optional boolean isDefaultBrowser;
+      optional boolean addonCompatibilityCheckEnabled;
+      optional binary locale (UTF8);
+      optional boolean e10sEnabled;
+      optional boolean blocklistEnabled;
+      optional binary defaultSearchEngine (UTF8);
+      optional boolean telemetryEnabled;
+      optional binary e10sCohort (UTF8);
+      optional binary searchCohort (UTF8);
+      optional int64 e10sMultiProcesses;
+      optional group defaultSearchEngineData {
+        optional binary name (UTF8);
+        optional binary loadPath (UTF8);
+        optional binary submissionURL (UTF8);
+        optional binary origin (UTF8);
+      }
+      optional group update {
+        optional boolean autoDownload;
+        optional binary channel (UTF8);
+        optional boolean enabled;
+      }
+      optional group sandbox {
+        optional int64 effectiveContentProcessLevel;
+      }
+    }
+    required group system {
+      optional boolean isWow64;
+      optional int64 memoryMB;
+      optional int64 virtualMaxMB (UINT_64);
+      optional binary appleModelId (UTF8);
+      optional group os {
+        optional binary name (UTF8);
+        optional binary locale (UTF8);
+        optional int64 windowsUBR;
+        optional int64 installYear;
+        optional int64 servicePackMajor;
+        optional int64 windowsBuildNumber;
+        optional int64 servicePackMinor;
+      }
+    }
+    optional group gfx {
+      optional group features {
+        optional group advancedLayers {
+          optional binary status (UTF8);
+        }
+        optional group webrender {
+          optional binary status (UTF8);
+        }
+        optional group wrQualified {
+          optional binary status (UTF8);
+        }
+        optional binary compositor (UTF8);
+        optional group d3d11 {
+          optional binary status (UTF8);
+          optional boolean textureSharing;
+          optional int64 version;
+          optional boolean blacklisted;
+          optional boolean warp;
+        }
+        optional group gpuProcess {
+          optional binary status (UTF8);
+        }
+        optional group d2d {
+          optional binary status (UTF8);
+          optional binary version (UTF8);
+        }
+      }
+      optional boolean DWriteEnabled;
+      optional boolean D2DEnabled;
+      optional binary ContentBackend (UTF8);
+      optional group adapters (LIST) {
+        repeated group list {
+          required group element {
+            optional binary description (UTF8);
+            optional binary vendorID (UTF8);
+            optional binary deviceID (UTF8);
+            optional binary subsysID (UTF8);
+            optional int64 RAM (UINT_64);
+            optional binary driver (UTF8);
+            optional binary driverVersion (UTF8);
+            optional binary driverDate (UTF8);
+            optional boolean GPUActive;
+          }
+        }
+      }
+      optional group monitors (LIST) {
+        repeated group list {
+          required group element {
+            optional int64 refreshRate (UINT_64);
+            optional int64 screenHeight (UINT_64);
+            optional int64 screenWidth (UINT_64);
+            optional boolean pseudoDisplay;
+          }
+        }
+      }
+    }
+    optional group sec {
+      optional group firewall (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+      optional group antispyware (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+      optional group antivirus (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+    }
+    optional group hdd {
+      optional group profile {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+      optional group binary {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+      optional group system {
+        optional binary model (UTF8);
+        optional binary revision (UTF8);
+      }
+    }
+    optional group cpu {
+      optional int64 cores;
+      optional int64 count;
+      optional int64 family (UINT_64);
+      optional int64 l2cacheKB (UINT_64);
+      optional int64 l3cacheKB (UINT_64);
+      optional int64 model (UINT_64);
+      optional int64 speedMHz (UINT_64);
+      optional int64 stepping (UINT_64);
+      optional binary vendor (UTF8);
+      optional group extensions (LIST) {
+        repeated group list {
+          required binary element (UTF8);
+        }
+      }
+    }
+    required group build {
+      required binary applicationId (UTF8);
+      required binary applicationName (UTF8);
+      required binary architecture (UTF8);
+      optional binary architecturesInBinary (UTF8);
+      required binary buildId (UTF8);
+      optional binary hotfixVersion (UTF8);
+      required binary version (UTF8);
+      required binary vendor (UTF8);
+      optional binary displayVersion (UTF8);
+      required binary platformVersion (UTF8);
+      optional boolean updaterAvailable;
+      required binary xpcomAbi (UTF8);
+    }
+    required group partner {
+      optional binary distributionId (UTF8);
+      optional binary distributionVersion (UTF8);
+      optional binary partnerId (UTF8);
+      optional binary distributor (UTF8);
+      optional binary distributorChannel (UTF8);
+      optional group partnerNames (LIST) {
+        repeated group list {
+          optional binary element (UTF8);
+        }
+      }
+    }
+    required group addons {
+      optional binary persona (UTF8);
+      required group theme {
+        required binary id (UTF8);
+        optional boolean blocklisted;
+        optional binary description (UTF8);
+        optional binary name (UTF8);
+        optional boolean userDisabled;
+        optional boolean appDisabled;
+        optional binary version (UTF8);
+        optional int64 scope;
+        optional boolean hasBinaryComponents;
+        optional int64 installDay (UINT_64);
+        optional int64 updateDay (UINT_64);
+      }
+      required group activeAddons (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            required boolean blocklisted;
+            required binary name (UTF8);
+            optional binary description (UTF8);
+            required boolean appDisabled;
+            required int64 scope;
+            required binary type (UTF8);
+            required boolean hasBinaryComponents;
+            required int64 installDay (UINT_64);
+            required int64 updateDay (UINT_64);
+            optional int64 signedState;
+            required boolean isSystem;
+          }
+        }
+      }
+      required group activeGMPlugins (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            required binary version (UTF8);
+            required boolean userDisabled;
+          }
+        }
+      }
+      required group activePlugins (LIST) {
+        repeated group list {
+          required group element {
+            required binary name (UTF8);
+            required binary version (UTF8);
+            required binary description (UTF8);
+            required boolean blocklisted;
+            required boolean disabled;
+            required boolean clicktoplay;
+            required int64 updateDay;
+            required group mimeTypes (LIST) {
+              repeated group list {
+                required binary element (UTF8);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  optional binary clientId (UTF8);
+  required binary creationDate (UTF8);
+  required binary id (UTF8);
+  required binary type (UTF8);
+  required double version;
+  required group payload {
+    required group combinedStacks {
+      required group memoryMap (LIST) {
+        repeated group list {
+          required group element (TUPLE) {
+            required binary moduleName (UTF8);
+            required binary debugId (UTF8);
+          }
+        }
+      }
+      required group stacks (LIST) {
+        repeated group list {
+          required group element (LIST) {
+            repeated group list {
+              required group element (TUPLE) {
+                required int64 moduleIndex;
+                required int64 moduleOffset (UINT_64);
+              }
+            }
+          }
+        }
+      }
+    }
+    required int64 structVersion (UINT_64);
+    required int64 errorModules (UINT_64);
+    required group events (LIST) {
+      repeated group list {
+        required group element {
+          optional int64 processUptimeMS;
+          required boolean isStartup;
+          optional binary threadName (UTF8);
+          optional int64 threadID (UINT_64);
+          required group modules (LIST) {
+            repeated group list {
+              required group element {
+                required binary baseAddress (UTF8);
+                required binary moduleName (UTF8);
+                optional binary fileVersion (UTF8);
+                optional binary loaderName (UTF8);
+                required int64 moduleTrustFlags (UINT_64);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  @TELEMETRY_APPLICATION_1_TXT@
+  required group metadata {
+    required int64 Timestamp;
+    required binary submissionDate (UTF8);
+    optional binary Date (UTF8);
+    required binary normalizedChannel (UTF8);
+    required binary geoCountry (UTF8);
+    required binary geoCity (UTF8);
+    required binary appVersion (UTF8);
+    required binary appBuildId (UTF8);
+  }
+}

--- a/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -17,11 +17,17 @@
                 "maxItems": 2,
                 "items": [
                   {
-                    "$comment": "// PDB filename, e.g. mozglue.pdb",
+                    "description": "The filename of the PDB symbol file",
+                    "examples": [
+                      "mozglue.pdb"
+                    ],
                     "type": "string"
                   },
                   {
-                    "$comment": "// DLL Debug ID, e.g. 2403397A44447F1E42C7089B974E2DD48",
+                    "description": "The debug ID of the DLL",
+                    "examples": [
+                      "2403397A44447F1E42C7089B974E2DD48"
+                    ],
                     "type": "string"
                   }
                 ]
@@ -30,21 +36,21 @@
             "stacks": {
               "type": "array",
               "items": {
-                "$comment": "// Stack object, an array of frames",
+                "description": "Stack object, an array of frames",
                 "type": "array",
                 "items": {
-                  "$comment": "// Frame tuple",
+                  "description": "Stack frame object, a tuple<int,int>",
                   "type": "array",
                   "minItems": 2,
                   "maxItems": 2,
                   "items": [
                     {
-                      "$comment": "// Module index",
+                      "description": "Module index, an index into the combinedStacks/memoryMap array",
                       "type": "number",
                       "minimum": 0
                     },
                     {
-                      "$comment": "// Module offset",
+                      "description": "Module offset, the RVA of the program counter for this stack frame.",
                       "type": "number",
                       "minimum": 0
                     }

--- a/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "untrusted-modules",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "properties": {
+        "combinedStacks": {
+          "type": "object",
+          "properties": {
+            "memoryMap": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                  {
+                    "$comment": "// PDB filename, e.g. mozglue.pdb",
+                    "type": "string"
+                  },
+                  {
+                    "$comment": "// DLL Debug ID, e.g. 2403397A44447F1E42C7089B974E2DD48",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "stacks": {
+              "type": "array",
+              "items": {
+                "$comment": "// Stack object, an array of frames",
+                "type": "array",
+                "items": {
+                  "$comment": "// Frame tuple",
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$comment": "// Module index",
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    {
+                      "$comment": "// Module offset",
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "structVersion": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "errorModules": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "processUptimeMS": {
+                "type": "number",
+                "minimum": 0
+              },
+              "isStartup": {
+                "type": "boolean"
+              },
+              "threadName": {
+                "type": "string"
+              },
+              "threadID": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "modules": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "baseAddress": {
+                      "type": "string"
+                    },
+                    "moduleName": {
+                      "type": "string"
+                    },
+                    "fileVersion": {
+                      "type": "string"
+                    },
+                    "loaderName": {
+                      "type": "string"
+                    },
+                    "moduleTrustFlags": {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  }
+                },
+                "required": [
+                  "baseAddress",
+                  "moduleName",
+                  "moduleTrustFlags"
+                ]
+              }
+            },
+            "required": [
+              "isStartup",
+              "modules"
+            ]
+          }
+        }
+      },
+      "required": [
+        "errorModules",
+        "events",
+        "structVersion",
+        "combinedStacks"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [ "untrustedModules" ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
+    },
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CLIENTID_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_ENVIRONMENT_1_JSON@,
+    @TELEMETRY_ID_1_JSON@
+  },
+  "required": [
+    "payload",
+    "application",
+    "creationDate",
+    "id",
+    "type",
+    "version"
+  ]
+}

--- a/validation/telemetry/untrusted-modules.4.minimal.pass.json
+++ b/validation/telemetry/untrusted-modules.4.minimal.pass.json
@@ -1,0 +1,41 @@
+{
+  "payload": {
+    "combinedStacks": {
+      "memoryMap": [
+      ], 
+      "stacks": [
+      ]
+    }, 
+    "structVersion": 1, 
+    "errorModules": 0, 
+    "events": [
+      {
+        "isStartup": false, 
+        "threadName": "", 
+        "modules": [
+          {
+            "baseAddress": "0x7ffec9ae0000", 
+            "moduleName": "nvinitx.dll", 
+            "moduleTrustFlags": 0
+          }
+        ], 
+        "threadID": 0
+      }
+    ]
+  },
+  "application": {
+    "vendor": "Mozilla", 
+    "name": "Firefox", 
+    "buildId": "20181031083922", 
+    "platformVersion": "65.0a1", 
+    "version": "65.0a1", 
+    "architecture": "x86-64", 
+    "displayVersion": "65.0a1", 
+    "xpcomAbi": "x86_64-msvc", 
+    "channel": "default"
+  }, 
+  "version": 4, 
+  "creationDate": "2018-11-02T12:41:20.160Z", 
+  "type": "untrustedModules", 
+  "id": "066af1e9-eca4-40bb-b691-54ced95257dd"
+}

--- a/validation/telemetry/untrusted-modules.4.moduletrustflags.fail.json
+++ b/validation/telemetry/untrusted-modules.4.moduletrustflags.fail.json
@@ -1,0 +1,59 @@
+{
+  "comment": [
+    "// moduleTrustFlags has been set to an invalid value, which should cause",
+    "// a validation failure."
+  ],
+
+  "payload": {
+    "combinedStacks": {
+      "memoryMap": [
+        [
+          "mozglue.pdb", 
+          "2403397A44447F1E42C7089B974E2DD48"
+        ]
+      ], 
+      "stacks": [
+        [
+          [
+            0, 
+            9760
+          ]
+        ]
+      ]
+    }, 
+    "structVersion": 1, 
+    "errorModules": 0, 
+    "events": [
+      {
+        "processUptimeMS": 825, 
+        "isStartup": false, 
+        "threadName": "", 
+        "modules": [
+          {
+            "baseAddress": "0x7ffec9ae0000", 
+            "moduleName": "nvinitx.dll", 
+            "fileVersion": "23.21.13.9125", 
+            "loaderName": "nvinitx.dll", 
+            "moduleTrustFlags": -1
+          }
+        ], 
+        "threadID": 2592
+      }
+    ]
+  },
+  "application": {
+    "vendor": "Mozilla", 
+    "name": "Firefox", 
+    "buildId": "20181031083922", 
+    "platformVersion": "65.0a1", 
+    "version": "65.0a1", 
+    "architecture": "x86-64", 
+    "displayVersion": "65.0a1", 
+    "xpcomAbi": "x86_64-msvc", 
+    "channel": "default"
+  }, 
+  "version": 4, 
+  "creationDate": "2018-11-02T12:41:20.160Z", 
+  "type": "untrustedModules", 
+  "id": "066af1e9-eca4-40bb-b691-54ced95257dd"
+}

--- a/validation/telemetry/untrusted-modules.4.sample.pass.json
+++ b/validation/telemetry/untrusted-modules.4.sample.pass.json
@@ -1,0 +1,634 @@
+{
+  "clientId": "437cb427-c6bc-4660-9103-43a77edba40e", 
+  "payload": {
+    "combinedStacks": {
+      "memoryMap": [
+        [
+          "mozglue.pdb", 
+          "2403397A44447F1E42C7089B974E2DD48"
+        ], 
+        [
+          "kernelbase.pdb", 
+          "7858D6CE5244CAFF49F36D91B2E488261"
+        ], 
+        [
+          "firefox.pdb", 
+          "487173A5F004CABF955914F000829EB52"
+        ], 
+        [
+          "kernel32.pdb", 
+          "63816243EC704DC091BC31470BAC48A31"
+        ], 
+        [
+          "ntdll.pdb", 
+          "5BADA6763A2DF568BAEAC8F70DA0DF3C1"
+        ], 
+        [
+          "dxgi.pdb", 
+          "E6581162D2C54D453D61C2165A1AEE8C1"
+        ], 
+        [
+          "xul.pdb", 
+          "7095D95BBF6B685F75418BCB0327320610"
+        ]
+      ], 
+      "stacks": [
+        [
+          [
+            0, 
+            9760
+          ], 
+          [
+            0, 
+            19179
+          ], 
+          [
+            1, 
+            207483
+          ], 
+          [
+            2, 
+            272348
+          ], 
+          [
+            2, 
+            6432
+          ], 
+          [
+            2, 
+            4976
+          ], 
+          [
+            2, 
+            4654
+          ], 
+          [
+            2, 
+            277576
+          ], 
+          [
+            3, 
+            77876
+          ], 
+          [
+            4, 
+            463969
+          ]
+        ], 
+        [
+          [
+            0, 
+            9760
+          ], 
+          [
+            0, 
+            19179
+          ], 
+          [
+            1, 
+            207483
+          ], 
+          [
+            5, 
+            360300
+          ], 
+          [
+            5, 
+            43491
+          ], 
+          [
+            5, 
+            75570
+          ], 
+          [
+            5, 
+            74485
+          ], 
+          [
+            5, 
+            76339
+          ], 
+          [
+            5, 
+            51070
+          ], 
+          [
+            5, 
+            40629
+          ], 
+          [
+            5, 
+            40513
+          ], 
+          [
+            6, 
+            35620797
+          ], 
+          [
+            6, 
+            35608159
+          ], 
+          [
+            6, 
+            632143
+          ], 
+          [
+            6, 
+            621858
+          ], 
+          [
+            6, 
+            639004
+          ], 
+          [
+            6, 
+            238017
+          ], 
+          [
+            6, 
+            833610
+          ], 
+          [
+            6, 
+            13124323
+          ], 
+          [
+            6, 
+            13122382
+          ], 
+          [
+            6, 
+            37191522
+          ], 
+          [
+            6, 
+            37195401
+          ], 
+          [
+            6, 
+            37386989
+          ], 
+          [
+            6, 
+            37765383
+          ], 
+          [
+            6, 
+            37284938
+          ], 
+          [
+            6, 
+            15721984
+          ], 
+          [
+            6, 
+            37575746
+          ], 
+          [
+            6, 
+            37575488
+          ], 
+          [
+            6, 
+            37574081
+          ], 
+          [
+            6, 
+            50558908
+          ], 
+          [
+            6, 
+            50557500
+          ], 
+          [
+            6, 
+            50572795
+          ], 
+          [
+            6, 
+            50573627
+          ], 
+          [
+            6, 
+            50688086
+          ], 
+          [
+            6, 
+            50682335
+          ], 
+          [
+            6, 
+            50683809
+          ], 
+          [
+            6, 
+            53065608
+          ], 
+          [
+            6, 
+            53544967
+          ], 
+          [
+            6, 
+            53543404
+          ], 
+          [
+            6, 
+            53535814
+          ], 
+          [
+            6, 
+            69811794
+          ], 
+          [
+            6, 
+            8341295
+          ], 
+          [
+            6, 
+            8346855
+          ], 
+          [
+            6, 
+            58852543
+          ], 
+          [
+            6, 
+            58854547
+          ], 
+          [
+            6, 
+            58803215
+          ], 
+          [
+            6, 
+            58799137
+          ], 
+          [
+            6, 
+            58857719
+          ], 
+          [
+            6, 
+            54631434
+          ], 
+          [
+            6, 
+            54632175
+          ]
+        ]
+      ]
+    }, 
+    "structVersion": 1, 
+    "errorModules": 0, 
+    "events": [
+      {
+        "processUptimeMS": 16, 
+        "isStartup": false, 
+        "threadName": "", 
+        "modules": [
+          {
+            "baseAddress": "0x7ffed38f0000", 
+            "moduleName": "mozglue.dll", 
+            "fileVersion": "65.0.0.6877", 
+            "loaderName": "mozglue.dll", 
+            "moduleTrustFlags": 24
+          }
+        ], 
+        "threadID": 2592
+      }, 
+      {
+        "processUptimeMS": 825, 
+        "isStartup": false, 
+        "threadName": "", 
+        "modules": [
+          {
+            "baseAddress": "0x7ffec9ae0000", 
+            "moduleName": "nvinitx.dll", 
+            "fileVersion": "23.21.13.9125", 
+            "loaderName": "nvinitx.dll", 
+            "moduleTrustFlags": 32
+          }
+        ], 
+        "threadID": 2592
+      }
+    ]
+  }, 
+  "environment": {
+    "profile": {
+      "resetDate": 17614, 
+      "creationDate": 17578
+    }, 
+    "settings": {
+      "isDefaultBrowser": false, 
+      "addonCompatibilityCheckEnabled": true, 
+      "locale": "en-US", 
+      "e10sMultiProcesses": 8, 
+      "defaultSearchEngineData": {
+        "origin": "default", 
+        "loadPath": "[app]/chrome/browser/searchplugins/google.xml", 
+        "submissionURL": "https://www.google.com/search?client=firefox-b&q=", 
+        "name": "Google"
+      }, 
+      "update": {
+        "enabled": true, 
+        "autoDownload": true, 
+        "channel": "default"
+      }, 
+      "e10sEnabled": true, 
+      "sandbox": {
+        "effectiveContentProcessLevel": 5
+      }, 
+      "blocklistEnabled": true, 
+      "userPrefs": {
+        "browser.search.region": "BE", 
+        "browser.cache.disk.capacity": 1048576, 
+        "browser.search.widget.inNavBar": false
+      }, 
+      "defaultSearchEngine": "google", 
+      "searchCohort": "nov17-1", 
+      "telemetryEnabled": true
+    }, 
+    "system": {
+      "gfx": {
+        "features": {
+          "advancedLayers": {
+            "status": "available"
+          }, 
+          "webrender": {
+            "status": "blocked"
+          }, 
+          "wrQualified": {
+            "status": "blocked"
+          }, 
+          "compositor": "d3d11", 
+          "d3d11": {
+            "status": "available", 
+            "textureSharing": true, 
+            "version": 45312, 
+            "blacklisted": false, 
+            "warp": false
+          }, 
+          "gpuProcess": {
+            "status": "available"
+          }, 
+          "d2d": {
+            "status": "available", 
+            "version": "1.1"
+          }
+        }, 
+        "DWriteEnabled": true, 
+        "D2DEnabled": true, 
+        "ContentBackend": "Skia", 
+        "adapters": [
+          {
+            "vendorID": "0x8086", 
+            "driverVersion": "21.20.16.4574", 
+            "driverDate": "12-23-2016", 
+            "description": "Intel(R) HD Graphics 630", 
+            "GPUActive": true, 
+            "RAM": null, 
+            "driver": "igdumdim64 igd10iumd64 igd10iumd64 igd12umd64 igdumdim32 igd10iumd32 igd10iumd32 igd12umd32", 
+            "deviceID": "0x591b", 
+            "subsysID": "07be1028"
+          }, 
+          {
+            "vendorID": "0x10de", 
+            "driverVersion": "23.21.13.9125", 
+            "driverDate": "3-16-2018", 
+            "description": "NVIDIA GeForce GTX 1050", 
+            "GPUActive": false, 
+            "RAM": 4096, 
+            "driver": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumdx.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumdx.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumdx.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumdx.dll C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumd.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumd.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumd.dll,C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\nvdm.inf_amd64_2c7c773e20d8bcfa\\nvldumd.dll", 
+            "deviceID": "0x1c8d", 
+            "subsysID": "07be1028"
+          }
+        ], 
+        "monitors": [
+          {
+            "refreshRate": 60, 
+            "screenHeight": 1080, 
+            "screenWidth": 1920, 
+            "pseudoDisplay": false
+          }, 
+          {
+            "refreshRate": 59, 
+            "screenHeight": 1080, 
+            "screenWidth": 1920, 
+            "pseudoDisplay": false
+          }
+        ]
+      }, 
+      "isWow64": false, 
+      "memoryMB": 32620, 
+      "sec": {
+        "firewall": [
+          "Windows Firewall"
+        ], 
+        "antispyware": [
+          "Windows Defender Antivirus"
+        ], 
+        "antivirus": [
+          "Windows Defender Antivirus"
+        ]
+      }, 
+      "hdd": {
+        "profile": {
+          "model": "NVMe THNSN51T02DUK NV", 
+          "revision": "5KDA"
+        }, 
+        "binary": {
+          "model": "NVMe THNSN51T02DUK NV", 
+          "revision": "5KDA"
+        }, 
+        "system": {
+          "model": "NVMe THNSN51T02DUK NV", 
+          "revision": "5KDA"
+        }
+      }, 
+      "virtualMaxMB": 134217728, 
+      "appleModelId": null, 
+      "os": {
+        "name": "Windows_NT", 
+        "windowsUBR": 345, 
+        "locale": "en-US", 
+        "installYear": 2018, 
+        "version": "10.0", 
+        "servicePackMajor": 0, 
+        "windowsBuildNumber": 17134, 
+        "servicePackMinor": 0
+      }, 
+      "cpu": {
+        "count": 8, 
+        "l3cacheKB": 6144, 
+        "vendor": "GenuineIntel", 
+        "family": 6, 
+        "extensions": [
+          "hasMMX", 
+          "hasSSE", 
+          "hasSSE2", 
+          "hasSSE3", 
+          "hasSSSE3", 
+          "hasSSE4_1", 
+          "hasSSE4_2", 
+          "hasAVX", 
+          "hasAVX2", 
+          "hasAES"
+        ], 
+        "stepping": 9, 
+        "cores": 4, 
+        "model": 158, 
+        "speedMHz": 2808, 
+        "l2cacheKB": 256
+      }
+    }, 
+    "experiments": {
+      "searchCohort": {
+        "branch": "nov17-1"
+      }
+    }, 
+    "build": {
+      "applicationName": "Firefox", 
+      "vendor": "Mozilla", 
+      "buildId": "20181031083922", 
+      "updaterAvailable": true, 
+      "platformVersion": "65.0a1", 
+      "version": "65.0a1", 
+      "architecture": "x86-64", 
+      "displayVersion": "65.0a1", 
+      "xpcomAbi": "x86_64-msvc", 
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
+    }, 
+    "partner": {
+      "distributionId": null, 
+      "distributorChannel": null, 
+      "partnerId": null, 
+      "distributor": null, 
+      "distributionVersion": null, 
+      "partnerNames": []
+    }, 
+    "addons": {
+      "activePlugins": [
+        {
+          "mimeTypes": [
+            "text/there.is.only.blocklist"
+          ], 
+          "name": "dummy", 
+          "disabled": true, 
+          "version": "0.1", 
+          "clicktoplay": false, 
+          "blocklisted": false, 
+          "updateDay": 17837, 
+          "description": "Blocklist unavailable"
+        }
+      ], 
+      "theme": {
+        "description": "The default theme.", 
+        "foreignInstall": false, 
+        "userDisabled": false, 
+        "appDisabled": false, 
+        "version": "", 
+        "blocklisted": false, 
+        "hasBinaryComponents": false, 
+        "scope": 1, 
+        "updateDay": 0, 
+        "installDay": 0, 
+        "id": "default-theme@mozilla.org", 
+        "name": "Default"
+      }, 
+      "activeAddons": {
+        "screenshots@mozilla.org": {
+          "description": "Take clips and screenshots from the Web and save them temporarily or permanently.", 
+          "foreignInstall": false, 
+          "userDisabled": false, 
+          "installDay": 17612, 
+          "isWebExtension": true, 
+          "appDisabled": false, 
+          "version": "35.0.0", 
+          "blocklisted": false, 
+          "hasBinaryComponents": false, 
+          "scope": 1, 
+          "updateDay": 17834, 
+          "isSystem": true, 
+          "type": "extension", 
+          "multiprocessCompatible": true, 
+          "name": "Firefox Screenshots"
+        }, 
+        "formautofill@mozilla.org": {
+          "description": null, 
+          "foreignInstall": false, 
+          "userDisabled": false, 
+          "installDay": 17614, 
+          "isWebExtension": true, 
+          "appDisabled": false, 
+          "version": "1.0", 
+          "blocklisted": false, 
+          "hasBinaryComponents": false, 
+          "scope": 1, 
+          "updateDay": 17837, 
+          "isSystem": true, 
+          "type": "extension", 
+          "multiprocessCompatible": true, 
+          "name": "Form Autofill"
+        }, 
+        "webcompat-reporter@mozilla.org": {
+          "description": "Report site compatibility issues on webcompat.com", 
+          "foreignInstall": false, 
+          "userDisabled": false, 
+          "installDay": 17617, 
+          "isWebExtension": true, 
+          "appDisabled": false, 
+          "version": "1.1.0", 
+          "blocklisted": false, 
+          "hasBinaryComponents": false, 
+          "scope": 1, 
+          "updateDay": 17837, 
+          "isSystem": true, 
+          "type": "extension", 
+          "multiprocessCompatible": true, 
+          "name": "WebCompat Reporter"
+        }, 
+        "webcompat@mozilla.org": {
+          "description": "Urgent post-release fixes for web compatibility.", 
+          "foreignInstall": false, 
+          "userDisabled": false, 
+          "installDay": 17612, 
+          "isWebExtension": true, 
+          "appDisabled": false, 
+          "version": "3.0.0", 
+          "blocklisted": false, 
+          "hasBinaryComponents": false, 
+          "scope": 1, 
+          "updateDay": 17834, 
+          "isSystem": true, 
+          "type": "extension", 
+          "multiprocessCompatible": true, 
+          "name": "Web Compat"
+        }
+      }, 
+      "activeGMPlugins": {
+        "dummy-gmp": {
+          "version": "0.1", 
+          "applyBackgroundUpdates": 1, 
+          "userDisabled": false
+        }
+      }, 
+      "persona": "default-theme@mozilla.org"
+    }
+  }, 
+  "application": {
+    "vendor": "Mozilla", 
+    "name": "Firefox", 
+    "buildId": "20181031083922", 
+    "platformVersion": "65.0a1", 
+    "version": "65.0a1", 
+    "architecture": "x86-64", 
+    "displayVersion": "65.0a1", 
+    "xpcomAbi": "x86_64-msvc", 
+    "channel": "default"
+  }, 
+  "version": 4, 
+  "creationDate": "2018-11-02T12:41:20.160Z", 
+  "type": "untrustedModules", 
+  "id": "066af1e9-eca4-40bb-b691-54ced95257dd"
+}

--- a/validation/telemetry/untrusted-modules.4.stackframe.fail.json
+++ b/validation/telemetry/untrusted-modules.4.stackframe.fail.json
@@ -1,0 +1,54 @@
+{
+  "comment": [
+    "// combinedStacks/stacks should be an array of tuple<number, number>.",
+    "// This test adds an extra tuple member and should fail."
+  ],
+
+  "payload": {
+    "combinedStacks": {
+      "memoryMap": [
+        [
+          "mozglue.pdb",
+          "2403397A44447F1E42C7089B974E2DD48"
+        ]
+      ], 
+      "stacks": [
+        [
+          [1, 2],
+          [1, 2, 3]
+        ]
+      ]
+    }, 
+    "structVersion": 1, 
+    "errorModules": 0, 
+    "events": [
+      {
+        "isStartup": false, 
+        "threadName": "", 
+        "modules": [
+          {
+            "baseAddress": "0x7ffec9ae0000", 
+            "moduleName": "nvinitx.dll", 
+            "moduleTrustFlags": 0
+          }
+        ], 
+        "threadID": 0
+      }
+    ]
+  },
+  "application": {
+    "vendor": "Mozilla", 
+    "name": "Firefox", 
+    "buildId": "20181031083922", 
+    "platformVersion": "65.0a1", 
+    "version": "65.0a1", 
+    "architecture": "x86-64", 
+    "displayVersion": "65.0a1", 
+    "xpcomAbi": "x86_64-msvc", 
+    "channel": "default"
+  }, 
+  "version": 4, 
+  "creationDate": "2018-11-02T12:41:20.160Z", 
+  "type": "untrustedModules", 
+  "id": "066af1e9-eca4-40bb-b691-54ced95257dd"
+}


### PR DESCRIPTION
This adds the necessary validation and ingestion schemas for the new "Untrusted Modules" ping introduced in Bug 1435827, along with basic test payloads.

The schema includes the telemetry ping environment block, which is essentially a port of /templates/include/telemetry/environment.1.schema.json, minus the following structures because of the difficulty in representing in parquet:
  - userPrefs
  - activeAddons/userDisabled
  - activeAddons/foreignInstall
  - activeGMPlugins/applyBackgroundUpdates
  - theme/foreignInstall
  - activeAddons/version
  - system/os/version
  - experiments