### PR TITLE
[glean] Don't allow additionalProperties in ping_info

### DIFF
--- a/schemas/glean/baseline/baseline.2.schema.json
+++ b/schemas/glean/baseline/baseline.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/glean/events/events.2.schema.json
+++ b/schemas/glean/events/events.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/glean/metrics/metrics.2.schema.json
+++ b/schemas/glean/metrics/metrics.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-reference-browser/events/events.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-samples-glean/events/events.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
@@ -646,6 +646,7 @@
       }
     },
     "ping_info": {
+      "additionalProperties": false,
       "properties": {
         "app_build": {
           "type": "string"

--- a/schemas/telemetry/heartbeat/heartbeat.4.parquetmr.txt
+++ b/schemas/telemetry/heartbeat/heartbeat.4.parquetmr.txt
@@ -5,7 +5,6 @@ message heartbeat {
   required double version;
   required binary clientId (UTF8);
   optional binary engagementType (UTF8);
-  
   required group application {
     required binary architecture (UTF8);
     required binary buildId (UTF8);

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -56,16 +56,16 @@
       "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
       "type": "string"
     },
-    "id": {
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
-    },
     "engagementType": {
       "enum": [
         "stars",
         "button1",
         "button2"
       ],
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"
     },
     "payload": {

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 2 (2019-02-08)
 
+- The `ping_info` section no longer allows extra properties.
+
 - Changed datetime values from a (value, time_unit) pair to simply the raw
   value.  (Backward-incompatible change).
   

--- a/templates/include/glean/glean.2.schema.json
+++ b/templates/include/glean/glean.2.schema.json
@@ -57,6 +57,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "ping_type",
         "app_build",


### PR DESCRIPTION
I feel like `ping_info` should be pretty locked down, since we want to be able to rely on exactly what's in there for every single ping.  This is in contrast to even things in the baseline ping where end-user code can add custom pings to the `metrics` section by design.  This has already been the source of [one bug](https://github.com/mozilla-mobile/android-components/pull/1984#discussion_r254739261) that slipped through the cracks.

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
