### PR TITLE
Avoid incompatible array and object union type

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -179,10 +179,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -196,10 +193,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -364,10 +358,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -815,10 +809,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1133,11 +1133,10 @@
           "type": "object"
         },
         "log": {
-          "items": {
-            "properties": {},
-            "type": "object"
-          },
-          "type": "array"
+          "type": [
+            "array",
+            "object"
+          ]
         },
         "processes": {
           "properties": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -984,10 +975,11 @@
     "payload": {
       "properties": {
         "UIMeasurements": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "addonDetails": {
           "properties": {},
@@ -1141,10 +1133,11 @@
           "type": "object"
         },
         "log": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "processes": {
           "properties": {
@@ -2022,10 +2015,11 @@
           "type": "object"
         },
         "threadHangStats": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "ver": {
           "type": "integer"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1133,11 +1133,10 @@
           "type": "object"
         },
         "log": {
-          "items": {
-            "properties": {},
-            "type": "object"
-          },
-          "type": "array"
+          "type": [
+            "array",
+            "object"
+          ]
         },
         "processes": {
           "properties": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -984,10 +975,11 @@
     "payload": {
       "properties": {
         "UIMeasurements": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "addonDetails": {
           "properties": {},
@@ -1141,10 +1133,11 @@
           "type": "object"
         },
         "log": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "processes": {
           "properties": {
@@ -2022,10 +2015,11 @@
           "type": "object"
         },
         "threadHangStats": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "properties": {},
+            "type": "object"
+          },
+          "type": "array"
         },
         "ver": {
           "type": "integer"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/shield-study-addon/shield-study-addon.3.schema.json
+++ b/schemas/telemetry/shield-study-addon/shield-study-addon.3.schema.json
@@ -124,10 +124,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -141,10 +138,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [

--- a/schemas/telemetry/shield-study-error/shield-study-error.3.schema.json
+++ b/schemas/telemetry/shield-study-error/shield-study-error.3.schema.json
@@ -124,10 +124,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -141,10 +138,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [

--- a/schemas/telemetry/shield-study/shield-study.3.schema.json
+++ b/schemas/telemetry/shield-study/shield-study.3.schema.json
@@ -124,10 +124,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -141,10 +138,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -183,10 +183,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": [
-                      "array",
-                      "object"
-                    ]
+                    "type": "array"
                   },
                   "name": {
                     "type": "string"
@@ -200,10 +197,7 @@
                 },
                 "type": "object"
               },
-              "type": [
-                "array",
-                "object"
-              ]
+              "type": "array"
             },
             "persona": {
               "type": [
@@ -368,10 +362,10 @@
               ]
             },
             "partnerNames": {
-              "type": [
-                "array",
-                "object"
-              ]
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -819,10 +813,7 @@
                     },
                     "type": "object"
                   },
-                  "type": [
-                    "array",
-                    "object"
-                  ]
+                  "type": "array"
                 }
               },
               "type": "object"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -91,7 +91,7 @@
           }
         },
         "activePlugins": {
-          "type": [ "array", "object" ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -114,7 +114,7 @@
                 "type": "boolean"
               },
               "mimeTypes": {
-                "type": [ "array", "object" ],
+                "type": "array",
                 "items": {
                   "type": "string"
                 }
@@ -276,10 +276,10 @@
           ]
         },
         "partnerNames": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -554,7 +554,7 @@
               }
             },
             "monitors": {
-              "type": [ "array", "object" ],
+              "type": "array",
               "items": {
                 "type": "object",
                 "properties": {

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -67,10 +67,11 @@
       "properties": { }
     },
     "log": {
-      "type": [
-        "array",
-        "object"
-        ]
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { }
+      }
     },
     "simpleMeasurements": {
       "type": "object",
@@ -85,16 +86,18 @@
       "properties": { }
     },
     "threadHangStats": {
-      "type": [
-        "array",
-        "object"
-        ]
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { }
+      }
     },
     "UIMeasurements": {
-      "type": [
-        "array",
-        "object"
-        ]
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { }
+      }
     },
     "ver": {
       "type": "integer"

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -67,11 +67,10 @@
       "properties": { }
     },
     "log": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": { }
