### PR TITLE
Allow null values for environment.build.vendor

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -302,7 +302,10 @@
               "type": "boolean"
             },
             "vendor": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "pattern": "^[0-9]{2,3}\\.",

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -203,7 +203,7 @@
           "pattern": "^[0-9]{2,3}\\."
         },
         "vendor": {
-          "type": "string"
+          "type": [ "string", "null" ]
         },
         "displayVersion": {
           "type": "string",

--- a/validation/telemetry/crash.4.null_vendor.pass.json
+++ b/validation/telemetry/crash.4.null_vendor.pass.json
@@ -1,0 +1,191 @@
+{
+  "clientId": "a136763f-3b9a-492d-8964-bfe783b68dc6",
+  "id": "89ba9d98-b041-46f3-8b1a-36dfeb5e1b15",
+  "environment": {
+    "settings": {
+      "blocklistEnabled": true,
+      "attribution": {
+        "content": "%2528not%2Bset%2529",
+        "source": "www.google.com",
+        "medium": "referral",
+        "campaign": "%2528not%2Bset%2529"
+      },
+      "isDefaultBrowser": true,
+      "addonCompatibilityCheckEnabled": true,
+      "locale": "en-US",
+      "e10sMultiProcesses": 4,
+      "defaultSearchEngineData": {
+        "origin": "default",
+        "loadPath": "jar:[app]/omni.ja!browser/google.xml",
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b",
+        "name": "Google"
+      },
+      "update": {
+        "enabled": true,
+        "autoDownload": true,
+        "channel": "nightly"
+      },
+      "e10sEnabled": true,
+      "sandbox": {
+        "effectiveContentProcessLevel": 5
+      },
+      "userPrefs": {
+        "browser.startup.homepage": "<user-set>",
+        "browser.search.region": "KE",
+        "browser.cache.disk.capacity": 358400,
+        "browser.search.widget.inNavBar": false
+      },
+      "defaultSearchEngine": "google",
+      "telemetryEnabled": true
+    },
+    "system": {
+      "gfx": {
+        "features": {
+          "compositor": "d3d11",
+          "advancedLayers": {
+            "status": "available"
+          },
+          "gpuProcess": {
+            "status": "unavailable"
+          },
+          "d3d11": {
+            "status": "available",
+            "textureSharing": true,
+            "version": 40960,
+            "blacklisted": false,
+            "warp": false
+          },
+          "d2d": {
+            "status": "blacklisted",
+            "version": "1.1"
+          }
+        },
+        "DWriteEnabled": true,
+        "D2DEnabled": false,
+        "ContentBackend": "Skia",
+        "adapters": [
+          {
+            "vendorID": "0x8086",
+            "driverVersion": "8.15.10.2302",
+            "driverDate": "2-11-2011",
+            "description": "Intel(R) Q45/Q43 Express Chipset",
+            "GPUActive": true,
+            "RAM": null,
+            "driver": "igdumdx32 igd10umd32",
+            "deviceID": "0x2e12",
+            "subsysID": "3034103c"
+          }
+        ],
+        "monitors": [
+          {
+            "refreshRate": 60,
+            "screenHeight": 1024,
+            "screenWidth": 1280,
+            "pseudoDisplay": false
+          }
+        ]
+      },
+      "os": {
+        "name": "Windows_NT",
+        "locale": "en-US",
+        "installYear": 2016,
+        "version": "6.1",
+        "servicePackMajor": 0,
+        "windowsBuildNumber": 7600,
+        "servicePackMinor": 0
+      },
+      "memoryMB": 1993,
+      "hdd": {
+        "profile": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "binary": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "system": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        }
+      },
+      "virtualMaxMB": 2048,
+      "appleModelId": null,
+      "isWow64": false,
+      "cpu": {
+        "count": 2,
+        "l3cacheKB": null,
+        "vendor": "GenuineIntel",
+        "family": 6,
+        "extensions": [
+          "hasMMX",
+          "hasSSE",
+          "hasSSE2",
+          "hasSSE3",
+          "hasSSSE3",
+          "hasSSE4_1"
+        ],
+        "stepping": 10,
+        "cores": 2,
+        "model": 23,
+        "speedMHz": 2926,
+        "l2cacheKB": 3072
+      }
+    },
+    "build": {
+      "applicationName": "Firefox",
+      "vendor": null,
+      "buildId": "20180409100035",
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "version": "61.0a1",
+      "architecture": "x86",
+      "platformVersion": "61.0a1",
+      "xpcomAbi": "x86-msvc",
+      "updaterAvailable": true
+    },
+    "partner": {
+      "distributionId": null,
+      "distributorChannel": null,
+      "partnerId": null,
+      "distributor": null,
+      "distributionVersion": null,
+      "partnerNames": []
+    }
+  },
+  "application": {
+    "vendor": "Mozilla",
+    "name": "Firefox",
+    "buildId": "20180409100035",
+    "displayVersion": "61.0a1",
+    "version": "61.0a1",
+    "architecture": "x86",
+    "platformVersion": "61.0a1",
+    "xpcomAbi": "x86-msvc",
+    "channel": "nightly"
+  },
+  "version": 4,
+  "creationDate": "2018-04-10T07:25:01.155Z",
+  "type": "crash",
+  "payload": {
+    "sessionId": null,
+    "version": 1,
+    "minidumpSha256Hash": "5f95d0abb0104fa7d13378a47b799b489b6c321febbe1cd9a7b921207708526b",
+    "crashTime": "2018-04-10T07:00:00.000Z",
+    "crashDate": "2018-04-10",
+    "metadata": {
+      "Version": "61.0a1",
+      "StartupCrash": "0",
+      "ipc_channel_error": "ShutDownKill",
+      "ProductName": "Firefox",
+      "StartupCrash": "0",
+      "BuildID": "20180409100035",
+      "UptimeTS": "56.8150704",
+      "CrashTime": "1523345096",
+      "ReleaseChannel": "nightly",
+      "ProductID": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
+    },
+    "processType": "content",
+    "crashId": "f6ecb3b9-bcb7-4c65-ae77-255d79836cc6",
+    "hasCrashEnvironment": true
+  }
+}


### PR DESCRIPTION
I noticed this as a common error with a few different ping types (using on @acmiyaguchi 's helpful query over in #400 🎉).

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)