### PR TITLE
Add a full schema for payload.logs in main pings

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1132,25 +1132,23 @@
         },
         "log": {
           "items": {
-            "items": {
-              "type": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
             "type": "array"
           },
           "type": "array"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1131,22 +1131,17 @@
           "type": "object"
         },
         "log": {
+          "description": "Removed in FF61 via bug 1443615",
           "items": {
+            "additionalItems": {
+              "type": "string"
+            },
             "items": [
               {
                 "type": "string"
               },
               {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "string"
+                "type": "integer"
               }
             ],
             "type": "array"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1131,10 +1131,29 @@
           "type": "object"
         },
         "log": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "items": {
+              "type": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "type": "array"
         },
         "processes": {
           "properties": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1132,25 +1132,23 @@
         },
         "log": {
           "items": {
-            "items": {
-              "type": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
             "type": "array"
           },
           "type": "array"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1131,22 +1131,17 @@
           "type": "object"
         },
         "log": {
+          "description": "Removed in FF61 via bug 1443615",
           "items": {
+            "additionalItems": {
+              "type": "string"
+            },
             "items": [
               {
                 "type": "string"
               },
               {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "string"
+                "type": "integer"
               }
             ],
             "type": "array"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1131,10 +1131,29 @@
           "type": "object"
         },
         "log": {
-          "type": [
-            "array",
-            "object"
-          ]
+          "items": {
+            "items": {
+              "type": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "type": "array"
         },
         "processes": {
           "properties": {

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -66,15 +66,13 @@
       "type": "array",
       "items": {
         "type": "array",
-        "items": {
-          "type": [
-            {"type": "string"},
-            {"type": "number"},
-            {"type": "string"},
-            {"type": "string"},
-            {"type": "string"}
-          ]
-        }
+        "items": [
+          {"type": "string"},
+          {"type": "number"},
+          {"type": "string"},
+          {"type": "string"},
+          {"type": "string"}
+        ]
       }
     },
     "simpleMeasurements": {

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -63,10 +63,19 @@
       "properties": { }
     },
     "log": {
-      "type": [
-        "array",
-        "object"
-        ]
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "string"},
+            {"type": "string"},
+            {"type": "string"}
+          ]
+        }
+      }
     },
     "simpleMeasurements": {
       "type": "object",

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -63,16 +63,17 @@
       "properties": { }
     },
     "log": {
+      "description": "Removed in FF61 via bug 1443615",
       "type": "array",
       "items": {
         "type": "array",
         "items": [
           {"type": "string"},
-          {"type": "number"},
-          {"type": "string"},
-          {"type": "string"},
-          {"type": "string"}
-        ]
+          {"type": "integer"}
+        ],
+        "additionalItems": {
+          "type": "string"
+        }
       }
     },
     "simpleMeasurements": {

--- a/validation/telemetry/main.4.log.fail.json
+++ b/validation/telemetry/main.4.log.fail.json
@@ -1,0 +1,23 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4,
+  "payload": {
+    "log": [
+      ["test"],
+      ["test", "1"],
+      ["test", 1, 1]
+    ]
+  }
+}

--- a/validation/telemetry/main.4.log_empty.pass.json
+++ b/validation/telemetry/main.4.log_empty.pass.json
@@ -1,0 +1,19 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4,
+  "payload": {
+    "log": []
+  }
+}

--- a/validation/telemetry/main.4.log_variable.pass.json
+++ b/validation/telemetry/main.4.log_variable.pass.json
@@ -1,0 +1,24 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4,
+  "payload": {
+    "log": [
+      ["test", 1],
+      ["test", 2, "a"],
+      ["test", 3, "a", "b"],
+      ["test", 4, "a", "b", "c"]
+    ]
+  }
+}


### PR DESCRIPTION
re: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/291#discussion_r266180942

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