-      }
+      "type": [
+        "array",
+        "object"
+        ]
     },
     "simpleMeasurements": {
       "type": "object",

--- a/templates/telemetry/shield-study-addon/shield-study-addon.3.schema.json
+++ b/templates/telemetry/shield-study-addon/shield-study-addon.3.schema.json
@@ -109,10 +109,7 @@
               }
             },
             "activePlugins": {
-              "type": [
-                "array",
-                "object"
-              ],
+              "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
@@ -135,10 +132,7 @@
                     "type": "boolean"
                   },
                   "mimeTypes": {
-                    "type": [
-                      "array",
-                      "object"
-                    ],
+                    "type": "array",
                     "items": {
                       "type": "string"
                     }

--- a/templates/telemetry/shield-study-error/shield-study-error.3.schema.json
+++ b/templates/telemetry/shield-study-error/shield-study-error.3.schema.json
@@ -109,10 +109,7 @@
               }
             },
             "activePlugins": {
-              "type": [
-                "array",
-                "object"
-              ],
+              "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
@@ -135,10 +132,7 @@
                     "type": "boolean"
                   },
                   "mimeTypes": {
-                    "type": [
-                      "array",
-                      "object"
-                    ],
+                    "type": "array",
                     "items": {
                       "type": "string"
                     }

--- a/templates/telemetry/shield-study/shield-study.3.schema.json
+++ b/templates/telemetry/shield-study/shield-study.3.schema.json
@@ -109,10 +109,7 @@
               }
             },
             "activePlugins": {
-              "type": [
-                "array",
-                "object"
-              ],
+              "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
@@ -135,10 +132,7 @@
                     "type": "boolean"
                   },
                   "mimeTypes": {
-                    "type": [
-                      "array",
-                      "object"
-                    ],
+                    "type": "array",
                     "items": {
                       "type": "string"
                     }


### PR DESCRIPTION
I used the following script to find all occurrences of `"type": ["array", "object"]`:

```python
#!/usr/bin/env python3

import json
import sys
from collections import deque

def main():
    # traverse a json document, finding path to leaves that match exactly with the term
    document = json.load(sys.stdin)
    
    search_term = {"object", "array"}
    results = []

    queue = deque([("root", document)])
    while queue:
        name, node = queue.popleft()
        if not isinstance(node, dict):
            continue
        dtype = node.get("type")
        if dtype and isinstance(dtype, list) and search_term.issubset(set(dtype)):
            results.append((name, node))
        for key, value in node.items():
            queue.append((f"{name}.{key}", value))
    
    results = [x[0] for x in results]
    for item in results:
        print(item)

if __name__ == "__main__":
    main()
```

This is saved as `find-array-object.py`.

This one-liner prints out unique errors (I used some form of this to link them to the documents that they came from).
```bash
find schemas/ -name "*.schema.json" | \
    { xargs -I {} bash -c "cat {} | python3 find-array-object.py"; } | \
    sort | uniq
```

```
root.properties.application.properties.addons.properties.activePlugins
root.properties.application.properties.addons.properties.activePlugins.items.properties.mimeTypes
root.properties.environment.properties.addons.properties.activePlugins
root.properties.environment.properties.addons.properties.activePlugins.items.properties.mimeTypes
root.properties.environment.properties.partner.properties.partnerNames
root.properties.environment.properties.system.properties.gfx.properties.monitors
root.properties.payload.properties.UIMeasurements
root.properties.payload.properties.log
root.properties.payload.properties.threadHangStats
```

To verify that the arrays are not actually objects, I ran the following jq expressions on the sampled landfill data.

```bash
find schemas/ -name "*.schema.json" | \
    { xargs -I {} bash -c "cat {} | python3 find-array-object.py"; } | \
    sort | uniq | \
    sed 's/root//g; s/.properties//g; s/.items/ | .[]? | /g; s/$/ | type/' | \
```

Results:
```
bash-3.2$ pwd
/Users/amiyaguchi/Work/mozilla-pipeline-schemas
bash-3.2$ find data/ -type f | xargs jq ".environment.addons.activePlugins | type" | sort | uniq -c
7617 "array"
4528 "null"
bash-3.2$ find data/ -type f | xargs jq ".environment.addons.activePlugins | .[]? | .mimeTypes | type" | sort | uniq -c
6693 "array"
bash-3.2$ find data/ -type f | xargs jq ".environment.partner.partnerNames | type" | sort | uniq -c
8186 "array"
3959 "null"
bash-3.2$ find data/ -type f | xargs jq ".environment.system.gfx.monitors | type" | sort | uniq -c
8172 "array"
3973 "null"
bash-3.2$ find data/ -type f | xargs jq ".payload.UIMeasurements | type" | sort | uniq -c
 962 "array"
11183 "null"
bash-3.2$ find data/ -type f | xargs jq ".payload.log | type" | sort | uniq -c
1026 "array"
11119 "null"
bash-3.2$ find data/ -type f | xargs jq ".payload.threadHangStats | type" | sort | uniq -c
 299 "array"
11846 "null"
```

These fields are not actually a union of array and objects, they are just arrays.

https://gist.github.com/acmiyaguchi/99efdbe9c84d4c990140ad0ea85ba4af

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
