### PR TITLE
Add `Headless` to Telemetry Environment.

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -641,6 +641,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -645,6 +645,12 @@
                     "null"
                   ]
                 },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "LowEndMachine": {
                   "type": "boolean"
                 },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -515,6 +515,12 @@
                 "null"
               ]
             },
+            "Headless": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "LowEndMachine": {
               "type": "boolean"
             },

--- a/validation/telemetry/main.4.headless.fail.json
+++ b/validation/telemetry/main.4.headless.fail.json
@@ -1,0 +1,35 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4,
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "buildId": "20180509105613",
+      "version": "62.0a1",
+      "vendor": "Mozilla",
+      "platformVersion": "62.0a1",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {},
+    "system": {
+      "gfx": {
+        "Headless": 0
+      }
+    }
+  }
+}

--- a/validation/telemetry/main.4.headless.pass.json
+++ b/validation/telemetry/main.4.headless.pass.json
@@ -1,0 +1,35 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "type": "main",
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "version": 4,
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "buildId": "20180509105613",
+      "version": "62.0a1",
+      "vendor": "Mozilla",
+      "platformVersion": "62.0a1",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {},
+    "system": {
+      "gfx": {
+        "Headless": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes bug 1536175

Might be nice to know if the ping's coming from a headless Firefox.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
