### PR TITLE
Updated frecency-update to match the v2 implementation

### DIFF
--- a/schemas/telemetry/frecency-update/frecency-update.4.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.parquetmr.txt
@@ -26,6 +26,8 @@ message frecency-update {
     required int32 time_at_selecteds_first_entry;
     required int32 search_string_length;
     required binary selected_style;
+    required int32 selected_url_was_same_as_search_string;
+    required int32 enter_was_pressed;
     required binary study_variation;
     required binary study_addon_version;
   }

--- a/schemas/telemetry/frecency-update/frecency-update.4.parquetmr.txt
+++ b/schemas/telemetry/frecency-update/frecency-update.4.parquetmr.txt
@@ -3,21 +3,30 @@ message frecency-update {
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
+    required int32 model_version;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;
       }
     }
-    required int32 model_version;
     required float loss;
-    required int32 num_chars_typed;
-    required int32 rank_selected;
-    required int32 num_suggestions_displayed;
-    required binary study_variation;
     required group update (LIST) {
       repeated group list {
         required float element;
       }
     }
+    required int32 num_suggestions_displayed;
+    required int32 rank_selected;
+    required int32 bookmark_and_history_num_suggestions_displayed;
+    required int32 bookmark_and_history_rank_selected;
+    required int32 num_key_down_events_at_selecteds_first_entry;
+    required int32 num_key_down_events;
+    required int32 time_start_interaction;
+    required int32 time_end_interaction;
+    required int32 time_at_selecteds_first_entry;
+    required int32 search_string_length;
+    required binary selected_style;
+    required binary study_variation;
+    required binary study_addon_version;
   }
 }

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.json
@@ -7,6 +7,14 @@
     },
     "payload": {
       "properties": {
+        "bookmark_and_history_num_suggestions_displayed": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "bookmark_and_history_rank_selected": {
+          "minimum": -1,
+          "type": "number"
+        },
         "frecency_scores": {
           "items": {
             "type": "number"
@@ -19,20 +27,46 @@
         "model_version": {
           "type": "number"
         },
-        "num_chars_typed": {
+        "num_key_down_events": {
           "minimum": 0,
+          "type": "number"
+        },
+        "num_key_down_events_at_selecteds_first_entry": {
+          "minimum": -1,
           "type": "number"
         },
         "num_suggestions_displayed": {
-          "minimum": 1,
-          "type": "number"
-        },
-        "rank_selected": {
           "minimum": 0,
           "type": "number"
         },
+        "rank_selected": {
+          "minimum": -1,
+          "type": "number"
+        },
+        "search_string_length": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "selected_style": {
+          "type": "string"
+        },
+        "study_addon_version": {
+          "type": "string"
+        },
         "study_variation": {
           "type": "string"
+        },
+        "time_at_selecteds_first_entry": {
+          "minimum": -1,
+          "type": "number"
+        },
+        "time_end_interaction": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "time_start_interaction": {
+          "minimum": 0,
+          "type": "number"
         },
         "update": {
           "items": {
@@ -44,14 +78,23 @@
         }
       },
       "required": [
+        "model_version",
         "frecency_scores",
         "loss",
-        "model_version",
-        "num_chars_typed",
+        "update",
         "num_suggestions_displayed",
         "rank_selected",
+        "bookmark_and_history_num_suggestions_displayed",
+        "bookmark_and_history_rank_selected",
+        "num_key_down_events_at_selecteds_first_entry",
+        "num_key_down_events",
+        "time_start_interaction",
+        "time_end_interaction",
+        "time_at_selecteds_first_entry",
+        "search_string_length",
+        "selected_style",
         "study_variation",
-        "update"
+        "study_addon_version"
       ]
     },
     "type": {

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.json
@@ -15,6 +15,10 @@
           "minimum": -1,
           "type": "number"
         },
+        "enter_was_pressed": {
+          "minimum": 0,
+          "type": "number"
+        },
         "frecency_scores": {
           "items": {
             "type": "number"
@@ -49,6 +53,10 @@
         },
         "selected_style": {
           "type": "string"
+        },
+        "selected_url_was_same_as_search_string": {
+          "minimum": -1,
+          "type": "number"
         },
         "study_addon_version": {
           "type": "string"
@@ -93,6 +101,8 @@
         "time_at_selecteds_first_entry",
         "search_string_length",
         "selected_style",
+        "selected_url_was_same_as_search_string",
+        "enter_was_pressed",
         "study_variation",
         "study_addon_version"
       ]

--- a/templates/telemetry/frecency-update/frecency-update.4.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.parquetmr.txt
@@ -26,6 +26,8 @@ message frecency-update {
     required int32 time_at_selecteds_first_entry;
     required int32 search_string_length;
     required binary selected_style;
+    required int32 selected_url_was_same_as_search_string;
+    required int32 enter_was_pressed;
     required binary study_variation;
     required binary study_addon_version;
   }

--- a/templates/telemetry/frecency-update/frecency-update.4.parquetmr.txt
+++ b/templates/telemetry/frecency-update/frecency-update.4.parquetmr.txt
@@ -3,21 +3,30 @@ message frecency-update {
   required binary clientId (UTF8);
   required binary type (UTF8);
   required group payload {
+    required int32 model_version;
     required group frecency_scores (LIST) {
       repeated group list {
         required float element;
       }
     }
-    required int32 model_version;
     required float loss;
-    required int32 num_chars_typed;
-    required int32 rank_selected;
-    required int32 num_suggestions_displayed;
-    required binary study_variation;
     required group update (LIST) {
       repeated group list {
         required float element;
       }
     }
+    required int32 num_suggestions_displayed;
+    required int32 rank_selected;
+    required int32 bookmark_and_history_num_suggestions_displayed;
+    required int32 bookmark_and_history_rank_selected;
+    required int32 num_key_down_events_at_selecteds_first_entry;
+    required int32 num_key_down_events;
+    required int32 time_start_interaction;
+    required int32 time_end_interaction;
+    required int32 time_at_selecteds_first_entry;
+    required int32 search_string_length;
+    required binary selected_style;
+    required binary study_variation;
+    required binary study_addon_version;
   }
 }

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.json
@@ -74,6 +74,14 @@
         "selected_style": {
           "type": "string"
         },
+        "selected_url_was_same_as_search_string": {
+          "type": "number",
+          "minimum": -1
+        },
+        "enter_was_pressed": {
+          "type": "number",
+          "minimum": 0
+        },
         "study_variation": {
           "type": "string"
         },
@@ -97,6 +105,8 @@
         "time_at_selecteds_first_entry",
         "search_string_length",
         "selected_style",
+        "selected_url_was_same_as_search_string",
+        "enter_was_pressed",
         "study_variation",
         "study_addon_version"
       ]

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.json
@@ -11,6 +11,9 @@
     },
     "payload": {
       "properties": {
+        "model_version": {
+          "type": "number"
+        },
         "frecency_scores": {
           "type": "array",
           "items": {
@@ -20,24 +23,6 @@
         "loss": {
           "type": "number"
         },
-        "model_version": {
-          "type": "number"
-        },
-        "num_chars_typed": {
-          "type": "number",
-          "minimum": 0
-        },
-        "num_suggestions_displayed": {
-          "type": "number",
-          "minimum": 1
-        },
-        "rank_selected": {
-          "type": "number",
-          "minimum": 0
-        },
-        "study_variation": {
-          "type": "string"
-        },
         "update": {
           "type": "array",
           "minItems": 22,
@@ -45,17 +30,75 @@
           "items": {
             "type": "number"
           }
+        },
+        "num_suggestions_displayed": {
+          "type": "number",
+          "minimum": 0
+        },
+        "rank_selected": {
+          "type": "number",
+          "minimum": -1
+        },
+        "bookmark_and_history_num_suggestions_displayed": {
+          "type": "number",
+          "minimum": 0
+        },
+        "bookmark_and_history_rank_selected": {
+          "type": "number",
+          "minimum": -1
+        },
+        "num_key_down_events_at_selecteds_first_entry": {
+          "type": "number",
+          "minimum": -1
+        },
+        "num_key_down_events": {
+          "type": "number",
+          "minimum": 0
+        },
+        "time_start_interaction": {
+          "type": "number",
+          "minimum": 0
+        },
+        "time_end_interaction": {
+          "type": "number",
+          "minimum": 0
+        },
+        "time_at_selecteds_first_entry": {
+          "type": "number",
+          "minimum": -1
+        },
+        "search_string_length": {
+          "type": "number",
+          "minimum": 0
+        },
+        "selected_style": {
+          "type": "string"
+        },
+        "study_variation": {
+          "type": "string"
+        },
+        "study_addon_version": {
+          "type": "string"
         }
       },
       "required": [
+        "model_version",
         "frecency_scores",
         "loss",
-        "model_version",
-        "num_chars_typed",
+        "update",
         "num_suggestions_displayed",
         "rank_selected",
+        "bookmark_and_history_num_suggestions_displayed",
+        "bookmark_and_history_rank_selected",
+        "num_key_down_events_at_selecteds_first_entry",
+        "num_key_down_events",
+        "time_start_interaction",
+        "time_end_interaction",
+        "time_at_selecteds_first_entry",
+        "search_string_length",
+        "selected_style",
         "study_variation",
-        "update"
+        "study_addon_version"
       ]
     }
   },

--- a/validation/telemetry/frecency-update.4.sample.pass.json
+++ b/validation/telemetry/frecency-update.4.sample.pass.json
@@ -1,6 +1,7 @@
 {
   "clientId": "e00d072c-db5c-42be-a159-a2e95466a7da",
   "payload": {
+    "model_version": 140,
     "frecency_scores": [
       38223,
       3933.4,
@@ -8,11 +9,6 @@
       21
     ],
     "loss": 291989.21,
-    "model_version": 3,
-    "num_chars_typed": 5,
-    "num_suggestions_displayed": 5,
-    "rank_selected": 2,
-    "study_variation": "treatment",
     "update": [
       1.2,
       3.2,
@@ -36,7 +32,20 @@
       0.39,
       0.54,
       0.78
-    ]
+    ],
+    "num_suggestions_displayed": 1,
+    "rank_selected": 0,
+    "bookmark_and_history_num_suggestions_displayed": 1,
+    "bookmark_and_history_rank_selected": 0,
+    "num_key_down_events_at_selecteds_first_entry": 8,
+    "num_key_down_events": 14,
+    "time_start_interaction": 0,
+    "time_end_interaction": 2275,
+    "time_at_selecteds_first_entry": 1458,
+    "search_string_length": 13,
+    "selected_style": "autofill heuristic",
+    "study_variation": "dogfooding",
+    "study_addon_version": "2.1.1"
   },
   "type": "frecency-update"
 }

--- a/validation/telemetry/frecency-update.4.sample.pass.json
+++ b/validation/telemetry/frecency-update.4.sample.pass.json
@@ -44,6 +44,8 @@
     "time_at_selecteds_first_entry": 1458,
     "search_string_length": 13,
     "selected_style": "autofill heuristic",
+    "selected_url_was_same_as_search_string": 0,
+    "enter_was_pressed": 1,
     "study_variation": "dogfooding",
     "study_addon_version": "2.1.1"
   },


### PR DESCRIPTION
For the relaunch of the federated learning study: https://github.com/mozilla/federated-learning-v2-study-addon

In this PR, I chose to overwrite the existing `frecency-update` ping rather than introducing `frecency-update-v2` or similar since the `frecency-update` pings from v1 of the study should no longer be consumed.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
