### PR TITLE
Add better definitions for array types missing items

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -998,6 +998,10 @@
           "type": "object"
         },
         "childPayloads": {
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
           "type": "array"
         },
         "chromeHangs": {
@@ -1032,6 +1036,9 @@
                 "type": "number"
               },
               "range": {
+                "items": {
+                  "type": "integer"
+                },
                 "type": "array"
               },
               "sum": {
@@ -1095,6 +1102,9 @@
                   "type": "number"
                 },
                 "range": {
+                  "items": {
+                    "type": "integer"
+                  },
                   "type": "array"
                 },
                 "sum": {
@@ -1308,6 +1318,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1359,6 +1372,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {
@@ -1586,6 +1602,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1637,6 +1656,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {
@@ -1864,6 +1886,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1915,6 +1940,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {

--- a/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -52,6 +52,9 @@
                   "type": "number"
                 },
                 "range": {
+                  "items": {
+                    "type": "integer"
+                  },
                   "type": "array"
                 },
                 "sum": {
@@ -103,6 +106,9 @@
                     "type": "number"
                   },
                   "range": {
+                    "items": {
+                      "type": "integer"
+                    },
                     "type": "array"
                   },
                   "sum": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -998,6 +998,10 @@
           "type": "object"
         },
         "childPayloads": {
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
           "type": "array"
         },
         "chromeHangs": {
@@ -1032,6 +1036,9 @@
                 "type": "number"
               },
               "range": {
+                "items": {
+                  "type": "integer"
+                },
                 "type": "array"
               },
               "sum": {
@@ -1095,6 +1102,9 @@
                   "type": "number"
                 },
                 "range": {
+                  "items": {
+                    "type": "integer"
+                  },
                   "type": "array"
                 },
                 "sum": {
@@ -1308,6 +1318,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1359,6 +1372,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {
@@ -1586,6 +1602,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1637,6 +1656,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {
@@ -1864,6 +1886,9 @@
                         "type": "number"
                       },
                       "range": {
+                        "items": {
+                          "type": "integer"
+                        },
                         "type": "array"
                       },
                       "sum": {
@@ -1915,6 +1940,9 @@
                           "type": "number"
                         },
                         "range": {
+                          "items": {
+                            "type": "integer"
+                          },
                           "type": "array"
                         },
                         "sum": {

--- a/templates/include/telemetry/histogram.1.schema.json
+++ b/templates/include/telemetry/histogram.1.schema.json
@@ -17,7 +17,10 @@
       "minimum": 0
     },
     "range": {
-      "type": "array"
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
     },
     "sum": {
       "type": "integer",

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -10,7 +10,11 @@
       "properties": { }
     },
     "childPayloads": {
-      "type": "array"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { }
+      }
     },
     "chromeHangs": {
       "type": "object",


### PR DESCRIPTION
This fixes #288 by adding a fuller type definition for arrays. The missing fields were found by using the following script:

https://gist.github.com/acmiyaguchi/0786d0cff8d79f8a9662377ad3e891b1

Then running the following command at the toplevel:

```
find schemas/ -name "*.schema.json" | xargs -I {} bash -c "echo {}; cat {} | python3 find-arrays.py" 
```

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
