### PR TITLE
Split some fields out of gleans'`ping_info` to `client_info`

### DIFF
--- a/schemas/glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/glean/baseline/baseline.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/glean/events/events.1.parquetmr.txt
+++ b/schemas/glean/events/events.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/glean/metrics/metrics.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -9,6 +9,56 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "app_build": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
     "events": {
       "items": {
         "items": [
@@ -630,16 +680,6 @@
     "ping_info": {
       "additionalProperties": false,
       "properties": {
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "client_id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "type": "string"
-        },
         "end_time": {
           "format": "datetime",
           "type": "string"
@@ -673,10 +713,6 @@
             "type": "string"
           }
         },
-        "first_run_date": {
-          "format": "datetime",
-          "type": "string"
-        },
         "ping_type": {
           "maxLength": 30,
           "pattern": "^[a-z_][a-z0-9_]*$",
@@ -688,21 +724,13 @@
         "start_time": {
           "format": "datetime",
           "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
         }
       },
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ],
       "type": "object"
     }

--- a/templates/include/glean/glean.1.parquetmr.txt
+++ b/templates/include/glean/glean.1.parquetmr.txt
@@ -18,15 +18,23 @@ message baseline {
     required int32 Pid;
     required int64 Timestamp;
   }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    required binary architecture (UTF8);
+    required binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
   required group ping_info {
     required binary ping_type (UTF8);
-    required binary app_build (UTF8);
-    required binary telemetry_sdk_build (UTF8);
-    required binary client_id (UTF8);
     required int32 seq;
     required binary start_time (UTF8);
     required binary end_time (UTF8);
-    required binary first_run_date (UTF8);
     optional group experiments (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -10,38 +10,46 @@
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
     },
-    "ping_info": {
+    "client_info": {
       "type": "object",
       "properties": {
-        "ping_type": @GLEAN_SHORT_ID_1_JSON@,
-        "app_build": {
-          "type": "string"
-        },
-        "app_display_version": {
-          "type": "string"
-        },
-        "telemetry_sdk_build": {
-          "type": "string"
-        },
+        "app_build": @GLEAN_STRING_1_JSON@,
+        "app_display_version": @GLEAN_STRING_1_JSON@,
+        "architecture": @GLEAN_STRING_1_JSON@,
         "client_id": {
           "type": "string",
           @COMMON_PATTERN_UUID_1_JSON@
         },
+        "device_manufacturer": @GLEAN_STRING_1_JSON@,
+        "device_model": @GLEAN_STRING_1_JSON@,
+        "first_run_date": @GLEAN_DATETIME_1_JSON@,
+        "os": @GLEAN_STRING_1_JSON@,
+        "os_version": @GLEAN_STRING_1_JSON@,
+        "telemetry_sdk_build": @GLEAN_STRING_1_JSON@
+      },
+      "additionalProperties": false,
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "client_id",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ]
+    },
+    "ping_info": {
+      "type": "object",
+      "properties": {
+        "ping_type": @GLEAN_SHORT_ID_1_JSON@,
         "seq": {
           "type": "integer"
         },
-        "start_time": {
-          "type": "string",
-          "format": "datetime"
-        },
-        "end_time": {
-          "type": "string",
-          "format": "datetime"
-        },
-        "first_run_date": {
-          "type": "string",
-          "format": "datetime"
-        },
+        "start_time": @GLEAN_DATETIME_1_JSON@,
+        "end_time": @GLEAN_DATETIME_1_JSON@,
         "experiments": {
           "propertyNames": @GLEAN_SHORT_ID_1_JSON@,
           "additionalProperties": {
@@ -67,14 +75,9 @@
       "additionalProperties": false,
       "required": [
         "ping_type",
-        "app_build",
-        "app_display_version",
-        "telemetry_sdk_build",
-        "client_id",
         "seq",
         "start_time",
-        "end_time",
-        "first_run_date"
+        "end_time"
       ]
     },
     "metrics": {

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -1,15 +1,22 @@
 {
   "$schema": "moz://mozilla.org/schemas/glean/ping/1",
-  "ping_info": {
-    "ping_type": "full",
+  "client_info": {
     "app_build": "59f330e5",
     "app_display_version": "1.0.0",
-    "telemetry_sdk_build": "abcdabcd",
+    "architecture": "arm",
     "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "device_manufacturer": "Mozilla",
+    "device_model": "phone123",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "full",
     "seq": 1,
     "start_time": "2018-10-23 11:23:15-04:00",
     "end_time": "2018-10-23 11:23:15-04:25",
-    "first_run_date": "2018-10-23-04:25",
     "experiments": {
       "experiment1": {
         "branch": "branch_a"

--- a/validation/glean/events.1.all.pass.json
+++ b/validation/glean/events.1.all.pass.json
@@ -1,15 +1,22 @@
 {
   "$schema": "moz://mozilla.org/schemas/glean/ping/1",
-  "ping_info": {
-    "ping_type": "full",
+  "client_info": {
     "app_build": "59f330e5",
     "app_display_version": "1.0.0",
-    "telemetry_sdk_build": "abcdabcd",
+    "architecture": "arm",
     "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "device_manufacturer": "Mozilla",
+    "device_model": "phone123",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "full",
     "seq": 1,
     "start_time": "2018-10-23 11:23:15-04:00",
     "end_time": "2018-10-23 11:23:15-04:25",
-    "first_run_date": "2018-10-23-04:25",
     "experiments": {
       "experiment1": {
         "branch": "branch_a"

--- a/validation/glean/metrics.1.all.pass.json
+++ b/validation/glean/metrics.1.all.pass.json
@@ -1,15 +1,22 @@
 {
   "$schema": "moz://mozilla.org/schemas/glean/ping/1",
-  "ping_info": {
-    "ping_type": "full",
+  "client_info": {
     "app_build": "59f330e5",
     "app_display_version": "1.0.0",
-    "telemetry_sdk_build": "abcdabcd",
+    "architecture": "arm",
     "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "device_manufacturer": "Mozilla",
+    "device_model": "phone123",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "full",
     "seq": 1,
     "start_time": "2018-10-23 11:23:15-04:00",
     "end_time": "2018-10-23 11:23:15-04:25",
-    "first_run_date": "2018-10-23-04:25",
     "experiments": {
       "experiment1": {
         "branch": "branch_a"

--- a/validation/glean/metrics.1.null_timespan.fail.json
+++ b/validation/glean/metrics.1.null_timespan.fail.json
@@ -1,15 +1,22 @@
 {
   "$schema": "moz://mozilla.org/schemas/glean/ping/1",
-  "ping_info": {
-    "ping_type": "full",
+  "client_info": {
     "app_build": "59f330e5",
     "app_display_version": "1.0.0",
-    "telemetry_sdk_build": "abcdabcd",
+    "architecture": "arm",
     "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "device_manufacturer": "Mozilla",
+    "device_model": "phone123",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "full",
     "seq": 1,
     "start_time": "2018-10-23 11:23:15-04:00",
-    "end_time": "2018-10-23 11:23:15-04:25",
-    "first_run_date": "2018-10-23-04:25"
+    "end_time": "2018-10-23 11:23:15-04:25"
   },
   "metrics": {
     "timespan": {


### PR DESCRIPTION
This additionally changes fields in `ping_info` and `client_info` to use the glean templates, where available, as done with other metrics. Since we're pre-data-reliance, I'm not bumping the schema version.

@fbertsch should I still add an entry to the changelog?

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
