### PR TITLE
Set `environment.system.os.version` type to string

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -985,8 +985,7 @@
                 },
                 "version": {
                   "type": [
-                    "string",
-                    "integer"
+                    "string"
                   ]
                 },
                 "windowsBuildNumber": {

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -776,7 +776,7 @@
               "type": "string"
             },
             "version": {
-              "type": [ "string", "integer" ]
+              "type": [ "string" ]
             },
             "kernelVersion": {
               "type": "string"


### PR DESCRIPTION
This will make `environment.system.os.version` available in BigQuery
schemas. Although we're receiving only strings in this field (verified
on AWS on 2019-09-02), its type in the schema was set to union of string
and integer.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
