### PR TITLE
Loosen label regex

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/baseline/baseline.2.schema.json
+++ b/schemas/glean/baseline/baseline.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/events/events.2.schema.json
+++ b/schemas/glean/events/events.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/metrics/metrics.2.schema.json
+++ b/schemas/glean/metrics/metrics.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/events/events.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -120,8 +120,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -139,8 +138,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -175,8 +173,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -194,8 +191,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -213,8 +209,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -232,8 +227,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -251,8 +245,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -273,8 +266,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -312,8 +304,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -382,8 +373,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -401,8 +391,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -444,8 +433,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -464,8 +452,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
@@ -104,8 +104,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -123,8 +122,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -143,8 +141,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -162,8 +159,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -181,8 +177,7 @@
               "type": "number"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -200,8 +195,7 @@
               "type": "integer"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -219,8 +213,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -241,8 +234,7 @@
               "type": "array"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -280,8 +272,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -350,8 +341,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -369,8 +359,7 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -412,8 +401,7 @@
               "type": "object"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"
@@ -432,8 +420,7 @@
               "type": "string"
             },
             "propertyNames": {
-              "maxLength": 30,
-              "pattern": "^[a-z_][a-z0-9_]*$",
+              "pattern": "^[a-z_][a-z0-9_.]*$",
               "type": "string"
             },
             "type": "object"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - `first_run_date` is added as a required property to `ping_info`.
 
+- Loosened the regular expression for labels to include `.` characters
+  (required for error reporting).
+
 - The `ping_info` section no longer allows extra properties.
 
 - Changed datetime values from a (value, time_unit) pair to simply the raw

--- a/templates/include/glean/labeled_group.1.schema.json
+++ b/templates/include/glean/labeled_group.1.schema.json
@@ -1,2 +1,5 @@
 "type": "object",
-"propertyNames": @GLEAN_SHORT_ID_1_JSON@
+"propertyNames": {
+  "type": "string",
+  "pattern": "^[a-z_][a-z0-9_.]*$"
+}


### PR DESCRIPTION
This broadens the `label` regex so it can include `.` and `/`.  This is needed for [error tracking](https://bugzilla.mozilla.org/show_bug.cgi?id=1499761).  Error tracking uses labeled counters where the label is the fully-qualified name of the metric associated with the error, and those have `.` in them.  Additionally the metric that caused the error may itself be a labeled metric, therefore it could have a `/` in it.

This is entirely independent of the allowed labels when using labeled metrics directly on the client, which still doesn't allow these characters.

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
