### PR TITLE
Fix inconsistencies between template and builds

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "moz://mozilla.org/schemas/glean/ping/2",
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "properties": {
     "$schema": {
       "enum": [
-        "moz://mozilla.org/schemas/glean/ping/2"
+        "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
     "events": {


### PR DESCRIPTION
This fixes the "Inconsistencies between templates and rendered schemas" [error here](https://circleci.com/gh/mozilla-services/mozilla-pipeline-schemas/670?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification) caused after merging #275.

I'm sure it was just human error (this human) that caused the issue -- but is there something that should have caught that pre-merge?

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
