### PR TITLE
Fix empty integration reports by updating edge-validator image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   edge-validator:
     docker:
-      - image: mozilla/edge-validator:1.3
+      - image: mozilla/edge-validator:v1.3.1
 
 jobs:
   test:


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
