### PR TITLE
1585019: Remove unnecessary timing_distribution keys as required

### DIFF
--- a/schemas/glean/baseline/baseline.1.schema.json
+++ b/schemas/glean/baseline/baseline.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/glean/events/events.1.schema.json
+++ b/schemas/glean/events/events.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/glean/metrics/metrics.1.schema.json
+++ b/schemas/glean/metrics/metrics.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/activation/activation.1.schema.json
+++ b/schemas/org-mozilla-fenix/activation/activation.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-fenix/baseline/baseline.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/bookmarks_sync/bookmarks_sync.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/events/events.1.schema.json
+++ b/schemas/org-mozilla-fenix/events/events.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
+++ b/schemas/org-mozilla-fenix/history_sync/history_sync.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-fenix/metrics/metrics.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/baseline/baseline.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-reference-browser/events/events.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/events/events.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-reference-browser/metrics/metrics.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/baseline/baseline.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/events/events.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
+++ b/schemas/org-mozilla-tv-firefox/metrics/metrics.1.schema.json
@@ -394,10 +394,7 @@
                 }
               },
               "required": [
-                "range",
-                "bucket_count",
-                "values",
-                "time_unit"
+                "values"
               ],
               "type": "object"
             },
@@ -674,10 +671,7 @@
               }
             },
             "required": [
-              "range",
-              "bucket_count",
-              "values",
-              "time_unit"
+              "values"
             ],
             "type": "object"
           },

--- a/templates/include/glean/timing_distribution.1.schema.json
+++ b/templates/include/glean/timing_distribution.1.schema.json
@@ -40,9 +40,6 @@
     "time_unit": @GLEAN_TIME_UNIT_1_JSON@
   },
   "required": [
-    "range",
-    "bucket_count",
-    "values",
-    "time_unit"
+    "values"
   ]
 }


### PR DESCRIPTION
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/424 reinstated the unnecessary information in a timing distribution as required.  Therefore, we started seeing newly rejected pings.  This retains those fields, but just makes them not required so they won't be rejected by the schema when missing.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
