### PR TITLE
Fixups to metadata schemas for payload_bytes tables

### DIFF
--- a/schemas/metadata/decoded/decoded.1.schema.json
+++ b/schemas/metadata/decoded/decoded.1.schema.json
@@ -2,8 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "http://jsonschema.net",
   "properties": {
-    "additional_properties": {
-      "description": "A JSON string containing any payload properties not present in the schema",
+    "client_id": {
       "type": "string"
     },
     "document_id": {

--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -5,6 +5,9 @@
     "args": {
       "type": "string"
     },
+    "client_id": {
+      "type": "string"
+    },
     "content_length": {
       "type": "string"
     },
@@ -12,6 +15,15 @@
       "type": "string"
     },
     "dnt": {
+      "type": "string"
+    },
+    "document_namespace": {
+      "type": "string"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "document_version": {
       "type": "string"
     },
     "error_message": {

--- a/templates/include/metadata/additionalProperties.1.schema.json
+++ b/templates/include/metadata/additionalProperties.1.schema.json
@@ -1,0 +1,4 @@
+"additional_properties": {
+  "type": "string",
+  "description": "A JSON string containing any payload properties not present in the schema"
+}

--- a/templates/include/metadata/ingestionTopLevel.1.schema.json
+++ b/templates/include/metadata/ingestionTopLevel.1.schema.json
@@ -29,8 +29,4 @@
 "normalized_country_code": {
   "type": "string",
   "description": "An ISO 3166-1 alpha-2 country code"
-},
-"additional_properties": {
-  "type": "string",
-  "description": "A JSON string containing any payload properties not present in the schema"
 }

--- a/templates/metadata/decoded/decoded.1.schema.json
+++ b/templates/metadata/decoded/decoded.1.schema.json
@@ -4,6 +4,9 @@
   "type": "object",
   "properties": {
     @METADATA_TELEMETRYINGESTION_1_JSON@,
+    "client_id": {
+      "type": "string"
+    },
     "payload": {
       "format": "bytes",
       "type": "string"

--- a/templates/metadata/error/error.1.schema.json
+++ b/templates/metadata/error/error.1.schema.json
@@ -4,6 +4,18 @@
   "type": "object",
   "properties": {
     @METADATA_RAW_1_JSON@,
+    "client_id": {
+      "type": "string"
+    },
+    "document_namespace": {
+      "type": "string"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "document_version": {
+      "type": "string"
+    },
     "error_message": {
       "type": "string"
     },

--- a/templates/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/templates/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -4,6 +4,7 @@
   "type": "object",
   "properties": {
     @METADATA_INGESTIONTOPLEVEL_1_JSON@,
+    @METADATA_ADDITIONALPROPERTIES_1_JSON@,
     "metadata": {
       "type": "object",
       "properties": {

--- a/templates/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/templates/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -3,7 +3,8 @@
   "id": "http://jsonschema.net",
   "type": "object",
   "properties": {
-    @METADATA_TELEMETRYINGESTION_1_JSON@
+    @METADATA_TELEMETRYINGESTION_1_JSON@,
+    @METADATA_ADDITIONALPROPERTIES_1_JSON@
   },
   "required": [
     "submission_timestamp",


### PR DESCRIPTION
We factor out additional_properties, which is not needed for payload_bytes
tables. We also include client_id and docType, etc. where those might be
available in the pipeline.