### PR TITLE
WIP: Add activity-stream impression-stats schema

### DIFF
--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -5,15 +5,15 @@
       "type": "string"
     },
     "block": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
     "click": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
-    "client_region": {
-      "type": "string"
-    },
     "impression_id": {
+      "description": "A UUID representing this impression",
       "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
       "type": "string"
     },
@@ -30,6 +30,7 @@
       "type": "string"
     },
     "pocket": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
     "profile_creation_date": {
@@ -41,12 +42,8 @@
     "release_channel": {
       "type": "string"
     },
-    "sample_id": {
-      "maximum": 99,
-      "minimum": 0,
-      "type": "integer"
-    },
     "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
     },
     "source": {

--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "action": {
+      "pattern": "^activity_stream_impression_stats$",
+      "type": "string"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "block": {
+      "type": "integer"
+    },
+    "click": {
+      "type": "integer"
+    },
+    "client_id": {
+      "pattern": "^n/a$",
+      "type": "string"
+    },
+    "impression_id": {
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "page": {
+      "enum": [
+        "about:newtab",
+        "about:home",
+        "about:welcome",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "pocket": {
+      "type": "integer"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "region": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "session_id": {
+      "pattern": "^n/a$",
+      "type": "string"
+    },
+    "source": {
+      "type": "string"
+    },
+    "tiles": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "pos": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "topic": {
+      "type": "string"
+    },
+    "user_prefs": {
+      "type": "integer"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "addon_version",
+    "locale",
+    "source",
+    "page",
+    "user_prefs",
+    "tiles"
+  ],
+  "title": "impression-stats",
+  "type": "object"
+}

--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -1,10 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
-    "action": {
-      "pattern": "^activity_stream_impression_stats$",
-      "type": "string"
-    },
     "addon_version": {
       "type": "string"
     },
@@ -14,8 +10,7 @@
     "click": {
       "type": "integer"
     },
-    "client_id": {
-      "pattern": "^n/a$",
+    "client_region": {
       "type": "string"
     },
     "impression_id": {
@@ -46,8 +41,12 @@
     "release_channel": {
       "type": "string"
     },
-    "session_id": {
-      "pattern": "^n/a$",
+    "sample_id": {
+      "maximum": 99,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "shield_id": {
       "type": "string"
     },
     "source": {
@@ -69,9 +68,6 @@
         "type": "object"
       },
       "type": "array"
-    },
-    "topic": {
-      "type": "string"
     },
     "user_prefs": {
       "type": "integer"

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -4,16 +4,13 @@
   "title": "impression-stats",
   "properties": {
     "impression_id": {
+      "description": "A UUID representing this impression",
       "type": "string",
       "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
     },
     "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
-    },
-    "sample_id": {
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 99
     },
     "addon_version": {
       "type": "string"
@@ -37,9 +34,6 @@
     "region": {
       "type": "string"
     },
-    "client_region": {
-      "type": "string"
-    },
     "profile_creation_date": {
       "type": "integer"
     },
@@ -47,12 +41,15 @@
       "type": "integer"
     },
     "click": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
     "block": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
     "pocket": {
+      "description": "A 0-based index to record which tile in the 'tiles' list the user just interacted with",
       "type": "integer"
     },
     "tiles": {

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -3,21 +3,17 @@
   "type": "object",
   "title": "impression-stats",
   "properties": {
-    "action": {
-      "type": "string",
-      "pattern": "^activity_stream_impression_stats$"
-    },
-    "client_id": {
-      "type": "string",
-      "pattern": "^n/a$"
-    },
-    "session_id": {
-      "type": "string",
-      "pattern": "^n/a$"
-    },
     "impression_id": {
       "type": "string",
       "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    },
+    "shield_id": {
+      "type": "string"
+    },
+    "sample_id": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 99
     },
     "addon_version": {
       "type": "string"
@@ -31,9 +27,6 @@
     "locale": {
       "type": "string"
     },
-    "topic": {
-      "type": "string"
-    },
     "source": {
       "type": "string"
     },
@@ -42,6 +35,9 @@
       "enum": [ "about:newtab", "about:home", "about:welcome", "unknown" ]
     },
     "region": {
+      "type": "string"
+    },
+    "client_region": {
       "type": "string"
     },
     "profile_creation_date": {

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "impression-stats",
+  "properties": {
+    "action": {
+      "type": "string",
+      "pattern": "^activity_stream_impression_stats$"
+    },
+    "client_id": {
+      "type": "string",
+      "pattern": "^n/a$"
+    },
+    "session_id": {
+      "type": "string",
+      "pattern": "^n/a$"
+    },
+    "impression_id": {
+      "type": "string",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "topic": {
+      "type": "string"
+    },
+    "source": {
+      "type": "string"
+    },
+    "page": {
+      "type": "string",
+      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown" ]
+    },
+    "region": {
+      "type": "string"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "user_prefs": {
+      "type": "integer"
+    },
+    "click": {
+      "type": "integer"
+    },
+    "block": {
+      "type": "integer"
+    },
+    "pocket": {
+      "type": "integer"
+    },
+    "tiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "pos": {
+            "type": "integer"
+          }
+        },
+        "required": [ "id" ]
+      }
+    }
+  },
+  "required": [
+    "impression_id",
+    "addon_version",
+    "locale",
+    "source",
+    "page",
+    "user_prefs",
+    "tiles"
+  ]
+}

--- a/validation/activity-stream/impression-stats.1.sample.pass.json
+++ b/validation/activity-stream/impression-stats.1.sample.pass.json
@@ -1,0 +1,23 @@
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "locale": "en-US",
+  "topic": "activity-stream",
+  "version": "65.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "user_prefs": 63,
+  "page": "about:newtab",
+  "source": "TOP_STORIES",
+  "click": 0,
+  "tiles": [
+    {
+      "id": 30001,
+      "pos": 0
+    }
+  ],
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "profile_creation_date": 17817,
+  "region": "US"
+}


### PR DESCRIPTION
Implements a schema matching the existing ping-centre payloads defined in
https://github.com/mozilla/activity-stream/blob/master/docs/v2-system-addon/data_events.md#top-story-pings

Should allow double-publishing of payloads via ping-centre and via telemetry.