### PR TITLE
Add proper typing for keyedHistograms

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1064,7 +1064,8 @@
                 }
               },
               "type": "object"
-            }
+            },
+            "type": "object"
           },
           "type": "object"
         },
@@ -1327,7 +1328,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },
@@ -1604,7 +1606,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },
@@ -1881,7 +1884,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },

--- a/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -129,7 +129,8 @@
                   }
                 },
                 "type": "object"
-              }
+              },
+              "type": "object"
             },
             "type": "object"
           },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1064,7 +1064,8 @@
                 }
               },
               "type": "object"
-            }
+            },
+            "type": "object"
           },
           "type": "object"
         },
@@ -1327,7 +1328,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },
@@ -1604,7 +1606,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },
@@ -1881,7 +1884,8 @@
                         }
                       },
                       "type": "object"
-                    }
+                    },
+                    "type": "object"
                   },
                   "type": "object"
                 },

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -52,6 +52,7 @@
     "keyedHistograms": {
       "type": "object",
       "additionalProperties": {
+        "type": "object",
         "additionalProperties": {
           @TELEMETRY_HISTOGRAM_1_JSON@
         }

--- a/templates/include/telemetry/metricsData.1.schema.json
+++ b/templates/include/telemetry/metricsData.1.schema.json
@@ -12,6 +12,7 @@
 "keyedHistograms": {
   "type": "object",
   "additionalProperties": {
+    "type": "object",
     "additionalProperties": {
       @TELEMETRY_HISTOGRAM_1_JSON@
     }


### PR DESCRIPTION
Keyed histograms are represented as doubly-nested maps. The first level of nested is missing the `"type": "object"` field, which was breaking a script. 