### PR TITLE
Add the `steps` field to the Sync ping

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -341,6 +341,45 @@
                     "status": {
                       "type": "string"
                     },
+                    "steps": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "counts": {
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "count"
+                              ],
+                              "type": "object"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "took": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
                     "took": {
                       "minimum": -1,
                       "type": "integer"

--- a/templates/include/telemetry/syncItem.1.schema.json
+++ b/templates/include/telemetry/syncItem.1.schema.json
@@ -33,7 +33,7 @@
     "engines": {
       "type": "array",
       "minItems": 0,
-      "items": { 
+      "items": {
         "type": "object",
         "required": ["name"],
         "properties": {
@@ -70,6 +70,24 @@
               }
             }
           },
+          "steps": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string" },
+                "took": { "type": "integer", "minimum": 0 },
+                "counts": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": @TELEMETRY_SYNCNAMEDCOUNT_1_JSON@
+                }
+              }
+            }
+          },
           "validation": {
             "type": "object",
             "additionalProperties": false,
@@ -81,14 +99,7 @@
               "problems": {
                 "type": "array",
                 "minItems": 1,
-                "items": {
-                  "type": "object",
-                  "required": ["name", "count"],
-                  "properties": {
-                    "name": { "type": "string" },
-                    "count": { "type": "integer" }
-                  }
-                }
+                "items": @TELEMETRY_SYNCNAMEDCOUNT_1_JSON@
               }
             }
           }

--- a/templates/include/telemetry/syncNamedCount.1.schema.json
+++ b/templates/include/telemetry/syncNamedCount.1.schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "required": ["name", "count"],
+  "properties": {
+    "name": { "type": "string" },
+    "count": { "type": "integer" }
+  }
+}

--- a/validation/telemetry/sync.4.sample.pass.json
+++ b/validation/telemetry/sync.4.sample.pass.json
@@ -84,7 +84,27 @@
           },
           {
             "name": "bookmarks",
-            "took": 12
+            "took": 12,
+            "steps": [
+              {
+                "name": "fetchLocalTree",
+                "took": 123,
+                "counts": [
+                  {
+                    "name": "items",
+                    "count": 1000
+                  },
+                  {
+                    "name": "deletions",
+                    "count": 10
+                  }
+                ]
+              },
+              {
+                "name": "fetchRemoteTree",
+                "took": 456
+              }
+            ]
           },
           {
             "name": "forms",


### PR DESCRIPTION
This was added in [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1552621), with each step having a name, millisecond
duration, and optional named counts. The new bookmarks engine uses
these to report finer-grained stats for each stage.

(I didn't trigger the integration test because I don't have
permission to push to this repo).

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
