### PR TITLE
1507788: Support dots in category part of dotted notation

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -10,7 +10,7 @@
       "type": "object"
     },
     "dot_separated_short_id": {
-      "pattern": "^[a-z_][a-z0-9_]{0,29}\\.[a-z_][a-z0-9_]{0,29}$",
+      "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
       "type": "string"
     },
     "histogram": {

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -10,6 +10,7 @@
       "type": "object"
     },
     "dot_separated_short_id": {
+      "maxLength": 61,
       "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
       "type": "string"
     },

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -26,7 +26,7 @@
     },
     "dot_separated_short_id": {
       "type": "string",
-      "pattern": "^[a-z_][a-z0-9_]{0,29}\\.[a-z_][a-z0-9_]{0,29}$"
+      "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$"
     },
     "base": {
       "type": "object",

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -26,7 +26,8 @@
     },
     "dot_separated_short_id": {
       "type": "string",
-      "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$"
+      "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+      "maxLength": 61
     },
     "base": {
       "type": "object",

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -14,7 +14,7 @@
       "examples.boolean_example": true
     },
     "string": {
-      "examples.string_example": "\u82f1\u6f22\u5b57\u5178"
+      "examples.subcategory.string_example": "\u82f1\u6f22\u5b57\u5178"
     },
     "number": {
       "examples.number_example": 5


### PR DESCRIPTION
Given [1507788](https://bugzilla.mozilla.org/show_bug.cgi?id=1507788), we need to support dots within the metric category name.  Therefore the `category.name` notation used to identify metrics can now have multiple dots.  This broadens the regex used to validate the metric name to support that.