### PR TITLE
Add is_admin_without_uac to the launcher-process-failure ping

### DIFF
--- a/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.parquetmr.txt
+++ b/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.parquetmr.txt
@@ -11,6 +11,7 @@ message launcher-process-failure {
   optional binary os_locale (UTF8);
   required int64 cpu_arch;
   required int64 num_logical_cpus;
+  optional boolean is_admin_without_uac;
   required binary xpcom_abi (UTF8);
   optional group security {
     optional group antispyware (LIST) {

--- a/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -21,6 +21,10 @@
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"
     },
+    "is_admin_without_uac": {
+      "description": "True if the process was launched with Administrator privileges but without User Account Control (= UAC)",
+      "type": "boolean"
+    },
     "launcher_error": {
       "description": "The error that raised the launcher process failure",
       "properties": {

--- a/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.parquetmr.txt
+++ b/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.parquetmr.txt
@@ -11,6 +11,7 @@ message launcher-process-failure {
   optional binary os_locale (UTF8);
   required int64 cpu_arch;
   required int64 num_logical_cpus;
+  optional boolean is_admin_without_uac;
   required binary xpcom_abi (UTF8);
   optional group security {
     optional group antispyware (LIST) {

--- a/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -44,6 +44,10 @@
       "description": "The number of logical CPUs on the host machine",
       "type": "integer"
     },
+    "is_admin_without_uac": {
+      "description": "True if the process was launched with Administrator privileges but without User Account Control (= UAC)",
+      "type": "boolean"
+    },
     "xpcom_abi": {
       "description": "This build's XPCOM_ABI string",
       "type": "string"

--- a/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
+++ b/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
@@ -11,6 +11,7 @@
  "os_locale": "en-US",
  "cpu_arch": 9,
  "num_logical_cpus": 8,
+ "is_admin_without_uac": true,
  "memory": {
   "total_phys": 16976711680,
   "avail_phys": 4024082432,


### PR DESCRIPTION
This patch is to add a new field `is_admin_without_uac` in the existing `launcher-process-failure` ping.

https://bugzilla.mozilla.org/show_bug.cgi?id=1567605

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
