### PR TITLE
Update prio schema

### DIFF
--- a/schemas/telemetry/prio/prio.4.schema.json
+++ b/schemas/telemetry/prio/prio.4.schema.json
@@ -66,13 +66,15 @@
                 "type": "string"
               },
               "prio": {
-                "a": {
-                  "description": "Shares for server A in base64",
-                  "type": "string"
-                },
-                "b": {
-                  "description": "Shares for server B in base64",
-                  "type": "string"
+                "properties": {
+                  "a": {
+                    "description": "Shares for server A in base64",
+                    "type": "string"
+                  },
+                  "b": {
+                    "description": "Shares for server B in base64",
+                    "type": "string"
+                  }
                 },
                 "type": "object"
               }

--- a/templates/telemetry/prio/prio.4.schema.json
+++ b/templates/telemetry/prio/prio.4.schema.json
@@ -34,13 +34,15 @@
               },
               "prio": {
                 "type": "object",
-                "a": {
-                  "type": "string",
-                  "description": "Shares for server A in base64"
-                },
-                "b": {
+                "properties": {
+                  "a": {
                     "type": "string",
-                    "description": "Shares for server B in base64"
+                    "description": "Shares for server A in base64"
+                  },
+                  "b": {
+                      "type": "string",
+                      "description": "Shares for server B in base64"
+                  }
                 }
               }
             },


### PR DESCRIPTION
This fixes the prio `payload.prioData.prio` field so it conforms to an actual object. Currently, it is casted into a string instead of a repeated struct.

I've dropped the table in `shared-nonprod` in preparation for this PR. 

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
