### PR TITLE
Add the optional `android_sdk_version` to glean pings

### DIFF
--- a/schemas/glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/glean/baseline/baseline.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/glean/events/events.1.parquetmr.txt
+++ b/schemas/glean/events/events.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/glean/metrics/metrics.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -12,6 +12,9 @@
     "client_info": {
       "additionalProperties": false,
       "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
         "app_build": {
           "type": "string"
         },

--- a/templates/include/glean/glean.1.parquetmr.txt
+++ b/templates/include/glean/glean.1.parquetmr.txt
@@ -29,6 +29,7 @@ message baseline {
     required binary first_run_date (UTF8);
     required binary os (UTF8);
     required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
     required binary telemetry_sdk_build (UTF8);
   }
   required group ping_info {

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -26,6 +26,7 @@
         "first_run_date": @GLEAN_DATETIME_1_JSON@,
         "os": @GLEAN_STRING_1_JSON@,
         "os_version": @GLEAN_STRING_1_JSON@,
+        "android_sdk_version": @GLEAN_STRING_1_JSON@,
         "telemetry_sdk_build": @GLEAN_STRING_1_JSON@
       },
       "additionalProperties": false,

--- a/validation/glean/metrics.1.all.pass.json
+++ b/validation/glean/metrics.1.all.pass.json
@@ -11,6 +11,7 @@
     "first_run_date": "2018-10-23-04:25",
     "os": "Android",
     "os_version": "3.2.1",
+    "android_sdk_version": "23",
     "telemetry_sdk_build": "abcdabcd"
   },
   "ping_info": {


### PR DESCRIPTION
Please note that the new `android_sdk_version` is optional, as this is an Android specific field.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
