### PR TITLE
Bug 1383111 - Add build step to validate if all generated schemas are committed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             cd release
             cmake ..
             cd ..
-            echo "Uncommitted schemas:"
+            echo "Inconsistencies between templates and rendered schemas:"
             git ls-files --other -x schemas/*
             test `git ls-files --other -x schemas/* | wc -l` = 0
   integrate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,24 @@ jobs:
       - run:
           name: Test Code
           command: docker run mps
+  verify-generated-schemas:
+    docker:
+      - image: circleci/rust:1.32
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Verify that all generated schemas are committed
+          command: |
+            sudo apt-get update
+            sudo apt-get -y install cmake jq
+            mkdir release
+            cd release
+            cmake ..
+            cd ..
+            echo "Uncommitted schemas:"
+            git ls-files --other -x schemas/*
+            test `git ls-files --other -x schemas/* | wc -l` = 0
   integrate:
     executor: edge-validator
     steps:
@@ -85,6 +103,7 @@ workflows:
               branches:
                 # This branch is only used for the .github/push-to-trigger-integration script
                 ignore: trigger-integration
+        - verify-generated-schemas
         - integrate:
             filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             cmake ..
             cd ..
             echo "Inconsistencies between templates and rendered schemas:"
-            git ls-files --other -x schemas/*
-            test `git ls-files --other -x schemas/* | wc -l` = 0
+            git ls-files --other --modified -x schemas/*
+            test `git ls-files --other --modified -x schemas/* | wc -l` = 0
   integrate:
     executor: edge-validator
     steps:


### PR DESCRIPTION
This adds simple check to verify that all generated schemas are committed.
Process consists of:
1. Generating schemas
2. Checking git for any untracked files under `schemas*`

Sample error output can be observed here: https://circleci.com/gh/mozilla-services/mozilla-pipeline-schemas/632

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
