### PR TITLE
Add missing "string" type.

### DIFF
--- a/schemas/eng-workflow/build/build.1.schema.json
+++ b/schemas/eng-workflow/build/build.1.schema.json
@@ -40,7 +40,8 @@
             "clang-cl",
             "gcc",
             "msvc"
-          ]
+          ],
+          "type": "string"
         },
         "debug": {
           "description": "true if build is debug (--enable-debug)",
@@ -127,7 +128,8 @@
             "macos",
             "linux",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         "physical_cores": {
           "description": "Number of physical CPU cores present",

--- a/templates/eng-workflow/build/build.1.schema.json
+++ b/templates/eng-workflow/build/build.1.schema.json
@@ -35,6 +35,7 @@
         },
         "compiler": {
           "description": "The compiler type in use (CC_TYPE)",
+          "type": "string",
           "enum": [
             "clang",
             "clang-cl",
@@ -122,6 +123,7 @@
         },
         "os": {
           "description": "Operating system",
+          "type": "string",
           "enum": [
             "windows",
             "macos",


### PR DESCRIPTION
This fixes the two `eng-workflow` issues [here](https://gist.github.com/acmiyaguchi/bbfb78590f0c5030c87ade879405d73e). In these cases, defaulting to string is the correct thing to do anyways.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
