### PR TITLE
Fix #363 - Update `payload.info` in main ping schema

### DIFF
--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1115,8 +1115,71 @@
         },
         "info": {
           "properties": {
-            "subsessionLength": {
+            "previousBuildId": {
+              "description": "null if this is the first run, or the previous build ID is unknown",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSessionId": {
+              "description": "session id of the previous session, null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSubsessionId": {
+              "description": "subsession id of the previous subsession (even if it was in a different session), null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profileSubsessionCounter": {
+              "description": "the running no. of all subsessions for the whole profile life time",
               "minimum": 0,
+              "type": "integer"
+            },
+            "reason": {
+              "description": "what triggered this ping e.g. saved-session, environment-change, shutdown, ...",
+              "type": "string"
+            },
+            "revision": {
+              "description": "the Histograms.json revision",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "random session id, shared by subsessions",
+              "type": "string"
+            },
+            "sessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "subsessionCounter": {
+              "description": "the running no. of this subsession since the start of the browser session",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "subsessionId": {
+              "description": "random subsession id",
+              "type": "string"
+            },
+            "subsessionLength": {
+              "description": "the session length until now in seconds, monotonic",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "subsessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "timezoneOffset": {
+              "description": "time-zone offset from UTC, in minutes, for the current locale",
               "type": [
                 "integer",
                 "null"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1115,8 +1115,71 @@
         },
         "info": {
           "properties": {
-            "subsessionLength": {
+            "previousBuildId": {
+              "description": "null if this is the first run, or the previous build ID is unknown",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSessionId": {
+              "description": "session id of the previous session, null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSubsessionId": {
+              "description": "subsession id of the previous subsession (even if it was in a different session), null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profileSubsessionCounter": {
+              "description": "the running no. of all subsessions for the whole profile life time",
               "minimum": 0,
+              "type": "integer"
+            },
+            "reason": {
+              "description": "what triggered this ping e.g. saved-session, environment-change, shutdown, ...",
+              "type": "string"
+            },
+            "revision": {
+              "description": "the Histograms.json revision",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "random session id, shared by subsessions",
+              "type": "string"
+            },
+            "sessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "subsessionCounter": {
+              "description": "the running no. of this subsession since the start of the browser session",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "subsessionId": {
+              "description": "random subsession id",
+              "type": "string"
+            },
+            "subsessionLength": {
+              "description": "the session length until now in seconds, monotonic",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "subsessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "timezoneOffset": {
+              "description": "time-zone offset from UTC, in minutes, for the current locale",
               "type": [
                 "integer",
                 "null"

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -47,9 +47,60 @@
     "info": {
       "type": "object",
       "properties": {
+        "previousBuildId": {
+          "type": ["string", "null"],
+          "description": "null if this is the first run, or the previous build ID is unknown"
+        },
+        "previousSessionId": {
+          "type": ["string", "null"],
+          "description": "session id of the previous session, null on first run."
+        },
+        "previousSubsessionId": {
+          "type": ["string", "null"],
+          "description": "subsession id of the previous subsession (even if it was in a different session), null on first run."
+        },
+        "profileSubsessionCounter": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "the running no. of all subsessions for the whole profile life time"
+        },
+        "reason": {
+          "type": "string",
+          "description": "what triggered this ping e.g. saved-session, environment-change, shutdown, ..."
+        },
+        "revision": {
+          "type": "string",
+          "description": "the Histograms.json revision"
+        },
+        "sessionId": {
+          "type": "string",
+          "description": "random session id, shared by subsessions"
+        },
         "subsessionLength": {
           "type": [ "integer", "null" ],
-          "minimum": 0
+          "minimum": 0,
+          "description": "the session length until now in seconds, monotonic"
+        },
+        "sessionStartDate": {
+          "type": "string",
+          "description": "hourly precision, ISO date in local time"
+        },
+        "subsessionCounter": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "the running no. of this subsession since the start of the browser session"
+        },
+        "subsessionId": {
+          "type": "string",
+          "description": "random subsession id"
+        },
+        "subsessionStartDate": {
+          "type": "string",
+          "description": "hourly precision, ISO date in local time"
+        },
+        "timezoneOffset": {
+          "type": ["integer", "null"],
+          "description": "time-zone offset from UTC, in minutes, for the current locale"
         }
       }
     },


### PR DESCRIPTION
This fixes #363 using the environment information on [this page](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html). I've also checked the additionalProperties to double check the types of each of the fields. The table in [this issue](https://github.com/mozilla/gcp-ingestion/issues/711#issue-472594034) shows the types and frequency of each field.

I left out `addons` and `flashVersion` because the docs say the fields are obsolete. Based on the data, it seems that they're being reported by a significant number of clients. It might be useful to add here just to increase the coverage of the schema and to reduce the size of additional properties.

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
