### PR TITLE
Bug 1526072 - Add fields for clobber builds and resource utilization to build telemetry

### DIFF
--- a/schemas/eng-workflow/build/build.1.parquetmr.txt
+++ b/schemas/eng-workflow/build/build.1.parquetmr.txt
@@ -9,6 +9,10 @@ message build {
       required binary element (UTF8);
     }
   }
+  optional group build_attrs {
+    optional boolean clobber;
+    optional int64 cpu_percent;
+  }
   required group build_opts {
     optional boolean artifact;
     optional boolean ccache;

--- a/schemas/eng-workflow/build/build.1.schema.json
+++ b/schemas/eng-workflow/build/build.1.schema.json
@@ -8,6 +8,20 @@
       },
       "type": "array"
     },
+    "build_attrs": {
+      "description": "Attributes characterizing a build",
+      "properties": {
+        "clobber": {
+          "description": "true if the build was a clobber/full build",
+          "type": "boolean"
+        },
+        "cpu_percent": {
+          "description": "cpu utilization observed during a build",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "build_opts": {
       "description": "Selected build options",
       "properties": {

--- a/templates/eng-workflow/build/build.1.parquetmr.txt
+++ b/templates/eng-workflow/build/build.1.parquetmr.txt
@@ -9,6 +9,10 @@ message build {
       required binary element (UTF8);
     }
   }
+  optional group build_attrs {
+    optional boolean clobber;
+    optional int64 cpu_percent;
+  }
   required group build_opts {
     optional boolean artifact;
     optional boolean ccache;

--- a/templates/eng-workflow/build/build.1.schema.json
+++ b/templates/eng-workflow/build/build.1.schema.json
@@ -1,33 +1,47 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#", 
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "argv": {
-      "description": "Full mach commandline. If the commandline contains absolute paths they will be sanitized.", 
+      "description": "Full mach commandline. If the commandline contains absolute paths they will be sanitized.",
       "items": {
         "type": "string"
-      }, 
+      },
       "type": "array"
-    }, 
+    },
+    "build_attrs": {
+      "description": "Attributes characterizing a build",
+      "properties": {
+        "clobber": {
+          "description": "true if the build was a clobber/full build",
+          "type": "boolean"
+        },
+        "cpu_percent": {
+          "description": "cpu utilization observed during a build",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "build_opts": {
-      "description": "Selected build options", 
+      "description": "Selected build options",
       "properties": {
         "artifact": {
-          "description": "true if --enable-artifact-builds", 
+          "description": "true if --enable-artifact-builds",
           "type": "boolean"
-        }, 
+        },
         "ccache": {
-          "description": "true if ccache is in use (--with-ccache)", 
+          "description": "true if ccache is in use (--with-ccache)",
           "type": "boolean"
-        }, 
+        },
         "compiler": {
-          "description": "The compiler type in use (CC_TYPE)", 
+          "description": "The compiler type in use (CC_TYPE)",
           "enum": [
-            "clang", 
-            "clang-cl", 
-            "gcc", 
+            "clang",
+            "clang-cl",
+            "gcc",
             "msvc"
           ]
-        }, 
+        },
         "debug": {
           "description": "true if build is debug (--enable-debug)",
           "type": "boolean"

--- a/validation/eng-workflow/build.1.buildAttrs.pass.json
+++ b/validation/eng-workflow/build.1.buildAttrs.pass.json
@@ -1,0 +1,27 @@
+{
+  "argv": ["./mach", "build"],
+  "build_attrs": {
+    "clobber": true,
+    "cpu_percent": 24
+  },
+  "build_opts": {
+    "artifact": false,
+    "ccache": true, 
+    "compiler": "clang", 
+    "debug": true, 
+    "opt": false, 
+    "sccache": true
+  }, 
+  "client_id": "c890ef1c-c6d8-4bc5-8859-f27e346cda8b", 
+  "command": "build", 
+  "duration_ms": 301020, 
+  "success": true, 
+  "system": {
+    "cpu_brand": "Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz", 
+    "logical_cores": 8, 
+    "memory_gb": 32, 
+    "os": "linux", 
+    "physical_cores": 4
+  }, 
+  "time": "2018-08-09T20:50:12.356679Z"
+}


### PR DESCRIPTION

This pr adds two fields to built system telemetry. datareview was granted in bug 1526072.