### PR TITLE
Add items for gcItems

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1197,6 +1197,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1247,6 +1251,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1475,6 +1483,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1525,6 +1537,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1753,6 +1769,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1803,6 +1823,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1197,6 +1197,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1247,6 +1251,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1475,6 +1483,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1525,6 +1537,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1753,6 +1769,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"
@@ -1803,6 +1823,10 @@
                         "maxProperties": 30,
                         "properties": {
                           "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
                             "type": [
                               "array",
                               "number"

--- a/templates/include/telemetry/gcItem.1.schema.json
+++ b/templates/include/telemetry/gcItem.1.schema.json
@@ -24,7 +24,11 @@
       "maxProperties": 65
     },
     "slices": {
-      "type": ["array", "number"]
+      "type": ["array", "number"],
+      "items": {
+        "type": "object",
+        "properties": {}
+      }
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
This adds the missing array items field to the gc slices, while retaining the variant numeric type. The object is the more recent of the two variants, introduced in ff58.

```
jq '.. | select(.gc?) | .gc.random[].slices, .gc.worst[].slices | type' data/telemetry.main.4.ndjson | sort | uniq -c 
  16 "array"
  84 "number"
```

re:
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/291#issuecomment-474380070
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/291#issuecomment-474814119

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
