### PR TITLE
Update edge validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   edge-validator:
     docker:
-      - image: mozilla/edge-validator:v1.3.1
+      - image: mozilla/edge-validator:v1.4.0
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
 
             # Run the comparison report and store the artifacts for future viewing.
             pipenv run \
-              python integration.py compare \
+              python integration.py sync compare \
                 --report-path test-reports \
                 $upstream_short_id $head_short_id
       - store_artifacts: &store_artifacts


### PR DESCRIPTION
This should fix empty integration reports occurring due to bad sampled data at the edge.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
