### PR TITLE
Add "campaignId" field

### DIFF
--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -16,6 +16,12 @@
     "campaign": {
       "type": "string"
     },
+    "campaignId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "clientId": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/templates/include/telemetry/coreCommon.2.schema.json
+++ b/templates/include/telemetry/coreCommon.2.schema.json
@@ -36,6 +36,9 @@
 "campaign": {
   "type": "string"
 },
+"campaignId": {
+  "type": ["string", "null"]
+},
 "defaultBrowser": {
   "type": "boolean"
 },

--- a/validation/telemetry/core.10.sample.pass.json
+++ b/validation/telemetry/core.10.sample.pass.json
@@ -7,6 +7,7 @@
   "durations" : 11,
   "created" : "2017-03-16",
   "clientId" : "6763e028-d9b2-49a9-b221-a82d62465322",
+  "campaignId": "test",
   "profileDate" : 17240,
   "experiments" : [
     "download-content-catalog-sync",


### PR DESCRIPTION
Per the Firefox docs[1] and source code[2], the field should
be called "campaignId".

[1] https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/core-ping.html
[2] https://searchfox.org/mozilla-central/source/mobile/android/base/java/org/mozilla/gecko/telemetry/pingbuilders/TelemetryCorePingBuilder.java#60

I ran a couple of queries too:
```
select campaign, count(*) from telemetry.core where date(submission_timestamp) = '2019-09-10' group by 1
```
Results were all null.

vs. 
```
select json_extract_scalar(additional_properties, '$.campaignId') as campaign_id, count(*) from telemetry.core where date(submission_timestamp) = '2019-09-10' group by 1
```
Lots of non-null values.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
