### PR TITLE
Remove extraneous newline

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -2,7 +2,7 @@
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "properties": {
     "$schema": {
       "enum": [

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Ping transport",
-  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK",
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "type": "object",
   "properties": {


### PR DESCRIPTION
This just removes an extraneous newline in a description (that I think is an artifact of the original version of this schema being written in YAML).

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
