### PR TITLE
Make GCP sumbmission_timestamp datetime

### DIFF
--- a/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -102,7 +102,7 @@
     },
     "submission_timestamp": {
       "description": "Time when the ingestion edge server accepted this message",
-      "type": "string"
+      "type": "date-time"
     }
   },
   "required": [

--- a/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -120,7 +120,7 @@
     },
     "submission_timestamp": {
       "description": "Time when the ingestion edge server accepted this message",
-      "type": "string"
+      "type": "date-time"
     }
   },
   "required": [

--- a/templates/include/metadata/ingestionTopLevel.1.schema.json
+++ b/templates/include/metadata/ingestionTopLevel.1.schema.json
@@ -1,5 +1,5 @@
 "submission_timestamp": {
-  "type": "string",
+  "type": "date-time",
   "description": "Time when the ingestion edge server accepted this message"
 },
 "sample_id": {

--- a/templates/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/templates/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "id": "http://jsonschema.net",
   "type": "object",
   "properties": {

--- a/templates/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/templates/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "id": "http://jsonschema.net",
   "type": "object",
   "properties": {

--- a/validation/metadata/structured-ingestion.1.sample.fail.json
+++ b/validation/metadata/structured-ingestion.1.sample.fail.json
@@ -1,0 +1,14 @@
+{
+  "submission_timestamp": "non-datetime string",
+  "metadata": {
+      "geo": {
+          "country": "CA"
+      },
+      "header": {
+          "x_debug_id": "mysession"
+      },
+      "user_agent": {}
+  },
+  "sample_id": 18,
+  "normalized_channel": "release"}
+}

--- a/validation/metadata/structured-ingestion.1.sample.pass.json
+++ b/validation/metadata/structured-ingestion.1.sample.pass.json
@@ -1,0 +1,14 @@
+{
+  "submission_timestamp": "2018-03-12T21:02:18.123456Z",
+  "metadata": {
+      "geo": {
+          "country": "CA"
+      },
+      "header": {
+          "x_debug_id": "mysession"
+      },
+      "user_agent": {}
+  },
+  "sample_id": 18,
+  "normalized_channel": "release"}
+}


### PR DESCRIPTION
This has been added to the jsonschema-transpiler and should fix our schemas deploys.

There's an issue in that we seem to be using v4 of json schemas for testing in this repository. The package we use in beam can use 4, 6, or 7; we'll need to ensure that it correctly verifies with v6.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
