### PR TITLE
Fix printed integration branch location

### DIFF
--- a/.github/push-to-trigger-integration
+++ b/.github/push-to-trigger-integration
@@ -25,5 +25,5 @@ cat <<EOF
 The requested forked branch has been pushed to the main repo integration branch
 and CircleCI is now running integration tests:
 
-https://circleci.com/gh/mozilla-services/mozilla-pipeline-schemas/tree/integration
+https://circleci.com/gh/mozilla-services/mozilla-pipeline-schemas/tree/trigger-integration
 EOF


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
