### PR TITLE
1531556: Allow any string -- not just snake case -- for experiment names

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/activation/activation.1.schema.json
+++ b/schemas/org-mozilla-fenix/activation/activation.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -727,7 +727,6 @@
             "properties": {
               "branch": {
                 "maxLength": 30,
-                "pattern": "^[a-z_][a-z0-9_]*$",
                 "type": "string"
               },
               "extra": {
@@ -746,7 +745,6 @@
           },
           "propertyNames": {
             "maxLength": 30,
-            "pattern": "^[a-z_][a-z0-9_]*$",
             "type": "string"
           },
           "type": "object"

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -54,11 +54,17 @@
         "end_time": @GLEAN_DATETIME_1_JSON@,
         "experiments": {
           "type": "object",
-          "propertyNames": @GLEAN_SHORT_ID_1_JSON@,
+          "propertyNames": {
+            "type": "string",
+            "maxLength": 30
+          },
           "additionalProperties": {
             "type": "object",
             "properties": {
-              "branch": @GLEAN_SHORT_ID_1_JSON@,
+              "branch": {
+                "type": "string",
+                "maxLength": 30
+              },
               "extra": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1581556 for context and analysis.

Experiment names were being rejected for not being in kebab case, causing all pings for the experiment-enrolled cohort to be rejected.  This just removes the regex from experiment and branch names to avoid this sort of problem in the future.  Unless there are other, unrelated, reasons to restrict experiment names, this might be the best solution.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
