### PR TITLE
Fix PR #280 - Skip the injection on failure instead of aborting the test

### DIFF
--- a/tests/hindsight/run/input/test_json_schemas.lua
+++ b/tests/hindsight/run/input/test_json_schemas.lua
@@ -115,16 +115,14 @@ function process_message()
                     local ok, err = doc:validate(schemas[string.format("%s.%s.%s", namespace, schema, version)])
                     if outcome == "pass" then
                         if not ok then error(err) end
+                        msg.Type = namespace
+                        msg.Fields.docType = schema
+                        msg.Fields.sourceVersion = tonumber(version)
+                        msg.Payload = json
+                        inject_message(msg)
                     else -- "fail"
                         if ok then error(string.format("Validation should not have passed: %s", fn)) end
-                        return 0
                     end
-
-                    msg.Type = namespace
-                    msg.Fields.docType = schema
-                    msg.Fields.sourceVersion = tonumber(version)
-                    msg.Payload = json
-                    inject_message(msg)
                 end
             end
         end


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
