### PR TITLE
Fix schema version specified in voice schema

### DIFF
--- a/schemas/telemetry/voice/voice-feedback.4.schema.json
+++ b/schemas/telemetry/voice/voice-feedback.4.schema.json
@@ -30,8 +30,8 @@
       "type": "string"
     },
     "version": {
-      "maximum": 1,
-      "minimum": 1,
+      "maximum": 4,
+      "minimum": 4,
       "type": "number"
     }
   },

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1186,8 +1186,8 @@
       "type": "string"
     },
     "version": {
-      "maximum": 1,
-      "minimum": 1,
+      "maximum": 4,
+      "minimum": 4,
       "type": "number"
     }
   },

--- a/templates/telemetry/voice/voice-feedback.4.schema.json
+++ b/templates/telemetry/voice/voice-feedback.4.schema.json
@@ -31,8 +31,8 @@
     },
     "version": {
       "type": "number",
-      "minimum": 1,
-      "maximum": 1
+      "minimum": 4,
+      "maximum": 4
     }
   },
   "required": ["id", "payload", "type", "version"]

--- a/templates/telemetry/voice/voice.4.schema.json
+++ b/templates/telemetry/voice/voice.4.schema.json
@@ -164,8 +164,8 @@
     },
     "version": {
       "type": "number",
-      "minimum": 1,
-      "maximum": 1
+      "minimum": 4,
+      "maximum": 4
     }
   },
   "required": [

--- a/validation/telemetry/voice-feedback.4.normal.pass.json
+++ b/validation/telemetry/voice-feedback.4.normal.pass.json
@@ -1,7 +1,7 @@
 {
   "type": "voice-feedback",
   "id": "d059fd44-534e-df49-8860-7d3c93b545e2",
-  "version": 1,
+  "version": 4,
   "payload": {
     "intentId": "a9e83ff0",
     "rating": -1,

--- a/validation/telemetry/voice.4.full.pass.json
+++ b/validation/telemetry/voice.4.full.pass.json
@@ -1,7 +1,7 @@
 {
   "type": "voice",
   "id": "d059fd44-534e-df49-8860-7d3c93b545e4",
-  "version": 1,
+  "version": 4,
   "payload": {
     "intentId": "a9e83ff0",
     "extensionVersion": "0.1",

--- a/validation/telemetry/voice.4.minimal.pass.json
+++ b/validation/telemetry/voice.4.minimal.pass.json
@@ -1,7 +1,7 @@
 {
   "type": "voice",
   "id": "d059fd44-534e-df49-8860-7d3c93b545e3",
-  "version": 1,
+  "version": 4,
   "payload": {
     "intentId": "93acc8e03",
     "extensionVersion": "0.1",


### PR DESCRIPTION
One more change I missed yesterday: the version specified in the schema is still 1 vs 4