### PR TITLE
Relax the displayVersion pattern to allow "2.0.1" for example.

### DIFF
--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "displayVersion": {
-      "pattern": "^[0-9]{2,3}\\.",
+      "pattern": "^[0-9]+\\.",
       "type": "string"
     },
     "distributionId": {

--- a/templates/include/telemetry/coreCommon.2.schema.json
+++ b/templates/include/telemetry/coreCommon.2.schema.json
@@ -6,7 +6,7 @@
   "type": [ "string", "null" ]
 },
 "displayVersion": {
-  "pattern": "^[0-9]{2,3}\\.",
+  "pattern": "^[0-9]+\\.",
   "type": "string"
 },
 "distributionId": {

--- a/validation/telemetry/core.10.one_digit_displayversion.pass.json
+++ b/validation/telemetry/core.10.one_digit_displayversion.pass.json
@@ -1,0 +1,33 @@
+{
+  "tz" : 480,
+  "seq" : 21,
+  "sessions" : 1,
+  "locale" : "en-US",
+  "os" : "Android",
+  "durations" : 11,
+  "created" : "2017-03-16",
+  "clientId" : "6763e028-d9b2-49a9-b221-a82d62465322",
+  "profileDate" : 17240,
+  "experiments" : [
+    "download-content-catalog-sync",
+    "offline-cache",
+    "promote-add-to-homescreen",
+    "triple-readerview-bookmark-prompt",
+    "hls-video-playback",
+    "bookmark-history-menu",
+    "onboarding3-c"
+  ],
+  "defaultSearch" : "google-nocodes",
+  "displayVersion" : "2.0.9",
+  "v" : 10,
+  "device" : "LGE-Nexus 5",
+  "osversion" : "23",
+  "arch" : "armeabi-v7a",
+  "defaultBrowser": true,
+  "showTrackerStatsShare": false,
+  "accessibilityServices" : [
+    "com.google.android.marvin.talkback/.TalkBackService",
+    "com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"
+  ],
+  "bug_1501329_affected": true
+}


### PR DESCRIPTION
I noticed there are several validation errors on `core` pings like:

`1558     org.everit.json.schema.ValidationException: #/displayVersion: string [2.0.9] does not match pattern ^[0-9]{2,3}\.`

This relaxes the pattern to start with one or more digits and a dot. 

I'm not sure which application(s) are reporting versions like `2.0.9`, but it seems consistent in that there are many like `2.0.8`, `2.0.7` and so on.


Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
