### PR TITLE
Improve schema/template inconsistency check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get -y install cmake jq
+            rm -rf schemas/
             mkdir release
             cd release
             cmake ..


### PR DESCRIPTION
By deleting schemas directory before generating them we can catch those written by hand without a template.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
