### PR TITLE
Enable the use of "dashes" in metric labels for Glean

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/activation/activation.1.schema.json
+++ b/schemas/org-mozilla-fenix/activation/activation.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -155,7 +155,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -175,7 +175,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -196,7 +196,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -216,7 +216,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -236,7 +236,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -256,7 +256,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -299,7 +299,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -340,7 +340,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -416,7 +416,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -436,7 +436,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -482,7 +482,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"
@@ -503,7 +503,7 @@
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
               "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
               "type": "string"
             },
             "type": "object"

--- a/templates/include/glean/labeled_group.1.schema.json
+++ b/templates/include/glean/labeled_group.1.schema.json
@@ -1,7 +1,7 @@
 "type": "object",
 "propertyNames": {
   "type": "string",
-  "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z0-9_]{0,29})*$",
+  "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
   "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
   "maxLength": 61
 }

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -46,7 +46,8 @@
       "examples.subcategory.labeled_string_example": {
         "longer_key_1": "ABCD",
         "an_even_longer_key_2": "EFGH",
-        "a_dotted.key": "IJKL"
+        "a_dotted.key": "IJKL",
+        "a-dashed-key.nice": "MNO"
       }
     },
     "number": {


### PR DESCRIPTION
This is the first part of the fix required to deal with [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764).

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
