### PR TITLE
Add schema for Firefox for FireTV

### DIFF
--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
@@ -1,0 +1,363 @@
+message baseline {
+  required group metadata {
+    optional binary EnvVersion (UTF8);
+    optional binary Host (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary geoSubdivision1 (UTF8);
+    optional binary geoSubdivision2 (UTF8);
+    optional binary normalizedChannel (UTF8);
+    optional double docVersion;
+    optional int32 Severity;
+    required binary Hostname (UTF8);
+    required binary Logger (UTF8);
+    required binary Type (UTF8);
+    required binary docType (UTF8);
+    required binary documentId (UTF8);
+    required binary geoCity (UTF8);
+    required binary geoCountry (UTF8);
+    required int32 Pid;
+    required int64 Timestamp;
+  }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    optional binary app_channel (UTF8);
+    required binary architecture (UTF8);
+    optional binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
+  required group ping_info {
+    required binary ping_type (UTF8);
+    required int32 seq;
+    required binary start_time (UTF8);
+    required binary end_time (UTF8);
+    optional group experiments (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required binary branch (UTF8);
+          optional group extra (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required binary value (UTF8);
+            }
+          }
+        }
+      }
+    }
+  }
+  optional group metrics {
+    optional group boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required double value;
+      }
+    }
+    optional group labeled_number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required double value;
+          }
+        }
+      }
+    }
+    optional group string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (LIST) {
+          repeated group list {
+            required binary element (UTF8);
+          }
+        }
+      }
+    }
+    optional group labeled_string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value (LIST) {
+              repeated group list {
+                required binary element (UTF8);
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required int64 value;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required int64 value;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required group range (TUPLE) {
+            required double lo;
+            required double hi;
+          }
+          required int64 bucket_count;
+          optional binary histogram_type (UTF8);
+          required group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              optional int64 value;
+            }
+          }
+          optional int64 underflow;
+          optional int64 overflow;
+          optional int64 sum;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required group range (TUPLE) {
+                required double lo;
+                required double hi;
+              }
+              required int64 bucket_count;
+              optional binary histogram_type (UTF8);
+              required group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional int64 value;
+                }
+              }
+              optional int64 underflow;
+              optional int64 overflow;
+              optional int64 sum;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          optional group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required int64 value;
+            }
+          }
+          optional group denominator {
+            optional binary name (UTF8);
+            optional int64 value;
+          }
+        }
+      }
+    }
+    optional group labeled_use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              optional group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  required int64 value;
+                }
+              }
+              optional group denominator {
+                optional binary name (UTF8);
+                optional int64 value;
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+  optional group events (LIST) {
+    repeated group list {
+      required group element {
+        required int64 timestamp;
+        required binary category (UTF8);
+        required binary name (UTF8);
+        optional group extra (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            optional binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -1,0 +1,756 @@
+{
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "additionalProperties": false,
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "properties": {
+    "$schema": {
+      "enum": [
+        "moz://mozilla.org/schemas/glean/ping/1"
+      ],
+      "type": "string"
+    },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
+        "app_build": {
+          "type": "string"
+        },
+        "app_channel": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
+    "events": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "timestamp": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "category",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metrics": {
+      "additionalProperties": false,
+      "properties": {
+        "boolean": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "counter": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "datetime": {
+          "additionalProperties": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "enumeration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_boolean": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_datetime": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "format": "datetime",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_enumeration": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_number": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_rate": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string_list": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timespan": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "value",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timing_distribution": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "bucket_count": {
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "enum": [
+                    "linear",
+                    "exponential"
+                  ]
+                },
+                "overflow": {
+                  "type": "integer"
+                },
+                "range": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "sum": {
+                  "type": "integer"
+                },
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "underflow": {
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "pattern": "[0-9]+"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "range",
+                "bucket_count",
+                "values",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_usage": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_use_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "denominator": {
+                  "name": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "value": {
+                    "type": "integer"
+                  }
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_uuid": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "number": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string_list": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timespan": {
+          "additionalProperties": {
+            "properties": {
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "value": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "value",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timing_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "bucket_count": {
+                "type": "integer"
+              },
+              "histogram_type": {
+                "enum": [
+                  "linear",
+                  "exponential"
+                ]
+              },
+              "overflow": {
+                "type": "integer"
+              },
+              "range": {
+                "items": {
+                  "type": "number"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "sum": {
+                "type": "integer"
+              },
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "underflow": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "range",
+              "bucket_count",
+              "values",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "usage": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "use_counter": {
+          "additionalProperties": {
+            "properties": {
+              "denominator": {
+                "name": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object",
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "uuid": {
+          "additionalProperties": {
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ping_info": {
+      "additionalProperties": false,
+      "properties": {
+        "end_time": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "maxLength": 30,
+                "pattern": "^[a-z_][a-z0-9_]*$",
+                "type": "string"
+              },
+              "extra": {
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "branch"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 30,
+            "pattern": "^[a-z_][a-z0-9_]*$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "ping_type": {
+          "maxLength": 30,
+          "pattern": "^[a-z_][a-z0-9_]*$",
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer"
+        },
+        "start_time": {
+          "format": "datetime",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ping_type",
+        "seq",
+        "start_time",
+        "end_time"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "ping_info",
+    "client_info"
+  ],
+  "title": "Ping transport",
+  "type": "object"
+}

--- a/schemas/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
@@ -1,0 +1,363 @@
+message baseline {
+  required group metadata {
+    optional binary EnvVersion (UTF8);
+    optional binary Host (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary geoSubdivision1 (UTF8);
+    optional binary geoSubdivision2 (UTF8);
+    optional binary normalizedChannel (UTF8);
+    optional double docVersion;
+    optional int32 Severity;
+    required binary Hostname (UTF8);
+    required binary Logger (UTF8);
+    required binary Type (UTF8);
+    required binary docType (UTF8);
+    required binary documentId (UTF8);
+    required binary geoCity (UTF8);
+    required binary geoCountry (UTF8);
+    required int32 Pid;
+    required int64 Timestamp;
+  }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    optional binary app_channel (UTF8);
+    required binary architecture (UTF8);
+    optional binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
+  required group ping_info {
+    required binary ping_type (UTF8);
+    required int32 seq;
+    required binary start_time (UTF8);
+    required binary end_time (UTF8);
+    optional group experiments (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required binary branch (UTF8);
+          optional group extra (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required binary value (UTF8);
+            }
+          }
+        }
+      }
+    }
+  }
+  optional group metrics {
+    optional group boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required double value;
+      }
+    }
+    optional group labeled_number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required double value;
+          }
+        }
+      }
+    }
+    optional group string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (LIST) {
+          repeated group list {
+            required binary element (UTF8);
+          }
+        }
+      }
+    }
+    optional group labeled_string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value (LIST) {
+              repeated group list {
+                required binary element (UTF8);
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required int64 value;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required int64 value;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required group range (TUPLE) {
+            required double lo;
+            required double hi;
+          }
+          required int64 bucket_count;
+          optional binary histogram_type (UTF8);
+          required group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              optional int64 value;
+            }
+          }
+          optional int64 underflow;
+          optional int64 overflow;
+          optional int64 sum;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required group range (TUPLE) {
+                required double lo;
+                required double hi;
+              }
+              required int64 bucket_count;
+              optional binary histogram_type (UTF8);
+              required group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional int64 value;
+                }
+              }
+              optional int64 underflow;
+              optional int64 overflow;
+              optional int64 sum;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          optional group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required int64 value;
+            }
+          }
+          optional group denominator {
+            optional binary name (UTF8);
+            optional int64 value;
+          }
+        }
+      }
+    }
+    optional group labeled_use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              optional group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  required int64 value;
+                }
+              }
+              optional group denominator {
+                optional binary name (UTF8);
+                optional int64 value;
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+  optional group events (LIST) {
+    repeated group list {
+      required group element {
+        required int64 timestamp;
+        required binary category (UTF8);
+        required binary name (UTF8);
+        optional group extra (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            optional binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -1,0 +1,756 @@
+{
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "additionalProperties": false,
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "properties": {
+    "$schema": {
+      "enum": [
+        "moz://mozilla.org/schemas/glean/ping/1"
+      ],
+      "type": "string"
+    },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
+        "app_build": {
+          "type": "string"
+        },
+        "app_channel": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
+    "events": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "timestamp": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "category",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metrics": {
+      "additionalProperties": false,
+      "properties": {
+        "boolean": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "counter": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "datetime": {
+          "additionalProperties": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "enumeration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_boolean": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_datetime": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "format": "datetime",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_enumeration": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_number": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_rate": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string_list": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timespan": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "value",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timing_distribution": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "bucket_count": {
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "enum": [
+                    "linear",
+                    "exponential"
+                  ]
+                },
+                "overflow": {
+                  "type": "integer"
+                },
+                "range": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "sum": {
+                  "type": "integer"
+                },
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "underflow": {
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "pattern": "[0-9]+"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "range",
+                "bucket_count",
+                "values",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_usage": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_use_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "denominator": {
+                  "name": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "value": {
+                    "type": "integer"
+                  }
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_uuid": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "number": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string_list": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timespan": {
+          "additionalProperties": {
+            "properties": {
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "value": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "value",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timing_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "bucket_count": {
+                "type": "integer"
+              },
+              "histogram_type": {
+                "enum": [
+                  "linear",
+                  "exponential"
+                ]
+              },
+              "overflow": {
+                "type": "integer"
+              },
+              "range": {
+                "items": {
+                  "type": "number"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "sum": {
+                "type": "integer"
+              },
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "underflow": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "range",
+              "bucket_count",
+              "values",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "usage": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "use_counter": {
+          "additionalProperties": {
+            "properties": {
+              "denominator": {
+                "name": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object",
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "uuid": {
+          "additionalProperties": {
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ping_info": {
+      "additionalProperties": false,
+      "properties": {
+        "end_time": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "maxLength": 30,
+                "pattern": "^[a-z_][a-z0-9_]*$",
+                "type": "string"
+              },
+              "extra": {
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "branch"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 30,
+            "pattern": "^[a-z_][a-z0-9_]*$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "ping_type": {
+          "maxLength": 30,
+          "pattern": "^[a-z_][a-z0-9_]*$",
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer"
+        },
+        "start_time": {
+          "format": "datetime",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ping_type",
+        "seq",
+        "start_time",
+        "end_time"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "ping_info",
+    "client_info"
+  ],
+  "title": "Ping transport",
+  "type": "object"
+}

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
@@ -1,0 +1,363 @@
+message baseline {
+  required group metadata {
+    optional binary EnvVersion (UTF8);
+    optional binary Host (UTF8);
+    optional binary appUpdateChannel (UTF8);
+    optional binary geoSubdivision1 (UTF8);
+    optional binary geoSubdivision2 (UTF8);
+    optional binary normalizedChannel (UTF8);
+    optional double docVersion;
+    optional int32 Severity;
+    required binary Hostname (UTF8);
+    required binary Logger (UTF8);
+    required binary Type (UTF8);
+    required binary docType (UTF8);
+    required binary documentId (UTF8);
+    required binary geoCity (UTF8);
+    required binary geoCountry (UTF8);
+    required int32 Pid;
+    required int64 Timestamp;
+  }
+  required group client_info {
+    required binary app_build (UTF8);
+    required binary app_display_version (UTF8);
+    optional binary app_channel (UTF8);
+    required binary architecture (UTF8);
+    optional binary client_id (UTF8);
+    required binary device_manufacturer (UTF8);
+    required binary device_model (UTF8);
+    required binary first_run_date (UTF8);
+    required binary os (UTF8);
+    required binary os_version (UTF8);
+    optional binary android_sdk_version (UTF8);
+    required binary telemetry_sdk_build (UTF8);
+  }
+  required group ping_info {
+    required binary ping_type (UTF8);
+    required int32 seq;
+    required binary start_time (UTF8);
+    required binary end_time (UTF8);
+    optional group experiments (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required binary branch (UTF8);
+          optional group extra (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required binary value (UTF8);
+            }
+          }
+        }
+      }
+    }
+  }
+  optional group metrics {
+    optional group boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_boolean (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_string (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required double value;
+      }
+    }
+    optional group labeled_number (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required double value;
+          }
+        }
+      }
+    }
+    optional group string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (LIST) {
+          repeated group list {
+            required binary element (UTF8);
+          }
+        }
+      }
+    }
+    optional group labeled_string_list (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value (LIST) {
+              repeated group list {
+                required binary element (UTF8);
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_enumeration (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required int64 value;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timespan (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required int64 value;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          required group range (TUPLE) {
+            required double lo;
+            required double hi;
+          }
+          required int64 bucket_count;
+          optional binary histogram_type (UTF8);
+          required group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              optional int64 value;
+            }
+          }
+          optional int64 underflow;
+          optional int64 overflow;
+          optional int64 sum;
+          required binary time_unit (UTF8);
+        }
+      }
+    }
+    optional group labeled_timing_distribution (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              required group range (TUPLE) {
+                required double lo;
+                required double hi;
+              }
+              required int64 bucket_count;
+              optional binary histogram_type (UTF8);
+              required group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional int64 value;
+                }
+              }
+              optional int64 underflow;
+              optional int64 overflow;
+              optional int64 sum;
+              required binary time_unit (UTF8);
+            }
+          }
+        }
+      }
+    }
+    optional group datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_datetime (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+    optional group use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value {
+          optional group values (MAP) {
+            repeated group key_value {
+              required binary key (UTF8);
+              required int64 value;
+            }
+          }
+          optional group denominator {
+            optional binary name (UTF8);
+            optional int64 value;
+          }
+        }
+      }
+    }
+    optional group labeled_use_counter (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required group value {
+              optional group values (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  required int64 value;
+                }
+              }
+              optional group denominator {
+                optional binary name (UTF8);
+                optional int64 value;
+              }
+            }
+          }
+        }
+      }
+    }
+    optional group usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required boolean value;
+      }
+    }
+    optional group labeled_usage (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required boolean value;
+          }
+        }
+      }
+    }
+    optional group rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required int64 value;
+      }
+    }
+    optional group labeled_rate (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required int64 value;
+          }
+        }
+      }
+    }
+    optional group uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required binary value (UTF8);
+      }
+    }
+    optional group labeled_uuid (MAP) {
+      repeated group key_value {
+        required binary key (UTF8);
+        required group value (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            required binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+  optional group events (LIST) {
+    repeated group list {
+      required group element {
+        required int64 timestamp;
+        required binary category (UTF8);
+        required binary name (UTF8);
+        optional group extra (MAP) {
+          repeated group key_value {
+            required binary key (UTF8);
+            optional binary value (UTF8);
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -1,0 +1,756 @@
+{
+  "$id": "moz://mozilla.org/schemas/glean/ping/1",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "additionalProperties": false,
+  "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
+  "properties": {
+    "$schema": {
+      "enum": [
+        "moz://mozilla.org/schemas/glean/ping/1"
+      ],
+      "type": "string"
+    },
+    "client_info": {
+      "additionalProperties": false,
+      "properties": {
+        "android_sdk_version": {
+          "type": "string"
+        },
+        "app_build": {
+          "type": "string"
+        },
+        "app_channel": {
+          "type": "string"
+        },
+        "app_display_version": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        },
+        "client_id": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        },
+        "device_manufacturer": {
+          "type": "string"
+        },
+        "device_model": {
+          "type": "string"
+        },
+        "first_run_date": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "os": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "telemetry_sdk_build": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "app_build",
+        "app_display_version",
+        "architecture",
+        "device_manufacturer",
+        "device_model",
+        "first_run_date",
+        "os",
+        "os_version",
+        "telemetry_sdk_build"
+      ],
+      "type": "object"
+    },
+    "events": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "maxLength": 40,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "timestamp": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "category",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metrics": {
+      "additionalProperties": false,
+      "properties": {
+        "boolean": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "counter": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "datetime": {
+          "additionalProperties": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "enumeration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_boolean": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_datetime": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "format": "datetime",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_enumeration": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_number": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_rate": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_string_list": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timespan": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "value",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_timing_distribution": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "bucket_count": {
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "enum": [
+                    "linear",
+                    "exponential"
+                  ]
+                },
+                "overflow": {
+                  "type": "integer"
+                },
+                "range": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "sum": {
+                  "type": "integer"
+                },
+                "time_unit": {
+                  "enum": [
+                    "nanosecond",
+                    "microsecond",
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day"
+                  ]
+                },
+                "underflow": {
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "pattern": "[0-9]+"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "range",
+                "bucket_count",
+                "values",
+                "time_unit"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_usage": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_use_counter": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "properties": {
+                "denominator": {
+                  "name": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "value": {
+                    "type": "integer"
+                  }
+                },
+                "values": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "propertyNames": {
+                    "maxLength": 30,
+                    "pattern": "^[a-z_][a-z0-9_]*$",
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "labeled_uuid": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "number": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "string_list": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timespan": {
+          "additionalProperties": {
+            "properties": {
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "value": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "value",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "timing_distribution": {
+          "additionalProperties": {
+            "properties": {
+              "bucket_count": {
+                "type": "integer"
+              },
+              "histogram_type": {
+                "enum": [
+                  "linear",
+                  "exponential"
+                ]
+              },
+              "overflow": {
+                "type": "integer"
+              },
+              "range": {
+                "items": {
+                  "type": "number"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "sum": {
+                "type": "integer"
+              },
+              "time_unit": {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day"
+                ]
+              },
+              "underflow": {
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "pattern": "[0-9]+"
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "range",
+              "bucket_count",
+              "values",
+              "time_unit"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "usage": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "use_counter": {
+          "additionalProperties": {
+            "properties": {
+              "denominator": {
+                "name": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object",
+                "value": {
+                  "type": "integer"
+                }
+              },
+              "values": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "maxLength": 30,
+                  "pattern": "^[a-z_][a-z0-9_]*$",
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "uuid": {
+          "additionalProperties": {
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ping_info": {
+      "additionalProperties": false,
+      "properties": {
+        "end_time": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "maxLength": 30,
+                "pattern": "^[a-z_][a-z0-9_]*$",
+                "type": "string"
+              },
+              "extra": {
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "branch"
+            ],
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 30,
+            "pattern": "^[a-z_][a-z0-9_]*$",
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "ping_type": {
+          "maxLength": 30,
+          "pattern": "^[a-z_][a-z0-9_]*$",
+          "type": "string"
+        },
+        "seq": {
+          "type": "integer"
+        },
+        "start_time": {
+          "format": "datetime",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ping_type",
+        "seq",
+        "start_time",
+        "end_time"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "ping_info",
+    "client_info"
+  ],
+  "title": "Ping transport",
+  "type": "object"
+}

--- a/templates/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
+++ b/templates/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_TXT@

--- a/templates/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/templates/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_JSON@

--- a/templates/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
+++ b/templates/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_TXT@

--- a/templates/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/templates/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_JSON@

--- a/templates/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
+++ b/templates/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_TXT@

--- a/templates/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/templates/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -1,0 +1,1 @@
+@GLEAN_GLEAN_1_JSON@


### PR DESCRIPTION
This adds basic Glean schemas for Firefox for FireTV (FFTV).  

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
