### PR TITLE
Implement the new events API schema

### DIFF
--- a/schemas/glean/baseline/baseline.2.parquetmr.txt
+++ b/schemas/glean/baseline/baseline.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/glean/baseline/baseline.2.schema.json
+++ b/schemas/glean/baseline/baseline.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/glean/events/events.2.parquetmr.txt
+++ b/schemas/glean/events/events.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/glean/events/events.2.schema.json
+++ b/schemas/glean/events/events.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/glean/metrics/metrics.2.parquetmr.txt
+++ b/schemas/glean/metrics/metrics.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/glean/metrics/metrics.2.schema.json
+++ b/schemas/glean/metrics/metrics.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.2.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-reference-browser/events/events.2.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/events/events.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/events/events.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.2.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.2.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-samples-glean/events/events.2.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/events/events.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/events/events.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.2.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.2.parquetmr.txt
@@ -338,9 +338,7 @@ message baseline {
       required group element (TUPLE) {
         required int64 timestamp;
         required binary category (UTF8);
-        required binary method (UTF8);
-        required binary object (UTF8);
-        optional binary value (UTF8);
+        required binary name (UTF8);
         optional group extra (MAP) {
           repeated group key_value {
             required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.2.schema.json
@@ -23,29 +23,18 @@
             "type": "string"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          {
             "additionalProperties": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             },
-            "type": [
-              "object",
-              "null"
-            ]
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
           }
         ],
-        "maxItems": 6,
-        "minItems": 4,
+        "maxItems": 4,
+        "minItems": 3,
         "type": "array"
       },
       "type": "array"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 2 (2019-02-08)
+# Version 2 (2019-02-21)
 
 - `UUID` was removed from the `metadata` section of the parquet schema.
 
@@ -14,7 +14,11 @@
 
 - Changed datetime values from a (value, time_unit) pair to simply the raw
   value.  (Backward-incompatible change).
-  
+
+- Changed the event schema to drop `object`, `value` and renaming
+  `method` to `name`.
+
+
 # Version 1
 
 - Added support for labeled metrics.

--- a/templates/include/glean/event.1.schema.json
+++ b/templates/include/glean/event.1.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "integer",
+      "minimum": 0
+    },
+    {
+      "type": "string"
+    },
+    {
+      "type": "string"
+    },
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string",
+        "maxLength": 40
+      }
+    }
+  ],
+  "minItems": 3,
+  "maxItems": 4
+}

--- a/templates/include/glean/glean.2.parquetmr.txt
+++ b/templates/include/glean/glean.2.parquetmr.txt
@@ -267,8 +267,17 @@ message baseline {
   }
   optional group events (LIST) {
     repeated group list {
-      required group element @COMMON_EVENT_1_TXT@
+      required group element (TUPLE) {
+        required int64 timestamp;
+        required binary category (UTF8);
+        required binary name (UTF8);
+        optional group extra (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            optional binary value (UTF8);
+          }
+        }
+      }
     }
   }
-  
 }

--- a/templates/include/glean/glean.2.schema.json
+++ b/templates/include/glean/glean.2.schema.json
@@ -227,7 +227,7 @@
     },
     "events": {
         "type": "array",
-        "items": @COMMON_EVENT_1_JSON@
+        "items": @GLEAN_EVENT_1_JSON@
     }
   },
   "required": [

--- a/validation/glean/baseline.2.all.pass.json
+++ b/validation/glean/baseline.2.all.pass.json
@@ -253,7 +253,7 @@
     }
   },
   "events": [
-    [123456789, "examples", "event_example", "button", "42", {"metadata1": "extra", "metadata2": "more_extra"}],
-    [123456791, "examples", "event_example", "button2", "45"]
+    [123456789, "examples", "event_example", {"metadata1": "extra", "metadata2": "more_extra"}],
+    [123456791, "examples", "event_example"]
   ]
 }

--- a/validation/glean/baseline.2.core.pass.json
+++ b/validation/glean/baseline.2.core.pass.json
@@ -93,6 +93,6 @@
     }
   },
   "events": [
-    [123456789, "examples", "event_example", "button", "42", {"metadata1": "extra", "metadata2": "more_extra"}]
+    [123456789, "examples", "event_example", {"metadata1": "extra", "metadata2": "more_extra"}]
   ]
 }

--- a/validation/glean/events.2.all.pass.json
+++ b/validation/glean/events.2.all.pass.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/2",
+  "ping_info": {
+    "ping_type": "full",
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "telemetry_sdk_build": "abcdabcd",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25",
+    "first_run_date": "2018-10-23-04:25",
+    "experiments": {
+      "experiment1": {
+        "branch": "branch_a"
+      },
+      "experiment2": {
+        "branch": "branch_b",
+        "extra": {
+          "type": "experiment_type"
+        }
+      }
+    }
+  },
+  "events": [
+    [123456789, "examples", "event_example", {"metadata1": "extra", "metadata2": "more_extra"}],
+    [123456791, "examples", "event_example"]
+  ]
+}


### PR DESCRIPTION
This adds the glean specific event format to the templates, since it differs from the desktop ones.
We're dropping object/value, renaming `method` to `name` (as we're dropping the "method" special case too), and keeping `extra` as optional.

I've not bumped the ping schema version, as we don't really care about the old data (there should be none, except from the samples). But I'm happy to address this, if needed.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
