### PR TITLE
Fix docs to explain how to install parquetfmt from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note that Pioneer studies have a [slightly amended](README.pioneer.md) process.
 
 * [`CMake` (3.0+)](http://cmake.org/cmake/resources/software.html)
 * [`jq` (1.5+)](https://github.com/stedolan/jq)
-* [`parquetfmt` (0.1+)](https://github.com/trink/parquetfmt), available via [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html): `cargo install parquetfmt`
+* [`parquetfmt` (0.1+)](https://github.com/trink/parquetfmt), available via [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html): `cargo install --git https://github.com/trink/parquetfmt`
 * Optional: [Docker](https://www.docker.com/get-started)
   
 On MacOS, these prerequisites can be installed using [homebrew](https://brew.sh/):


### PR DESCRIPTION
parquetfmt is not released on crates.io.
We could either change that or explain how to install it from git.

r?@trink