### PR TITLE
Add explicit types to Glean pings

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -7,7 +7,8 @@
     "$schema": {
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
-      ]
+      ],
+      "type": "string"
     },
     "client_info": {
       "additionalProperties": false,
@@ -681,7 +682,8 @@
           },
           "type": "object"
         }
-      }
+      },
+      "type": "object"
     },
     "ping_info": {
       "additionalProperties": false,
@@ -717,7 +719,8 @@
             "maxLength": 30,
             "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
-          }
+          },
+          "type": "object"
         },
         "ping_type": {
           "maxLength": 30,

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -745,7 +745,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "title": "Ping transport",
   "type": "object"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Make `client_info` required.
+
 - Explicit types added for all objects and strings.
 
 - `UUID` was removed from the `metadata` section of the parquet schema.

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Explicit types added for all objects and strings.
+
 - `UUID` was removed from the `metadata` section of the parquet schema.
 
 - The field `clientId` was changed to `client_id` to consistently use snake case

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -6,6 +6,7 @@
   "type": "object",
   "properties": {
     "$schema": {
+      "type": "string",
       "enum": [
         "moz://mozilla.org/schemas/glean/ping/1"
       ]
@@ -53,6 +54,7 @@
         "start_time": @GLEAN_DATETIME_1_JSON@,
         "end_time": @GLEAN_DATETIME_1_JSON@,
         "experiments": {
+          "type": "object",
           "propertyNames": @GLEAN_SHORT_ID_1_JSON@,
           "additionalProperties": {
             "type": "object",
@@ -83,6 +85,7 @@
       ]
     },
     "metrics": {
+      "type": "object",
       "properties": {
         "boolean": {
           @GLEAN_BASE_OBJECT_1_JSON@,

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -239,7 +239,8 @@
     }
   },
   "required": [
-    "ping_info"
+    "ping_info",
+    "client_info"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
This way I can remove this: https://github.com/fbertsch/mozilla-schema-generator/blob/9d27dcc18a31c9c2061282893aeefad4771cedcf/mozilla_schema_generator/glean_ping.py#L33

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
