### PR TITLE
Remove 'source' from the required fields for impression-stats

### DIFF
--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -81,7 +81,6 @@
     "impression_id",
     "addon_version",
     "locale",
-    "source",
     "page",
     "user_prefs",
     "tiles"

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -76,7 +76,6 @@
     "impression_id",
     "addon_version",
     "locale",
-    "source",
     "page",
     "user_prefs",
     "tiles"

--- a/validation/activity-stream/impression-stats.1.save-to-pocket.pass.json
+++ b/validation/activity-stream/impression-stats.1.save-to-pocket.pass.json
@@ -1,0 +1,20 @@
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "locale": "en-US",
+  "topic": "activity-stream",
+  "version": "70.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20190702095435",
+  "user_prefs": 239,
+  "page": "about:newtab",
+  "pocket": 0,
+  "tiles": [
+    {
+      "id": 30001,
+      "pos": 0
+    }
+  ],
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}"
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

Duplicate of #359, which was accidentally pointed at dev rather than master.
