### PR TITLE
Bug 1524291 Add certSubject to modules ping schemas

### DIFF
--- a/schemas/telemetry/modules/modules.4.parquetmr.txt
+++ b/schemas/telemetry/modules/modules.4.parquetmr.txt
@@ -13,6 +13,7 @@ message modules {
           optional binary debugName (UTF8);
           optional binary version (UTF8);
           optional binary debugID (UTF8);
+          optional binary certSubject (UTF8);
         }
       }
     }

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -935,6 +935,12 @@
         "modules": {
           "items": {
             "properties": {
+              "certSubject": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "debugID": {
                 "type": [
                   "string",

--- a/templates/telemetry/modules/modules.4.parquetmr.txt
+++ b/templates/telemetry/modules/modules.4.parquetmr.txt
@@ -13,6 +13,7 @@ message modules {
           optional binary debugName (UTF8);
           optional binary version (UTF8);
           optional binary debugID (UTF8);
+          optional binary certSubject (UTF8);
         }
       }
     }

--- a/templates/telemetry/modules/modules.4.schema.json
+++ b/templates/telemetry/modules/modules.4.schema.json
@@ -32,6 +32,9 @@
               },
               "debugID": {
                 "type": [ "string", "null" ]
+              },
+              "certSubject": {
+                "type": [ "string", "null" ]
               }
             }
           }

--- a/validation/telemetry/modules.4.windows.pass.json
+++ b/validation/telemetry/modules.4.windows.pass.json
@@ -21,13 +21,15 @@
         "name": "firefox.exe",
         "debugName": "firefox.pdb",
         "debugID": "3046805AB5E34628BC9B5041DF253A02C",
-        "version": "53.0.0.6228"
+        "version": "53.0.0.6228",
+        "certSubject": "Mozilla Corporation"
       },
       {
         "name": "ntdll.dll",
         "debugName": "wntdll.pdb",
         "debugID": "9D5EBB427B3449C0BA160009A90706251",
-        "version": "10.0.14393.479"
+        "version": "10.0.14393.479",
+        "certSubject": "Microsoft Windows"
       },
       {
         "name": "KERNEL32.DLL",


### PR DESCRIPTION
This adds the additional optional "certSubject" field to the modules ping
schemas, and updates the Windows validation test accordingly.

The "certSubject" field was already present in the payload sent from clients,
but it was not available in redash. This patch aims to correct that.

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
