### PR TITLE
Add checks for telemetry version number to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,25 +22,12 @@ jobs:
       - run:
           name: Test Code
           command: docker run mps
-  verify-generated-schemas:
-    docker:
-      - image: circleci/rust:1.32
-    steps:
-      - checkout
-      - setup_remote_docker
       - run:
           name: Verify that all generated schemas are committed
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install cmake jq
-            rm -rf schemas/
-            mkdir release
-            cd release
-            cmake ..
-            cd ..
-            echo "Inconsistencies between templates and rendered schemas:"
-            git ls-files --other --modified -x schemas/*
-            test `git ls-files --other --modified -x schemas/* | wc -l` = 0
+          command: docker run -w /app mps scripts/assert-consistent-schemas
+      - run:
+          name: Verify set version in telemetry namespace is correct
+          command: docker run -w /app mps scripts/assert-telemetry-version
   integrate:
     executor: edge-validator
     steps:
@@ -104,7 +91,6 @@ workflows:
               branches:
                 # This branch is only used for the .github/push-to-trigger-integration script
                 ignore: trigger-integration
-        - verify-generated-schemas
         - integrate:
             filters:
               branches:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 release/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ RUN yum -y update && \
         jq \
         make \
         wget \
-        python-pip \
+        git \
+        python36 \
     && yum clean all
-
-RUN pip install jsonschema
 
 WORKDIR /downloads
 

--- a/scripts/assert-consistent-schemas
+++ b/scripts/assert-consistent-schemas
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+rm -rf schemas/
+rm -rf release/
+(
+    mkdir release
+    cd release
+    cmake ..
+)
+echo "Inconsistencies between templates and rendered schemas:"
+git ls-files --other --modified -x schemas/*
+test "$(git ls-files --other --modified -x schemas/* | wc -l)" = 0

--- a/scripts/assert-telemetry-version
+++ b/scripts/assert-telemetry-version
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Assert that that all documents under the telemetry namespace contain a top-level
+version that corresponds to the version of the common ping format. See [1] for
+more details. [1]
+https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/common-ping.html#common-ping-format
+"""
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def is_placeholder(schema: Dict[str, Any]) -> bool:
+    return schema["title"] == "placeholder_schema" and not schema.get("properties")
+
+
+def is_valid_telemetry_version(schema: Dict[str, Any]) -> (bool, Optional[str]):
+    # either the version is set properly or not set at all
+    version = schema["properties"].get(
+        "version", {"minimum": 4, "maximum": 4, "type": "number"}
+    )
+    missing_fields = {"maximum", "minimum", "type"} - set(version.keys())
+    if missing_fields:
+        return False, f"missing {missing_fields} from version property"
+    if not version["minimum"] == 4:
+        return False, f"invalid minimum version number"
+    if not version["maximum"] == 4:
+        return False, f"invalid maximum version number"
+    if not version["type"] in {"integer", "number"}:
+        return False, f"version must be a number or integer"
+    return True, None
+
+
+def main(project_root: Path) -> None:
+    retval = 0
+    for path in (project_root / "schemas" / "telemetry").glob("**/*.schema.json"):
+        schema = json.load(open(path))
+        relative_path = "/".join(path.parts[-3:])
+        if is_placeholder(schema):
+            continue
+        is_valid, err_msg = is_valid_telemetry_version(schema)
+        if not is_valid:
+            print(f"{relative_path} is invalid: {err_msg}")
+            retval = 1
+    if not retval:
+        print("Success!")
+    return retval
+
+
+if __name__ == "__main__":
+    sys.exit(main(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
This tackles 1/2 items in issue #413, which includes checking that the version number is set up correctly. The goal of this change is to add a location where more checks can be added.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
