### PR TITLE
Bug 1567339 - Add parameters to attribution in environment data

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -402,16 +402,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -402,6 +402,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -403,7 +403,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -413,7 +413,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -406,16 +406,18 @@
                 "content": {
                   "type": "string"
                 },
-                "funnel_experiment": {
-                  "type": "string"
-                },
-                "funnel_variation": {
+                "experiment": {
+                  "description": "bug 1567339",
                   "type": "string"
                 },
                 "medium": {
                   "type": "string"
                 },
                 "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -407,7 +407,7 @@
                   "type": "string"
                 },
                 "experiment": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 },
                 "medium": {
@@ -417,7 +417,7 @@
                   "type": "string"
                 },
                 "variation": {
-                  "description": "bug 1567339",
+                  "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"
                 }
               },

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -406,6 +406,12 @@
                 "content": {
                   "type": "string"
                 },
+                "funnel_experiment": {
+                  "type": "string"
+                },
+                "funnel_variation": {
+                  "type": "string"
+                },
                 "medium": {
                   "type": "string"
                 },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -320,6 +320,12 @@
             },
             "content": {
               "type": "string"
+            },
+            "funnel_experiment": {
+              "type": "string"
+            },
+            "funnel_variation": {
+              "type": "string"
             }
           }
         },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -321,11 +321,13 @@
             "content": {
               "type": "string"
             },
-            "funnel_experiment": {
-              "type": "string"
+            "experiment": {
+              "type": "string",
+              "description": "bug 1567339"
             },
-            "funnel_variation": {
-              "type": "string"
+            "variation": {
+              "type": "string",
+              "description": "bug 1567339"
             }
           }
         },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -323,11 +323,11 @@
             },
             "experiment": {
               "type": "string",
-              "description": "bug 1567339"
+              "description": "funnel experiment parameters, see bug 1567339"
             },
             "variation": {
               "type": "string",
-              "description": "bug 1567339"
+              "description": "funnel experiment parameters, see bug 1567339"
             }
           }
         },

--- a/validation/telemetry/main.4.attribution.pass.json
+++ b/validation/telemetry/main.4.attribution.pass.json
@@ -20,8 +20,8 @@
                 "medium": "medium",
                 "campaign": "campaign",
                 "content": "content",
-                "funnel_experiment": "experiment",
-                "funnel_variation": "variation"
+                "experiment": "experiment",
+                "variation": "variation"
             }
         }
     }

--- a/validation/telemetry/main.4.attribution.pass.json
+++ b/validation/telemetry/main.4.attribution.pass.json
@@ -1,0 +1,28 @@
+{
+    "application": {
+        "architecture": "x86-64",
+        "buildId": "20151103030248",
+        "channel": "beta",
+        "name": "Firefox",
+        "platformVersion": "45.0",
+        "vendor": "Mozilla",
+        "version": "45.0",
+        "xpcomAbi": "x86_64-gcc3"
+    },
+    "creationDate": "2015-11-05T01:25:43.312Z",
+    "type": "main",
+    "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+    "version": 4,
+    "payload": {
+        "environment": {
+            "attribution": {
+                "source": "source",
+                "medium": "medium",
+                "campaign": "campaign",
+                "content": "content",
+                "funnel_experiment": "experiment",
+                "funnel_variation": "variation"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1567339)

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)