### PR TITLE
Bug 1518490: Add pipeline schemas for 2 new timing fields in untrusted modules ping

### DIFF
--- a/schemas/telemetry/untrustedModules/untrustedModules.4.parquetmr.txt
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.parquetmr.txt
@@ -266,6 +266,7 @@ message untrusted-modules {
     }
     required int64 structVersion;
     required int64 errorModules;
+    optional double xulLoadDurationMS;
     required group events (LIST) {
       repeated group list {
         required group element {
@@ -280,6 +281,7 @@ message untrusted-modules {
                 required binary moduleName (UTF8);
                 optional binary fileVersion (UTF8);
                 optional binary loaderName (UTF8);
+                optional double loadDurationMS;
                 required int64 moduleTrustFlags;
               }
             }

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -1006,6 +1006,7 @@
                       "type": "string"
                     },
                     "loadDurationMS": {
+                      "minimum": 0,
                       "type": "number"
                     },
                     "loaderName": {
@@ -1056,6 +1057,7 @@
           "type": "integer"
         },
         "xulLoadDurationMS": {
+          "minimum": 0,
           "type": "number"
         }
       },

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -1005,6 +1005,9 @@
                     "fileVersion": {
                       "type": "string"
                     },
+                    "loadDurationMS": {
+                      "type": "number"
+                    },
                     "loaderName": {
                       "type": "string"
                     },
@@ -1051,6 +1054,9 @@
           "maximum": 1,
           "minimum": 1,
           "type": "integer"
+        },
+        "xulLoadDurationMS": {
+          "type": "number"
         }
       },
       "required": [

--- a/templates/telemetry/untrustedModules/untrustedModules.4.parquetmr.txt
+++ b/templates/telemetry/untrustedModules/untrustedModules.4.parquetmr.txt
@@ -30,6 +30,7 @@ message untrusted-modules {
     }
     required int64 structVersion;
     required int64 errorModules;
+    optional double xulLoadDurationMS;
     required group events (LIST) {
       repeated group list {
         required group element {
@@ -44,6 +45,7 @@ message untrusted-modules {
                 required binary moduleName (UTF8);
                 optional binary fileVersion (UTF8);
                 optional binary loaderName (UTF8);
+                optional double loadDurationMS;
                 required int64 moduleTrustFlags;
               }
             }

--- a/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -70,7 +70,8 @@
           "minimum": 0
         },
         "xulLoadDurationMS": {
-          "type": "number"
+          "type": "number",
+          "minimum": 0
         },
         "events": {
           "type": "array",
@@ -115,7 +116,8 @@
                       "minimum": 0
                     },
                     "loadDurationMS": {
-                      "type": "number"
+                      "type": "number",
+                      "minimum": 0
                     }
                   }
                 },

--- a/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/templates/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -69,6 +69,9 @@
           "type": "integer",
           "minimum": 0
         },
+        "xulLoadDurationMS": {
+          "type": "number"
+        },
         "events": {
           "type": "array",
           "minItems": 1,
@@ -110,6 +113,9 @@
                     "moduleTrustFlags": {
                       "type": "number",
                       "minimum": 0
+                    },
+                    "loadDurationMS": {
+                      "type": "number"
                     }
                   }
                 },

--- a/validation/telemetry/untrustedModules.4.sample.pass.json
+++ b/validation/telemetry/untrustedModules.4.sample.pass.json
@@ -280,6 +280,7 @@
       ]
     }, 
     "structVersion": 1, 
+    "xulLoadDurationMS": 44.987654321,
     "errorModules": 0, 
     "events": [
       {
@@ -301,6 +302,7 @@
         "processUptimeMS": 825, 
         "isStartup": false, 
         "threadName": "", 
+        "loadDurationMS": 0.0123456,
         "modules": [
           {
             "baseAddress": "0x7ffec9ae0000", 


### PR DESCRIPTION
This modifies the untrusted modules ping Parquet and JSON schemas to add 2 new
fields:
- "xulLoadDurationMS" (optional, number) at the payload root
- "loadDurationMS" (optional, number) per module object

And adds these fields to validation schema: untrustedModules.4.sample.pass.json

These fields are marked optional in order to be compatible with the previous
schema.

The code that generates these fields landed in
https://hg.mozilla.org/mozilla-central/rev/1b1fe5815dff

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
