### PR TITLE
Add a new enum entry to activity stream spocs fill

### DIFF
--- a/schemas/activity-stream/spocs-fills/spocs-fills.1.schema.json
+++ b/schemas/activity-stream/spocs-fills/spocs-fills.1.schema.json
@@ -38,7 +38,8 @@
               "below_min_score",
               "campaign_duplicate",
               "probability_selection",
-              "n/a"
+              "n/a",
+              "out_of_position"
             ],
             "type": "string"
           }

--- a/templates/activity-stream/spocs-fills/spocs-fills.1.schema.json
+++ b/templates/activity-stream/spocs-fills/spocs-fills.1.schema.json
@@ -37,7 +37,7 @@
           },
           "reason": {
               "type": "string",
-              "enum": [ "frequency_cap", "blocked_by_user", "below_min_score", "campaign_duplicate", "probability_selection", "n/a" ]
+              "enum": [ "frequency_cap", "blocked_by_user", "below_min_score", "campaign_duplicate", "probability_selection", "n/a", "out_of_position" ]
           },
           "full_recalc": {
               "type": "integer"

--- a/validation/activity-stream/spocs-fills.1.sample.pass.json
+++ b/validation/activity-stream/spocs-fills.1.sample.pass.json
@@ -43,6 +43,12 @@
       "displayed": 1,
       "reason": "n/a",
       "full_recalc": 1
+    },
+    {
+      "id": 30007,
+      "displayed": 0,
+      "reason": "out_of_position",
+      "full_recalc": 0
     }
   ]
 }


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

This adds a new enum entry to the `reason` column of the SPOCS Fill in Activity Stream.

r? @jklukas  