### PR TITLE
Integer tz for mobile/activation

### DIFF
--- a/schemas/mobile/activation/activation.1.schema.json
+++ b/schemas/mobile/activation/activation.1.schema.json
@@ -56,7 +56,8 @@
       "type": "integer"
     },
     "tz": {
-      "type": "string"
+      "description": "timezone offset in minutes from UTC",
+      "type": "integer"
     }
   },
   "required": [

--- a/templates/mobile/activation/activation.1.schema.json
+++ b/templates/mobile/activation/activation.1.schema.json
@@ -40,7 +40,8 @@
       "type": "integer"
     },
     "tz": {
-      "type": "string"
+      "type": "integer",
+      "description": "timezone offset in minutes from UTC"
     },
     "app_name": {
       "type": "string"

--- a/validation/mobile/activation.1.both_ids.fail.json
+++ b/validation/mobile/activation.1.both_ids.fail.json
@@ -8,7 +8,7 @@
   "os" : "Android",
   "osversion" : "23",
   "created" : "2017-03-16",
-  "tz" : "+08:00",
+  "tz" : 0,
   "app_name": "Fennec",
   "channel": "release"
 }

--- a/validation/mobile/activation.1.sample.pass.json
+++ b/validation/mobile/activation.1.sample.pass.json
@@ -7,7 +7,7 @@
   "os" : "Android",
   "osversion" : "23",
   "created" : "2017-03-16",
-  "tz" : "+08:00",
+  "tz" : -240,
   "app_name": "Fennec",
   "channel": "release"
 }


### PR DESCRIPTION
This makes mobile/activation consistent with existing pings (core
and mobile events) that have an integer "tz" field given in minutes.

This is an incompatible change, but since it's a new ping that's not yet deployed, we can simply delete the existing BQ table before merging and let the machinery recreate it.