### PR TITLE
Add new scalar data to new-profile ping schema

### DIFF
--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1019,6 +1019,303 @@
     },
     "payload": {
       "properties": {
+        "processes": {
+          "properties": {
+            "parent": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "reason": {
           "enum": [
             "shutdown",

--- a/templates/telemetry/new-profile/new-profile.4.schema.json
+++ b/templates/telemetry/new-profile/new-profile.4.schema.json
@@ -17,6 +17,12 @@
             "shutdown",
             "startup"
             ]
+        },
+        "processes": {
+          "type": "object",
+          "properties": {
+            "parent": { @TELEMETRY_PROCESSDATA_1_JSON@ }
+          }
         }
       },
       "required": [

--- a/validation/telemetry/new-profile.4.sample.pass.json
+++ b/validation/telemetry/new-profile.4.sample.pass.json
@@ -15,7 +15,14 @@
     "channel" : "default"
   },
   "payload" : {
-    "reason" : "shutdown"
+    "reason" : "shutdown",
+    "processes": {
+      "parent": {
+        "scalars": {
+          "startup.profile_selection_reason": "argument-profile"
+        }
+      }
+    }
   },
   "clientId" : "f7bb4848-17ca-4e5d-bec8-e8905a8ea35e",
   "environment" : {


### PR DESCRIPTION
This explicitely leaves out changes to the parquet schema, as we still
don't have a good way to coerce potentially different data types (numbers, strings, booleans) into a single type.
(Even though for now it's definitely only a string in the new-profile ping)

m-c Patch: https://bugzilla.mozilla.org/show_bug.cgi?id=1570652
This should land first so that we're sure we don't break any data in the pipeline (though everything in the payload is optional already)

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
