### PR TITLE
Bug 1502921 - Add new 'intl' fields to environment data schema

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -443,6 +443,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -447,6 +447,53 @@
             "e10sEnabled": {
               "type": "boolean"
             },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "isDefaultBrowser": {
               "type": [
                 "boolean",

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -379,13 +379,13 @@
               }
             },
             "systemLocales": {
-              "type": "array",
+              "type": [ "array", "null" ],
               "items": {
                 "type": "string"
               }
             },
             "regionalPrefsLocales": {
-              "type": "array",
+              "type": [ "array", "null" ],
               "items": {
                 "type": "string"
               }

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -357,6 +357,47 @@
         "e10sCohort": {
           "type": "string"
         },
+        "intl": {
+          "type": "object",
+          "properties": {
+            "requestedLocales": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "availableLocales": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "appLocales": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "systemLocales": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "regionalPrefsLocales": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "acceptLanguages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "locale": {
           "type": "string"
         },

--- a/validation/telemetry/main.4.intl_alldata.pass.json
+++ b/validation/telemetry/main.4.intl_alldata.pass.json
@@ -1,0 +1,42 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {
+      "intl": {
+        "requestedLocales": ["it"],
+        "availableLocales": ["it", "en-US"],
+        "appLocales": ["it", "en-US"],
+        "systemLocales": ["it-IT", "en-IT"],
+        "regionalPrefsLocales": ["it-IT", "en-IT"],
+        "acceptLanguages": ["it-IT", "it", "en-US", "en"]
+      }
+    },
+    "system": {}
+  },
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4
+}

--- a/validation/telemetry/main.4.intl_nosection.pass.json
+++ b/validation/telemetry/main.4.intl_nosection.pass.json
@@ -1,0 +1,33 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {},
+    "system": {}
+  },
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4
+}

--- a/validation/telemetry/main.4.intl_null.fail.json
+++ b/validation/telemetry/main.4.intl_null.fail.json
@@ -1,0 +1,42 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {
+      "intl": {
+        "requestedLocales": null,
+        "availableLocales": null,
+        "appLocales": null,
+        "systemLocales": ["it-IT", "en-IT"],
+        "regionalPrefsLocales": ["it-IT", "en-IT"],
+        "acceptLanguages": null
+      }
+    },
+    "system": {}
+  },
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4
+}

--- a/validation/telemetry/main.4.intl_null.pass.json
+++ b/validation/telemetry/main.4.intl_null.pass.json
@@ -1,0 +1,42 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {
+      "intl": {
+        "requestedLocales": ["it"],
+        "availableLocales": ["it", "en-US"],
+        "appLocales": ["it", "en-US"],
+        "systemLocales": null,
+        "regionalPrefsLocales": null,
+        "acceptLanguages": ["it-IT", "it", "en-US", "en"]
+      }
+    },
+    "system": {}
+  },
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4
+}


### PR DESCRIPTION
CC @mstriemer

Bug 1502921 added a few field to the Environment ping. Per IRC discussion, we need this data to be validated in order to add it to datasets in STMO.

Landing in m-c (Firefox 66): https://hg.mozilla.org/mozilla-central/rev/de6426e0f491