### PR TITLE
Bug 1535717 - Add SPOCS fill telemetry for Activity Stream

### DIFF
--- a/schemas/activity-stream/spocs-fills/spocs-fills.1.schema.json
+++ b/schemas/activity-stream/spocs-fills/spocs-fills.1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "addon_version": {
+      "type": "string"
+    },
+    "impression_id": {
+      "description": "A UUID representing this impression",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
+      "type": "string"
+    },
+    "spoc_fills": {
+      "items": {
+        "properties": {
+          "displayed": {
+            "type": "integer"
+          },
+          "full_recalc": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "reason": {
+            "enum": [
+              "frequency_cap",
+              "blocked_by_user",
+              "below_min_score",
+              "campaign_duplicate",
+              "probability_selection",
+              "n/a"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "displayed",
+          "reason",
+          "full_recalc"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "locale",
+    "version",
+    "addon_version",
+    "release_channel",
+    "spocs_fills"
+  ],
+  "title": "spocs-fills",
+  "type": "object"
+}

--- a/templates/activity-stream/spocs-fills/spocs-fills.1.schema.json
+++ b/templates/activity-stream/spocs-fills/spocs-fills.1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "spocs-fills",
+  "properties": {
+    "impression_id": {
+      "description": "A UUID representing this impression",
+      "type": "string",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "spoc_fills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "displayed": {
+            "type": "integer"
+          },
+          "reason": {
+              "type": "string",
+              "enum": [ "frequency_cap", "blocked_by_user", "below_min_score", "campaign_duplicate", "probability_selection", "n/a" ]
+          },
+          "full_recalc": {
+              "type": "integer"
+          }
+        },
+        "required": [ "id", "displayed", "reason", "full_recalc" ]
+      }
+    }
+  },
+  "required": [
+    "impression_id",
+    "locale",
+    "version",
+    "addon_version",
+    "release_channel",
+    "spocs_fills"
+  ]
+}

--- a/validation/activity-stream/spocs-fills.1.sample.pass.json
+++ b/validation/activity-stream/spocs-fills.1.sample.pass.json
@@ -1,0 +1,48 @@
+{
+  "action": "activity_stream_spocs_fills",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "client_id": "n/a",
+  "locale": "en-US",
+  "topic": "activity-stream",
+  "version": "65.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "spocs_fills": [
+    {
+      "id": 30001,
+      "displayed": 0,
+      "reason": "frequency_cap",
+      "full_recalc": 1
+    },
+    {
+      "id": 30002,
+      "displayed": 0,
+      "reason": "blocked_by_user",
+      "full_recalc": 1
+    },
+    {
+      "id": 30003,
+      "displayed": 0,
+      "reason": "below_min_score",
+      "full_recalc": 1
+    },
+    {
+      "id": 30004,
+      "displayed": 0,
+      "reason": "campaign_duplicate",
+      "full_recalc": 1
+    },
+    {
+      "id": 30005,
+      "displayed": 0,
+      "reason": "probability_selection",
+      "full_recalc": 1
+    },
+    {
+      "id": 30006,
+      "displayed": 1,
+      "reason": "n/a",
+      "full_recalc": 1
+    }
+  ]
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

This adds a new schema (`spocs-fills`) to Activity Stream.

The schema was defined in [bug 1535717](https://bugzilla.mozilla.org/show_bug.cgi?id=1535717#c9).

r? @jklukas 

/cc Kirill, Kenny