### PR TITLE
glean: 1529226: Make client_id optional

### DIFF
--- a/schemas/glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/glean/baseline/baseline.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/glean/events/events.1.parquetmr.txt
+++ b/schemas/glean/events/events.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/glean/metrics/metrics.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-fenix/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/events/events.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -56,7 +56,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Make `client_id` optional.
+
 - Make `client_info` required.
 
 - Explicit types added for all objects and strings.

--- a/templates/include/glean/glean.1.parquetmr.txt
+++ b/templates/include/glean/glean.1.parquetmr.txt
@@ -23,7 +23,7 @@ message baseline {
     required binary app_display_version (UTF8);
     optional binary app_channel (UTF8);
     required binary architecture (UTF8);
-    required binary client_id (UTF8);
+    optional binary client_id (UTF8);
     required binary device_manufacturer (UTF8);
     required binary device_model (UTF8);
     required binary first_run_date (UTF8);

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -35,7 +35,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "client_id",
         "device_manufacturer",
         "device_model",
         "first_run_date",


### PR DESCRIPTION
Use case: custom pings need to be able to be sent without the client_id to preserve privacy.

@fbertsch: Does this require a version bump?

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
