### PR TITLE
Remove labeled timespan

### DIFF
--- a/schemas/glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/glean/baseline/baseline.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/glean/events/events.1.parquetmr.txt
+++ b/schemas/glean/events/events.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/glean/metrics/metrics.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/activation/activation.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/activation/activation.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/activation/activation.1.schema.json
+++ b/schemas/org-mozilla-fenix/activation/activation.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/events/events.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/history_sync/history_sync.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/history_sync/history_sync.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/events/events.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/baseline/baseline.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/events/events.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/events/events.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/events/events.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-samples-glean/metrics/metrics.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.parquetmr.txt
@@ -172,20 +172,6 @@ message baseline {
         }
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            required group value {
-              required int64 value;
-              required binary time_unit (UTF8);
-            }
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -311,47 +311,6 @@
           },
           "type": "object"
         },
-        "labeled_timespan": {
-          "additionalProperties": {
-            "additionalProperties": {
-              "properties": {
-                "time_unit": {
-                  "enum": [
-                    "nanosecond",
-                    "microsecond",
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day"
-                  ],
-                  "type": "string"
-                },
-                "value": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "value",
-                "time_unit"
-              ],
-              "type": "object"
-            },
-            "propertyNames": {
-              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
-              "pattern": "^[a-z_][a-z0-9_-]{0,29}(\\.[a-z0-9_-]{0,29})*$",
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
-          "type": "object"
-        },
         "labeled_timing_distribution": {
           "additionalProperties": {
             "additionalProperties": {

--- a/templates/include/glean/glean.1.parquetmr.txt
+++ b/templates/include/glean/glean.1.parquetmr.txt
@@ -161,17 +161,6 @@ message baseline {
         @GLEAN_TIMESPAN_1_TXT@
       }
     }
-    optional group labeled_timespan (MAP) {
-      repeated group key_value {
-        required binary key (UTF8);
-        required group value (MAP) {
-          repeated group key_value {
-            required binary key (UTF8);
-            @GLEAN_TIMESPAN_1_TXT@
-          }
-        }
-      }
-    }
     optional group timing_distribution (MAP) {
       repeated group key_value {
         required binary key (UTF8);
@@ -226,7 +215,7 @@ message baseline {
     optional group usage (MAP) {
       repeated group key_value {
         required binary key (UTF8);
-        @GLEAN_USAGE_1_TXT@ 
+        @GLEAN_USAGE_1_TXT@
       }
     }
     optional group labeled_usage (MAP) {

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -156,13 +156,6 @@
           @GLEAN_BASE_OBJECT_1_JSON@,
           "additionalProperties": @GLEAN_TIMESPAN_1_JSON@
         },
-        "labeled_timespan": {
-          @GLEAN_BASE_OBJECT_1_JSON@,
-          "additionalProperties": {
-            @GLEAN_LABELED_GROUP_1_JSON@,
-            "additionalProperties": @GLEAN_TIMESPAN_1_JSON@
-          }
-        },
         "timing_distribution": {
           @GLEAN_BASE_OBJECT_1_JSON@,
           "additionalProperties": @GLEAN_TIMING_DISTRIBUTION_1_JSON@

--- a/validation/glean/baseline.1.all.pass.json
+++ b/validation/glean/baseline.1.all.pass.json
@@ -97,18 +97,6 @@
         "time_unit": "second"
       }
     },
-    "labeled_timespan": {
-      "examples.labeled_timespan_example": {
-        "a": {
-          "value": 2,
-          "time_unit": "second"
-        },
-        "b": {
-          "value": 32,
-          "time_unit": "millisecond"
-        }
-      }
-    },
     "timing_distribution": {
       "examples.timing_distribution_example": {
         "range": [


### PR DESCRIPTION
We are currently removing support for it.
I did the research and it seems to never have been in use anywhere:
* I looked through the code bases of Fenix, a-c & reference-browser. Except for Glean itself in tests, no `labeled_timespan` was used
* I looked through the data available in parquet tables for Fenix, Fenix Nightly, Reference browser, the sample app and Firefox for FireTV. None contained any labeled timespan data.

cc @Dexterp37, @mdboom (can't add them as reviewers)

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
