### PR TITLE
Fix Webpagetest parquet schema

### DIFF
--- a/schemas/webpagetest/webpagetest-run/webpagetest-run.1.parquetmr.txt
+++ b/schemas/webpagetest/webpagetest-run/webpagetest-run.1.parquetmr.txt
@@ -11,9 +11,14 @@ message webpagetest-run {
   optional group metrics (MAP) {
     repeated group key_value {
       required binary key (UTF8);
-      required group value {
-        optional float median;
-        optional float standardDeviation;
+      required group value (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            optional float median;
+            optional float standardDeviation;
+          }
+        }
       }
     }
   }

--- a/templates/webpagetest/webpagetest-run/webpagetest-run.1.parquetmr.txt
+++ b/templates/webpagetest/webpagetest-run/webpagetest-run.1.parquetmr.txt
@@ -11,9 +11,14 @@ message webpagetest-run {
   optional group metrics (MAP) {
     repeated group key_value {
       required binary key (UTF8);
-      required group value {
-        optional float median;
-        optional float standardDeviation;
+      required group value (MAP) {
+        repeated group key_value {
+          required binary key (UTF8);
+          required group value {
+            optional float median;
+            optional float standardDeviation;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes metric field mapping in Parquet schema - we were missing one level of nesting (representing measurement type).

Relevant part of the ping: https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/dev/validation/webpagetest/webpagetest-run.1.sample.pass.json#L8-L14