### PR TITLE
Allow -1 value for untrustedModules / moduleIndex field (#226)

### DIFF
--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -959,8 +959,8 @@
                   "description": "Stack frame object, a tuple<int,int>",
                   "items": [
                     {
-                      "description": "Module index, an index into the combinedStacks/memoryMap array",
-                      "minimum": 0,
+                      "description": "Module index, an index into the combinedStacks/memoryMap array, or -1 if not applicable",
+                      "minimum": -1,
                       "type": "number"
                     },
                     {

--- a/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -45,9 +45,9 @@
                   "maxItems": 2,
                   "items": [
                     {
-                      "description": "Module index, an index into the combinedStacks/memoryMap array",
+                      "description": "Module index, an index into the combinedStacks/memoryMap array, or -1 if not applicable",
                       "type": "number",
-                      "minimum": 0
+                      "minimum": -1
                     },
                     {
                       "description": "Module offset, the RVA of the program counter for this stack frame.",

--- a/validation/telemetry/untrustedModules.4.unknownmodule.pass.json
+++ b/validation/telemetry/untrustedModules.4.unknownmodule.pass.json
@@ -1,0 +1,64 @@
+{
+  "payload": {
+    "combinedStacks": {
+      "memoryMap": [
+        [
+          "mozglue.pdb",
+            "AA23EBDA96F2433BFAB2CB85597C378F1"
+        ],
+        [
+          "mbae64.pdb",
+          "5DA02C492F9F412984B4384EF5B3CFDC1"
+        ]
+      ],
+      "stacks": [
+        [
+          [
+            0,
+            21035
+          ],
+          [
+            1,
+            13385
+          ],
+          [
+            -1,
+            18446744073709552000
+          ]
+        ],
+        []
+      ]
+    },
+    "structVersion": 1,
+    "errorModules": 0,
+    "events": [
+      {
+        "isStartup": false,
+        "threadName": "",
+        "modules": [
+          {
+            "baseAddress": "0x7ffec9ae0000",
+            "moduleName": "nvinitx.dll",
+            "moduleTrustFlags": 0
+          }
+        ],
+        "threadID": 0
+      }
+    ]
+  },
+  "application": {
+    "vendor": "Mozilla",
+    "name": "Firefox",
+    "buildId": "20181031083922",
+    "platformVersion": "65.0a1",
+    "version": "65.0a1",
+    "architecture": "x86-64",
+    "displayVersion": "65.0a1",
+    "xpcomAbi": "x86_64-msvc",
+    "channel": "default"
+  },
+  "version": 4,
+  "creationDate": "2018-11-02T12:41:20.160Z",
+  "type": "untrustedModules",
+  "id": "066af1e9-eca4-40bb-b691-54ced95257dd"
+}


### PR DESCRIPTION
The previous schema specified 0 as the minimum value for this field, but -1
should also pass validation.

A value of -1 indicates that the address does not fall in any known module.

See also:
  * Documentation: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/untrusted-modules-ping.html#payload-combinedstacks
  * The value of -1 is generated here: https://searchfox.org/mozilla-central/source/toolkit/components/telemetry/other/CombinedStacks.cpp#206
  * And the underlying logic for this value comes from: and https://searchfox.org/mozilla-central/rev/e22c0d152060f4f8d4ca8904094f15f65a1b6f93/toolkit/components/telemetry/other/ProcessedStack.cpp#141