### PR TITLE
Add a Telemetry schema for Firefox Voice

### DIFF
--- a/schemas/telemetry/voice/voice-feedback.1.schema.json
+++ b/schemas/telemetry/voice/voice-feedback.1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "payload": {
+      "properties": {
+        "feedback": {
+          "title": "Any free-text feedback given by the user",
+          "type": "string"
+        },
+        "intentId": {
+          "title": "A unique random ID specific to the past intent execution",
+          "type": "string"
+        },
+        "rating": {
+          "title": "The rating given by the user, -1 (thumbs-down), 0, 1 (thums-up)",
+          "type": "number"
+        },
+        "timestamp": {
+          "minimum": 0,
+          "title": "Milliseconds-since-the-epoch when feedback was submitted",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "voice-feedback"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 1,
+      "minimum": 1,
+      "type": "number"
+    }
+  },
+  "required": [
+    "id",
+    "payload",
+    "type",
+    "version"
+  ],
+  "title": "voice-feedback",
+  "type": "object"
+}

--- a/schemas/telemetry/voice/voice.1.parquetmr.txt
+++ b/schemas/telemetry/voice/voice.1.parquetmr.txt
@@ -1,0 +1,51 @@
+message voice {
+  required binary id (UTF8);
+  optional binary clientId (UTF8);
+  required group metadata {
+    required int64 Timestamp;
+    required binary submissionDate (UTF8);
+    optional binary Date (UTF8);
+    optional binary normalizedChannel (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary geoCity (UTF8);
+  }
+  optional group application {
+    optional binary name (UTF8);
+  }
+  optional group environment {
+    optional group system {
+      optional group os {
+        optional binary name (UTF8);
+        optional binary version (UTF8);
+      }
+    }
+  }
+  optional group payload {
+    optional binary extension_version (UTF8);
+    optional boolean extension_temporary_install;
+    optional binary extension_installation_channel (UTF8);
+    optional binary site_category_opened (UTF8);
+    optional binary site_category_triggering (UTF8);
+    optional int64 input_length;
+    optional boolean has_card;
+    optional boolean input_cancelled;
+    optional boolean input_typed;
+    optional binary intent_category (UTF8);
+    optional binary intent (UTF8);
+    optional boolean intent_fallback;
+    optional binary intent_extension_id (UTF8);
+    optional binary intent_extension_version (UTF8);
+    optional float intent_confidence;
+    optional boolean intent_parsed;
+    optional boolean intent_success;
+    optional binary intent_service_name (UTF8);
+    optional binary internal_error (UTF8);
+    optional binary server_error_intent (UTF8);
+    optional binary server_error_speech (UTF8);
+    optional float server_time_speech;
+    optional float server_time_intent;
+    optional binary server_version (UTF8);
+    optional float transcription_confidence;
+    optional int64 timestamp;
+  }
+}

--- a/schemas/telemetry/voice/voice.1.schema.json
+++ b/schemas/telemetry/voice/voice.1.schema.json
@@ -1,0 +1,1206 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "properties": {
+            "activeAddons": {
+              "additionalProperties": {
+                "properties": {
+                  "appDisabled": {
+                    "type": "boolean"
+                  },
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "foreignInstall": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "hasBinaryComponents": {
+                    "type": "boolean"
+                  },
+                  "installDay": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "isSystem": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "signedState": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": [
+                      "boolean",
+                      "integer"
+                    ]
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activeExperiment": {
+              "properties": {
+                "branch": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "activeGMPlugins": {
+              "additionalProperties": {
+                "properties": {
+                  "applyBackgroundUpdates": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activePlugins": {
+              "items": {
+                "properties": {
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "clicktoplay": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "mimeTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "type": "integer"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "persona": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "properties": {
+                "appDisabled": {
+                  "type": "boolean"
+                },
+                "blocklisted": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "foreignInstall": {
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                },
+                "hasBinaryComponents": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "installDay": {
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "integer"
+                },
+                "updateDay": {
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "userDisabled": {
+                  "type": "boolean"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "build": {
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            },
+            "applicationName": {
+              "type": "string"
+            },
+            "architecture": {
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "type": "string"
+            },
+            "buildId": {
+              "pattern": "^[0-9]{10}",
+              "type": "string"
+            },
+            "displayVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "hotfixVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platformVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "updaterAvailable": {
+              "type": "boolean"
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "version": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "xpcomAbi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ],
+          "type": "object"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "partner": {
+          "properties": {
+            "distributionId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "type": "number"
+            },
+            "firstUseDate": {
+              "type": "number"
+            },
+            "isStubProfile": {
+              "type": "boolean"
+            },
+            "resetDate": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "addonCompatibilityCheckEnabled": {
+              "type": "boolean"
+            },
+            "attribution": {
+              "properties": {
+                "campaign": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "experiment": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                },
+                "medium": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "blocklistEnabled": {
+              "type": "boolean"
+            },
+            "defaultSearchEngine": {
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "e10sEnabled": {
+              "type": "boolean"
+            },
+            "e10sMultiProcesses": {
+              "description": "maximum number of processes that will be launched for regular web content",
+              "type": "integer"
+            },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "isDefaultBrowser": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "launcherProcessState": {
+              "type": "integer"
+            },
+            "locale": {
+              "type": "string"
+            },
+            "sandbox": {
+              "properties": {
+                "effectiveContentProcessLevel": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "searchCohort": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "telemetryEnabled": {
+              "type": "boolean"
+            },
+            "update": {
+              "properties": {
+                "autoDownload": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "userPrefs": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "system": {
+          "properties": {
+            "appleModelId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu": {
+              "properties": {
+                "cores": {
+                  "maximum": 2048,
+                  "minimum": 1,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "maximum": 1024,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "extensions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "family": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "l2cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "l3cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "model": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "speedMHz": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "stepping": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "vendor": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "device": {
+              "properties": {
+                "hardware": {
+                  "type": "string"
+                },
+                "isTablet": {
+                  "type": "boolean"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "gfx": {
+              "properties": {
+                "D2DEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "LowEndMachine": {
+                  "type": "boolean"
+                },
+                "adapters": {
+                  "items": {
+                    "properties": {
+                      "GPUActive": {
+                        "type": "boolean"
+                      },
+                      "RAM": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVersion": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "subsysID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "vendorID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "features": {
+                  "properties": {
+                    "advancedLayers": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "compositor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "d2d": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "d3d11": {
+                      "properties": {
+                        "blacklisted": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "textureSharing": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "warp": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "gpuProcess": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "monitors": {
+                  "items": {
+                    "properties": {
+                      "pseudoDisplay": {
+                        "type": "boolean"
+                      },
+                      "refreshRate": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": "number"
+                      },
+                      "screenHeight": {
+                        "type": "integer"
+                      },
+                      "screenWidth": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "hdd": {
+              "properties": {
+                "binary": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "profile": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "system": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "isWow64": {
+              "type": "boolean"
+            },
+            "memoryMB": {
+              "type": "number"
+            },
+            "os": {
+              "properties": {
+                "installYear": {
+                  "type": "number"
+                },
+                "kernelVersion": {
+                  "type": "string"
+                },
+                "locale": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "type": "number"
+                },
+                "version": {
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                },
+                "windowsBuildNumber": {
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "sec": {
+              "properties": {
+                "antispyware": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "antivirus": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "firewall": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "virtualMaxMB": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "extensionInstallationChannel": {
+          "description": "Where the user first installed the extension (e.g., internal_beta, external_beta, etc)",
+          "title": "First install channel",
+          "type": "string"
+        },
+        "extensionTemporaryInstall": {
+          "description": "When the extension is installed locally for development, this will be true",
+          "title": "Temporary Install?",
+          "type": "boolean"
+        },
+        "extensionVersion": {
+          "title": "Firefox Voice extension version",
+          "type": "string"
+        },
+        "hasCard": {
+          "title": "Does the intent produce a card-like output?",
+          "type": "boolean"
+        },
+        "inputCancelled": {
+          "title": "Was the interaction cancelled?",
+          "type": "boolean"
+        },
+        "inputLength": {
+          "minumum": 0,
+          "title": "Number of characters in text/voice input",
+          "type": "integer"
+        },
+        "inputTyped": {
+          "title": "Was the input typed on the keyboard?",
+          "type": "boolean"
+        },
+        "intent": {
+          "description": "This should begin with intent_category.exact_intent",
+          "title": "Full name of the intent handler",
+          "type": "string"
+        },
+        "intentCategory": {
+          "title": "Category of the intent handler",
+          "type": "string"
+        },
+        "intentConfidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence of the intent parsing",
+          "type": "number"
+        },
+        "intentExtensionId": {
+          "description": "If intent was handled by another extension, the id of that extension",
+          "title": "ID of second extension that handled intent",
+          "type": "string"
+        },
+        "intentExtensionVersion": {
+          "description": "The self-reported title of an extension that handled the intent",
+          "title": "Title of second extension",
+          "type": "string"
+        },
+        "intentExtraData": {
+          "description": "A specific intent can add information here about how it interepreted the command",
+          "title": "Ad hoc intent-specific data",
+          "type": "object"
+        },
+        "intentFallback": {
+          "description": "True if we couldn't parse the intent to some exact handler, and just fell back on something generic like search",
+          "title": "Was this a fallback intent handler?",
+          "type": "boolean"
+        },
+        "intentId": {
+          "title": "A unique random ID specific to this intent execution",
+          "type": "string"
+        },
+        "intentParseSuccess": {
+          "title": "Was this intent parsed successfully?",
+          "type": "boolean"
+        },
+        "intentServiceName": {
+          "description": "If an intent used some external service, what service did it choose?",
+          "title": "What service did the intent handler use?",
+          "type": "string"
+        },
+        "intentSuccess": {
+          "description": "This is the self-reported success of the intent handler",
+          "title": "Was the intent action successful?",
+          "type": "boolean"
+        },
+        "internalError": {
+          "title": "If there was an unexpected error, the name of that error",
+          "type": "string"
+        },
+        "serverErrorIntentParser": {
+          "title": "Error with the server intent parser",
+          "type": "string"
+        },
+        "serverErrorSpeech": {
+          "title": "Error with the server speech-to-text parser",
+          "type": "string"
+        },
+        "serverTimeIntentParser": {
+          "minimum": 0,
+          "title": "Time in milliseconds for server intent parsing",
+          "type": "number"
+        },
+        "serverTimeSpeech": {
+          "minimum": 0,
+          "title": "Time in milliseconds for server TTS",
+          "type": "number"
+        },
+        "serverVersion": {
+          "title": "Server version",
+          "type": "string"
+        },
+        "siteCategoryOpened": {
+          "title": "Category of site opened by intent",
+          "type": "string"
+        },
+        "siteCategoryTriggering": {
+          "description": "This only set if the intent dependent on the current tab in some way",
+          "title": "Category of site of active tab when started",
+          "type": "string"
+        },
+        "timestamp": {
+          "minimum": 0,
+          "title": "Milliseconds-since-the-epoch when intent was started",
+          "type": "number"
+        },
+        "transcriptionConfidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence of text-to-speech transcription",
+          "type": "number"
+        },
+        "utterance": {
+          "description": "This is the actual text the user spoke",
+          "title": "Text utterance by user",
+          "type": "string"
+        },
+        "utteranceParsed": {
+          "description": "Typically the slots found in the utterance",
+          "title": "Parsed form of the utterance",
+          "type": "object"
+        }
+      },
+      "required": [
+        "extensionVersion",
+        "extensionTemporaryInstall",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "voice"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 1,
+      "minimum": 1,
+      "type": "number"
+    }
+  },
+  "required": [
+    "application",
+    "clientId",
+    "creationDate",
+    "environment",
+    "id",
+    "payload",
+    "type",
+    "version"
+  ],
+  "title": "voice",
+  "type": "object"
+}

--- a/templates/telemetry/voice/voice-feedback.1.schema.json
+++ b/templates/telemetry/voice/voice-feedback.1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "voice-feedback",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "properties": {
+        "intentId": {
+          "title": "A unique random ID specific to the past intent execution",
+          "type": "string"
+        },
+        "rating": {
+          "title": "The rating given by the user, -1 (thumbs-down), 0, 1 (thums-up)",
+          "type": "number"
+        },
+        "feedback": {
+          "title": "Any free-text feedback given by the user",
+          "type": "string"
+        },
+        "timestamp": {
+          "title": "Milliseconds-since-the-epoch when feedback was submitted",
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "type": {
+      "type": "string",
+      "enum": ["voice-feedback"]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 1,
+      "maximum": 1
+    }
+  },
+  "required": ["id", "payload", "type", "version"]
+}

--- a/templates/telemetry/voice/voice.1.parquetmr.txt
+++ b/templates/telemetry/voice/voice.1.parquetmr.txt
@@ -1,0 +1,51 @@
+message voice {
+  required binary id (UTF8);
+  optional binary clientId (UTF8);
+  required group metadata {
+    required int64  Timestamp;
+    required binary submissionDate (UTF8);
+    optional binary Date (UTF8);
+    optional binary normalizedChannel (UTF8);
+    optional binary geoCountry (UTF8);
+    optional binary geoCity (UTF8);
+  }
+  optional group application {
+    optional binary name (UTF8);
+  }
+  optional group environment {
+    optional group system {
+      optional group os {
+        optional binary name (UTF8);
+        optional binary version (UTF8);
+      }
+    }
+  }
+  optional group payload {
+    optional binary extension_version (UTF8);
+    optional boolean extension_temporary_install;
+    optional binary extension_installation_channel (UTF8);
+    optional binary site_category_opened (UTF8);
+    optional binary site_category_triggering (UTF8);
+    optional int64 input_length;
+    optional boolean has_card;
+    optional boolean input_cancelled;
+    optional boolean input_typed;
+    optional binary intent_category (UTF8);
+    optional binary intent (UTF8);
+    optional boolean intent_fallback;
+    optional binary intent_extension_id (UTF8);
+    optional binary intent_extension_version (UTF8);
+    optional float intent_confidence;
+    optional boolean intent_parsed;
+    optional boolean intent_success;
+    optional binary intent_service_name (UTF8);
+    optional binary internal_error (UTF8);
+    optional binary server_error_intent (UTF8);
+    optional binary server_error_speech (UTF8);
+    optional float server_time_speech;
+    optional float server_time_intent;
+    optional binary server_version (UTF8);
+    optional float transcription_confidence;
+    optional int64 timestamp;
+  }
+}

--- a/templates/telemetry/voice/voice.1.schema.json
+++ b/templates/telemetry/voice/voice.1.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "voice",
+  "properties": {
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CLIENTID_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_ENVIRONMENT_1_JSON@,
+    @TELEMETRY_ID_1_JSON@,
+    "payload": {
+      "type": "object",
+      "properties": {
+        "intentId": {
+          "title": "A unique random ID specific to this intent execution",
+          "type": "string"
+        },
+        "extensionVersion": {
+          "title": "Firefox Voice extension version",
+          "type": "string"
+        },
+        "extensionTemporaryInstall": {
+          "title": "Temporary Install?",
+          "description": "When the extension is installed locally for development, this will be true",
+          "type": "boolean"
+        },
+        "extensionInstallationChannel": {
+          "title": "First install channel",
+          "description": "Where the user first installed the extension (e.g., internal_beta, external_beta, etc)",
+          "type": "string"
+        },
+        "siteCategoryOpened": {
+          "title": "Category of site opened by intent",
+          "type": "string"
+        },
+        "siteCategoryTriggering": {
+          "title": "Category of site of active tab when started",
+          "description": "This only set if the intent dependent on the current tab in some way",
+          "type": "string"
+        },
+        "inputLength": {
+          "title": "Number of characters in text/voice input",
+          "type": "integer",
+          "minumum": 0
+        },
+        "hasCard": {
+          "title": "Does the intent produce a card-like output?",
+          "type": "boolean"
+        },
+        "inputCancelled": {
+          "title": "Was the interaction cancelled?",
+          "type": "boolean"
+        },
+        "inputTyped": {
+          "title": "Was the input typed on the keyboard?",
+          "type": "boolean"
+        },
+        "intentCategory": {
+          "title": "Category of the intent handler",
+          "type": "string"
+        },
+        "intent": {
+          "title": "Full name of the intent handler",
+          "description": "This should begin with intent_category.exact_intent",
+          "type": "string"
+        },
+        "intentFallback": {
+          "title": "Was this a fallback intent handler?",
+          "description": "True if we couldn't parse the intent to some exact handler, and just fell back on something generic like search",
+          "type": "boolean"
+        },
+        "intentExtensionId": {
+          "title": "ID of second extension that handled intent",
+          "description": "If intent was handled by another extension, the id of that extension",
+          "type": "string"
+        },
+        "intentExtensionVersion": {
+          "title": "Title of second extension",
+          "description": "The self-reported title of an extension that handled the intent",
+          "type": "string"
+        },
+        "intentExtraData": {
+          "title": "Ad hoc intent-specific data",
+          "description": "A specific intent can add information here about how it interepreted the command",
+          "type": "object"
+        },
+        "intentConfidence": {
+          "title": "Confidence of the intent parsing",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "intentParseSuccess": {
+          "title": "Was this intent parsed successfully?",
+          "type": "boolean"
+        },
+        "intentSuccess": {
+          "title": "Was the intent action successful?",
+          "description": "This is the self-reported success of the intent handler",
+          "type": "boolean"
+        },
+        "intentServiceName": {
+          "title": "What service did the intent handler use?",
+          "description": "If an intent used some external service, what service did it choose?",
+          "type": "string"
+        },
+        "internalError": {
+          "title": "If there was an unexpected error, the name of that error",
+          "type": "string"
+        },
+        "serverErrorIntentParser": {
+          "title": "Error with the server intent parser",
+          "type": "string"
+        },
+        "serverErrorSpeech": {
+          "title": "Error with the server speech-to-text parser",
+          "type": "string"
+        },
+        "serverTimeSpeech": {
+          "title": "Time in milliseconds for server TTS",
+          "type": "number",
+          "minimum": 0
+        },
+        "serverTimeIntentParser": {
+          "title": "Time in milliseconds for server intent parsing",
+          "type": "number",
+          "minimum": 0
+        },
+        "serverVersion": {
+          "title": "Server version",
+          "type": "string"
+        },
+        "transcriptionConfidence": {
+          "title": "Confidence of text-to-speech transcription",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "timestamp": {
+          "title": "Milliseconds-since-the-epoch when intent was started",
+          "type": "number",
+          "minimum": 0
+        },
+        "utterance": {
+          "title": "Text utterance by user",
+          "description": "This is the actual text the user spoke",
+          "type": "string"
+        },
+        "utteranceParsed": {
+          "title": "Parsed form of the utterance",
+          "description": "Typically the slots found in the utterance",
+          "type": "object"
+        }
+      },
+      "required": [
+        "extensionVersion",
+        "extensionTemporaryInstall",
+        "timestamp"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [ "voice" ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 1,
+      "maximum": 1
+    }
+  },
+  "required": [
+    "application",
+    "clientId",
+    "creationDate",
+    "environment",
+    "id",
+    "payload",
+    "type",
+    "version"
+  ]
+}

--- a/validation/telemetry/voice-feedback.1.normal.pass.json
+++ b/validation/telemetry/voice-feedback.1.normal.pass.json
@@ -1,0 +1,11 @@
+{
+  "type": "voice-feedback",
+  "id": "d059fd44-534e-df49-8860-7d3c93b545e2",
+  "version": 1,
+  "payload": {
+    "intentId": "a9e83ff0",
+    "rating": -1,
+    "timestamp": 1567635589896,
+    "feedback": "Did not work as expected"
+  }
+}

--- a/validation/telemetry/voice.1.full.pass.json
+++ b/validation/telemetry/voice.1.full.pass.json
@@ -1,0 +1,73 @@
+{
+  "type": "voice",
+  "id": "d059fd44-534e-df49-8860-7d3c93b545e4",
+  "version": 1,
+  "payload": {
+    "intentId": "a9e83ff0",
+    "extensionVersion": "0.1",
+    "extensionTemporaryInstall": false,
+    "extensionInstallationChannel": "internal_alpha",
+    "siteCategoryOpened": "search",
+    "inputLength": 10,
+    "hasCard": false,
+    "inputCancelled": false,
+    "inputTyped": false,
+    "intentCategory": "navigation",
+    "intent": "navigation.search",
+    "intentFallback": false,
+    "intentExtraData": {
+      "attempted_ddg": false
+    },
+    "intentConfidence": 1.0,
+    "intentParseSuccess": true,
+    "intentSuccess": true,
+    "intentServiceName": "google",
+    "serverTimeSpeech": 1082,
+    "serverVersion": "1.0",
+    "transcriptionConfidence": 0.9,
+    "timestamp": 1567635586896,
+    "utterance": "search for something",
+    "utteranceParsed": {
+      "slots": { "query": "something" }
+    }
+  },
+  "creationDate": "2019-02-16T17:23:29.850Z",
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20190213102848",
+    "name": "Firefox",
+    "version": "67.0a1",
+    "displayVersion": "67.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "67.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "clientId": "6763e028-d9b2-49a9-b221-a82d62465322",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {
+      "intl": {
+        "requestedLocales": ["it"],
+        "availableLocales": ["it", "en-US"],
+        "appLocales": ["it", "en-US"],
+        "systemLocales": ["it-IT", "en-IT"],
+        "regionalPrefsLocales": ["it-IT", "en-IT"],
+        "acceptLanguages": ["it-IT", "it", "en-US", "en"]
+      }
+    },
+    "system": {}
+  }
+}

--- a/validation/telemetry/voice.1.minimal.pass.json
+++ b/validation/telemetry/voice.1.minimal.pass.json
@@ -1,0 +1,50 @@
+{
+  "type": "voice",
+  "id": "d059fd44-534e-df49-8860-7d3c93b545e3",
+  "version": 1,
+  "payload": {
+    "intentId": "93acc8e03",
+    "extensionVersion": "0.1",
+    "extensionTemporaryInstall": false,
+    "timestamp": 1567635761384
+  },
+  "creationDate": "2019-02-16T17:23:29.850Z",
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20190213102848",
+    "name": "Firefox",
+    "version": "67.0a1",
+    "displayVersion": "67.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "67.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "clientId": "6763e028-d9b2-49a9-b221-a82d62465322",
+  "environment": {
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "partner": {},
+    "settings": {
+      "intl": {
+        "requestedLocales": ["it"],
+        "availableLocales": ["it", "en-US"],
+        "appLocales": ["it", "en-US"],
+        "systemLocales": ["it-IT", "en-IT"],
+        "regionalPrefsLocales": ["it-IT", "en-IT"],
+        "acceptLanguages": ["it-IT", "it", "en-US", "en"]
+      }
+    },
+    "system": {}
+  }
+}


### PR DESCRIPTION
This is a schema for a custom Telemetry ping for the Firefox Voice project (an extension that receives and handles voice commands).

We talked with @sunahsuh about this, but I'm kind of making it up as I go, so I'm not sure if I've put the schema in the appropriate location, or if there's other things I should include in the PR.

Note this includes PII (the exact voice commands), and it's our understanding that it's OK to store this information in Telemetry (assuming that we've received appropriate consent in-product). We've avoided full URLs, though we have included URL domains.

Note: we're still getting data review on this, and will hold the PR until we've also sent this proposed data through that review.

The actual data:
* We expect to submit one ping per interaction, so this covers everything from starting the voice interaction, speaking, translating that to text, interpreting the text, and executing the action.
* I've tried to mostly make everything flat, and we'll null out everything that doesn't apply to a specific interaction.
* We'll do full error handling through Sentry, but we include some brief indication of errors in the ping.
* We'll null out information if we don't have consent for that category of information. But I haven't included any properties to indicate the consent. (Should I?)
* I've included everything I think we might want to collect, but I expect we won't instrument everything right away. I'm assuming it's easier to include it all now.
* There's some `"object"` types where specific intent handlers can save arbitrary information. I expect we'll mostly want to download and process this information offline. Is that reasonable? Should we force these arbitrary bits of information into a string?
* **Question:** we want to get thumbs up/down reactions from users for a specific interaction, but that rating will happen after the ping has been submitted. How can we collect that information and relate it to the original interaction? E.g., we could do a separate ping type, and include IDs in both this ping and that ping to relate them. Or can we amend a submitted ping? Or use one kind of Telemetry ping, and use timestamps to see how they relate?

----

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
