### PR TITLE
Fix #368 - Add a schema for first-shutdown pings

### DIFF
--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1,6 +1,2198 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {},
-  "title": "placeholder_schema",
+  "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "clientId": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "addons": {
+          "properties": {
+            "activeAddons": {
+              "additionalProperties": {
+                "properties": {
+                  "appDisabled": {
+                    "type": "boolean"
+                  },
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "foreignInstall": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "hasBinaryComponents": {
+                    "type": "boolean"
+                  },
+                  "installDay": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "isSystem": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "signedState": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": [
+                      "boolean",
+                      "integer"
+                    ]
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activeExperiment": {
+              "properties": {
+                "branch": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "activeGMPlugins": {
+              "additionalProperties": {
+                "properties": {
+                  "applyBackgroundUpdates": {
+                    "type": [
+                      "integer",
+                      "boolean"
+                    ]
+                  },
+                  "userDisabled": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "object"
+            },
+            "activePlugins": {
+              "items": {
+                "properties": {
+                  "blocklisted": {
+                    "type": "boolean"
+                  },
+                  "clicktoplay": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "mimeTypes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updateDay": {
+                    "type": "integer"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "persona": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "theme": {
+              "properties": {
+                "appDisabled": {
+                  "type": "boolean"
+                },
+                "blocklisted": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "foreignInstall": {
+                  "type": [
+                    "boolean",
+                    "integer"
+                  ]
+                },
+                "hasBinaryComponents": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "installDay": {
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "scope": {
+                  "type": "integer"
+                },
+                "updateDay": {
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "userDisabled": {
+                  "type": "boolean"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "build": {
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            },
+            "applicationName": {
+              "type": "string"
+            },
+            "architecture": {
+              "type": "string"
+            },
+            "architecturesInBinary": {
+              "type": "string"
+            },
+            "buildId": {
+              "pattern": "^[0-9]{10}",
+              "type": "string"
+            },
+            "displayVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "hotfixVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platformVersion": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "updaterAvailable": {
+              "type": "boolean"
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "version": {
+              "pattern": "^[0-9]{2,3}\\.",
+              "type": "string"
+            },
+            "xpcomAbi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "applicationId",
+            "applicationName",
+            "architecture",
+            "buildId",
+            "version",
+            "vendor",
+            "platformVersion",
+            "xpcomAbi"
+          ],
+          "type": "object"
+        },
+        "experiments": {
+          "additionalProperties": {
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "partner": {
+          "properties": {
+            "distributionId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributionVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "distributorChannel": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "partnerNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "type": "number"
+            },
+            "firstUseDate": {
+              "type": "number"
+            },
+            "isStubProfile": {
+              "type": "boolean"
+            },
+            "resetDate": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "addonCompatibilityCheckEnabled": {
+              "type": "boolean"
+            },
+            "attribution": {
+              "properties": {
+                "campaign": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "experiment": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                },
+                "medium": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "variation": {
+                  "description": "funnel experiment parameters, see bug 1567339",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "blocklistEnabled": {
+              "type": "boolean"
+            },
+            "defaultSearchEngine": {
+              "type": "string"
+            },
+            "defaultSearchEngineData": {
+              "properties": {
+                "loadPath": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "origin": {
+                  "type": "string"
+                },
+                "submissionURL": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "e10sCohort": {
+              "type": "string"
+            },
+            "e10sEnabled": {
+              "type": "boolean"
+            },
+            "e10sMultiProcesses": {
+              "description": "maximum number of processes that will be launched for regular web content",
+              "type": "integer"
+            },
+            "intl": {
+              "properties": {
+                "acceptLanguages": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "appLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "availableLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "regionalPrefsLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "requestedLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemLocales": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "isDefaultBrowser": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "launcherProcessState": {
+              "type": "integer"
+            },
+            "locale": {
+              "type": "string"
+            },
+            "sandbox": {
+              "properties": {
+                "effectiveContentProcessLevel": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "searchCohort": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "telemetryEnabled": {
+              "type": "boolean"
+            },
+            "update": {
+              "properties": {
+                "autoDownload": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "userPrefs": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "system": {
+          "properties": {
+            "appleModelId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu": {
+              "properties": {
+                "cores": {
+                  "maximum": 2048,
+                  "minimum": 1,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "count": {
+                  "maximum": 1024,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "extensions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "family": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "l2cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "l3cacheKB": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "model": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "speedMHz": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "stepping": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "vendor": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "device": {
+              "properties": {
+                "hardware": {
+                  "type": "string"
+                },
+                "isTablet": {
+                  "type": "boolean"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "gfx": {
+              "properties": {
+                "D2DEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "DWriteEnabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "Headless": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "LowEndMachine": {
+                  "type": "boolean"
+                },
+                "adapters": {
+                  "items": {
+                    "properties": {
+                      "GPUActive": {
+                        "type": "boolean"
+                      },
+                      "RAM": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "deviceID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVersion": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "subsysID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "vendorID": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "features": {
+                  "properties": {
+                    "advancedLayers": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "compositor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "d2d": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "d3d11": {
+                      "properties": {
+                        "blacklisted": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "textureSharing": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "version": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "warp": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "gpuProcess": {
+                      "properties": {
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "monitors": {
+                  "items": {
+                    "properties": {
+                      "pseudoDisplay": {
+                        "type": "boolean"
+                      },
+                      "refreshRate": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": "number"
+                      },
+                      "screenHeight": {
+                        "type": "integer"
+                      },
+                      "screenWidth": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "hdd": {
+              "properties": {
+                "binary": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "profile": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "system": {
+                  "properties": {
+                    "model": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "revision": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "enum": [
+                        "SSD",
+                        "HDD",
+                        null
+                      ],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "isWow64": {
+              "type": "boolean"
+            },
+            "memoryMB": {
+              "type": "number"
+            },
+            "os": {
+              "properties": {
+                "installYear": {
+                  "type": "number"
+                },
+                "kernelVersion": {
+                  "type": "string"
+                },
+                "locale": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "servicePackMajor": {
+                  "type": "number"
+                },
+                "servicePackMinor": {
+                  "type": "number"
+                },
+                "version": {
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                },
+                "windowsBuildNumber": {
+                  "type": "number"
+                },
+                "windowsUBR": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "sec": {
+              "properties": {
+                "antispyware": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "antivirus": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "firewall": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "virtualMaxMB": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "build",
+        "partner",
+        "settings",
+        "system"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "UIMeasurements": {
+          "items": {
+            "properties": {
+              "action": {
+                "type": "string"
+              },
+              "extras": {
+                "type": "string"
+              },
+              "method": {
+                "type": "string"
+              },
+              "timestamp": {
+                "type": "number"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "addonDetails": {
+          "properties": {},
+          "type": "object"
+        },
+        "addonHistograms": {
+          "properties": {},
+          "type": "object"
+        },
+        "fileIOReports": {
+          "properties": {},
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "histograms": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "bucket_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "histogram_type": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "log_sum": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "log_sum_squares": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "range": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "sum": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_hi": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sum_squares_lo": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^[0-9]+$": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "info": {
+          "properties": {
+            "previousBuildId": {
+              "description": "null if this is the first run, or the previous build ID is unknown",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSessionId": {
+              "description": "session id of the previous session, null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "previousSubsessionId": {
+              "description": "subsession id of the previous subsession (even if it was in a different session), null on first run.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profileSubsessionCounter": {
+              "description": "the running no. of all subsessions for the whole profile life time",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "reason": {
+              "description": "what triggered this ping e.g. saved-session, environment-change, shutdown, ...",
+              "type": "string"
+            },
+            "revision": {
+              "description": "the Histograms.json revision",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "random session id, shared by subsessions",
+              "type": "string"
+            },
+            "sessionLength": {
+              "description": "the session length until now in seconds, monotonic",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "sessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "subsessionCounter": {
+              "description": "the running no. of this subsession since the start of the browser session",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "subsessionId": {
+              "description": "random subsession id",
+              "type": "string"
+            },
+            "subsessionLength": {
+              "description": "the subsession length until now in seconds, monotonic",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "subsessionStartDate": {
+              "description": "hourly precision, ISO date in local time",
+              "type": "string"
+            },
+            "timezoneOffset": {
+              "description": "time-zone offset from UTC, in minutes, for the current locale",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "keyedHistograms": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "bucket_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "histogram_type": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "log_sum": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "log_sum_squares": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "range": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sum": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "sum_squares_hi": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "sum_squares_lo": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[0-9]+$": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "lateWrites": {
+          "properties": {},
+          "type": "object"
+        },
+        "processes": {
+          "properties": {
+            "content": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "gpu": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "parent": {
+              "properties": {
+                "events": {
+                  "items": {
+                    "items": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    ],
+                    "maxItems": 6,
+                    "minItems": 4,
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "gc": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "random": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    },
+                    "worst": {
+                      "items": {
+                        "additionalProperties": {
+                          "type": [
+                            "number",
+                            "string",
+                            "null",
+                            "boolean"
+                          ]
+                        },
+                        "maxProperties": 30,
+                        "properties": {
+                          "slices": {
+                            "items": {
+                              "properties": {},
+                              "type": "object"
+                            },
+                            "type": [
+                              "array",
+                              "number"
+                            ]
+                          },
+                          "slices_list": {
+                            "items": {
+                              "additionalProperties": {
+                                "type": [
+                                  "number",
+                                  "string",
+                                  "null",
+                                  "boolean"
+                                ]
+                              },
+                              "maxProperties": 15,
+                              "properties": {
+                                "times": {
+                                  "maxProperties": 73,
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "maxItems": 4,
+                            "type": "array"
+                          },
+                          "totals": {
+                            "maxProperties": 73,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "maxItems": 2,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "histograms": {
+                  "additionalProperties": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "bucket_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "histogram_type": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "log_sum": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "log_sum_squares": {
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "range": {
+                        "items": {
+                          "type": "integer"
+                        },
+                        "type": "array"
+                      },
+                      "sum": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_hi": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "sum_squares_lo": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "values": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^[0-9]+$": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedHistograms": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bucket_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "histogram_type": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "log_sum": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "log_sum_squares": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "range": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sum": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_hi": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "sum_squares_lo": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "values": {
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^[0-9]+$": {
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "keyedScalars": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "string",
+                        "boolean"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "type": "object"
+                },
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "scalars"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "parent"
+          ],
+          "type": "object"
+        },
+        "simpleMeasurements": {
+          "properties": {},
+          "type": "object"
+        },
+        "slowSQL": {
+          "properties": {},
+          "type": "object"
+        },
+        "slowSQLStartup": {
+          "properties": {},
+          "type": "object"
+        },
+        "ver": {
+          "type": "integer"
+        },
+        "webrtc": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "first-shutdown"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
+    }
+  },
+  "required": [
+    "application",
+    "creationDate",
+    "id",
+    "type",
+    "version"
+  ],
+  "title": "first-shutdown",
   "type": "object"
 }

--- a/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1,1 +1,29 @@
-@COMMON_PLACEHOLDER_1_JSON@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "first-shutdown",
+    "properties": {
+      @TELEMETRY_APPLICATION_1_JSON@,
+      @TELEMETRY_CLIENTID_1_JSON@,
+      @TELEMETRY_CREATIONDATE_1_JSON@,
+      @TELEMETRY_ENVIRONMENT_1_JSON@,
+      @TELEMETRY_ID_1_JSON@,
+      @TELEMETRY_MAINPAYLOAD_1_JSON@,
+      "type": {
+        "type": "string",
+        "enum": [ "first-shutdown" ]
+      },
+      "version": {
+        "type": "number",
+        "minimum": 4,
+        "maximum": 4
+      }
+    },
+    "required": [
+      "application",
+      "creationDate",
+      "id",
+      "type",
+      "version"
+    ]
+}


### PR DESCRIPTION
This fixes #368 by adding a schema for first shutdown pings. Since this is a copy of the main ping, we should treat it like the main ping during schema generation.


Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)