### PR TITLE
[glean] NULL timespan checks

### DIFF
--- a/tests/hindsight/run/input/test_json_schemas.lua
+++ b/tests/hindsight/run/input/test_json_schemas.lua
@@ -117,6 +117,7 @@ function process_message()
                         if not ok then error(err) end
                     else -- "fail"
                         if ok then error(string.format("Validation should not have passed: %s", fn)) end
+                        return 0
                     end
 
                     msg.Type = namespace

--- a/validation/glean/metrics.1.null_timespan.fail.json
+++ b/validation/glean/metrics.1.null_timespan.fail.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "ping_info": {
+    "ping_type": "full",
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "telemetry_sdk_build": "abcdabcd",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25",
+    "first_run_date": "2018-10-23-04:25"
+  },
+  "metrics": {
+    "timespan": {
+      "test.timespan": {
+        "value": null,
+        "time_unit": "second"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a test to ensure that `null` timespans in glean are rejected by the JSON schema.

This includes a small workaround for the test harness so that failing JSON tests are not passed along for a parquet test (where there is currently no provision to handle failing tests).

Related to [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1525600)

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
