### PR TITLE
Glean: allow dotted snake-case for labeled metric labels

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/activation/activation.1.schema.json
+++ b/schemas/org-mozilla-fenix/activation/activation.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -153,7 +153,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -171,7 +172,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -190,7 +192,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -208,7 +211,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -226,7 +230,8 @@
               "type": "number"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -244,7 +249,8 @@
               "type": "integer"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -262,7 +268,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -283,7 +290,8 @@
               "type": "array"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -321,7 +329,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -393,7 +402,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -411,7 +421,8 @@
               "type": "boolean"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -453,7 +464,8 @@
               "type": "object"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -472,7 +484,8 @@
               "type": "string"
             },
             "propertyNames": {
-              "pattern": "^[a-z_][a-z0-9_.]*$",
+              "maxLength": 30,
+              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/templates/include/glean/labeled_group.1.schema.json
+++ b/templates/include/glean/labeled_group.1.schema.json
@@ -1,5 +1,6 @@
 "type": "object",
 "propertyNames": {
   "type": "string",
-  "pattern": "^[a-z_][a-z0-9_.]*$"
+  "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+  "maxLength": 30
 }

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -45,7 +45,8 @@
     "labeled_string": {
       "examples.subcategory.labeled_string_example": {
         "longer_key_1": "ABCD",
-        "an_even_longer_key_2": "EFGH"
+        "an_even_longer_key_2": "EFGH",
+        "a_dotted.key": "IJKL"
       }
     },
     "number": {


### PR DESCRIPTION
Expand the regex pattern for Glean labeled metrics to allow for dotted snakecase.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
