### PR TITLE
Remove "object" type for monitors

### DIFF
--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -509,7 +509,7 @@
               }
             },
             "monitors": {
-              "type": [ "array", "object" ],
+              "type": [ "array" ],
               "items": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Keeping the two types makes the type of this field be "string" in BQ, which is not ideal. We'll need to thoroughly check that this doesn't break the schema.

I will be making changes to other parts as well (so they are more easily queryable), if you'd like you can hold off on reviewing until they are all in.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
