### PR TITLE
Remove Uuid from fire-tv metadata

### DIFF
--- a/schemas/pocket/fire-tv-events/fire-tv-events.1.parquetmr.txt
+++ b/schemas/pocket/fire-tv-events/fire-tv-events.1.parquetmr.txt
@@ -15,7 +15,6 @@ message fire_tv_events {
     required binary documentId (UTF8);
     required binary geoCity (UTF8);
     required binary geoCountry (UTF8);
-    required fixed_len_byte_array(16) Uuid;
     required int32 Pid;
     required int64 Timestamp;
   }

--- a/templates/pocket/fire-tv-events/fire-tv-events.1.parquetmr.txt
+++ b/templates/pocket/fire-tv-events/fire-tv-events.1.parquetmr.txt
@@ -15,7 +15,6 @@ message fire_tv_events {
     required binary documentId (UTF8);
     required binary geoCity (UTF8);
     required binary geoCountry (UTF8);
-    required fixed_len_byte_array(16) Uuid;
     required int32 Pid;
     required int64 Timestamp;
   }


### PR DESCRIPTION
This field isn't queryable and borks the whole metadata section: ` Parquet type FIXED_LEN_BYTE_ARRAY supported as DECIMAL; got null`.

We'll need to bump the version with this change.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
