### PR TITLE
Bug 1530740 - Add "loaded" to activity-stream.impression-stats

### DIFF
--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -17,6 +17,10 @@
       "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
       "type": "string"
     },
+    "loaded": {
+      "description": "An integer to record the size of the loaded 'tiles' list",
+      "type": "integer"
+    },
     "locale": {
       "type": "string"
     },

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -66,6 +66,10 @@
         },
         "required": [ "id" ]
       }
+    },
+    "loaded": {
+      "description": "An integer to record the size of the loaded 'tiles' list",
+      "type": "integer"
     }
   },
   "required": [

--- a/validation/activity-stream/impression-stats.1.loadedContent.pass.json
+++ b/validation/activity-stream/impression-stats.1.loadedContent.pass.json
@@ -1,0 +1,27 @@
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "locale": "en-US",
+  "topic": "activity-stream",
+  "version": "65.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "user_prefs": 63,
+  "page": "about:newtab",
+  "source": "TOP_STORIES",
+  "loaded": 2,
+  "tiles": [
+    {
+      "id": 30001,
+      "pos": 0
+    },
+    {
+      "id": 30002,
+      "pos": 1
+    }
+  ],
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "profile_creation_date": 17817,
+  "region": "US"
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`

This adds an optional integer field "loaded" to `activity-stream.impression-stats`.

r? @jklukas 
