### PR TITLE
Add new experiment enrollmentId to telemetry environment schema cf bu…

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -332,6 +332,12 @@
             "properties": {
               "branch": {
                 "type": "string"
+              },
+              "enrollmentId": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
               }
             },
             "type": "object"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -236,6 +236,12 @@
         "properties": {
           "branch": {
             "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "enrollmentId": {
+            "type": "string"
           }
         },
         "type": "object"

--- a/validation/telemetry/event.4.sample.pass.json
+++ b/validation/telemetry/event.4.sample.pass.json
@@ -374,7 +374,9 @@
     },
     "experiments": {
       "searchCohort": {
-        "branch": "nov17-2"
+        "branch": "nov17-2",
+        "type": "high-population",
+        "enrollmentId": "01f4c3fe-05e2-4af5-a10e-8422639c3536"
       }
     }
   }

--- a/validation/telemetry/main.4.experiments.fail.json
+++ b/validation/telemetry/main.4.experiments.fail.json
@@ -147,6 +147,15 @@
       },
       "experiment_name2": {
         "branch" : 1
+      },
+      "experiment_name3": {
+        "branch" : "b3",
+        "type": 123
+      },
+      "experiment_name4": {
+        "branch" : "b3",
+        "type": "pref-flip",
+        "enrollmentId": 0
       }
     }
   }


### PR DESCRIPTION
…g 1555176

Touches a lot of schemas since this is a change to the environment template, but the code to actually submit an enrollmentId to the experiments block just landed: https://bugzilla.mozilla.org/show_bug.cgi?id=1555176

Looks like the schema also never included the "type" annotation either, so this change adds that property as well.

Tagging Chutten since he implemented the ability to annotate enrollmentId on the client side :)