### PR TITLE
Update nightly CI job from dev to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,4 +121,4 @@ workflows:
             filters:
               branches:
                 only:
-                  - dev
+                  - master


### PR DESCRIPTION
This updates a small piece of the CI config that was missed during the transition from dev to master. This sets the cache to the latest run for the day and is used during the `restore_cache` step.

---

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
