### PR TITLE
Add some missing fields to the environment and main payload.

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -966,6 +978,12 @@
             "isWow64": {
               "type": "boolean"
             },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "memoryMB": {
               "type": "number"
             },
@@ -1155,6 +1173,26 @@
         },
         "info": {
           "properties": {
+            "addons": {
+              "description": "obsolete, use environment.addons",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "asyncPluginInit": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "flashVersion": {
+              "description": "obsolete, use environment.addons.activePlugins",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "previousBuildId": {
               "description": "null if this is the first run, or the previous build ID is unknown",
               "type": [
@@ -1293,7 +1331,51 @@
           "type": "object"
         },
         "lateWrites": {
-          "properties": {},
+          "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
+          "properties": {
+            "memoryMap": {
+              "description": "entries in the format [module name, breakpad identifier]",
+              "items": {
+                "items": [
+                  {
+                    "description": "module name",
+                    "type": "string"
+                  },
+                  {
+                    "description": "breakpad identifier",
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "stacks": {
+              "description": "a list of stacks",
+              "items": {
+                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "items": {
+                  "items": [
+                    {
+                      "description": "the module index or -1 for invalid module indices",
+                      "type": "integer"
+                    },
+                    {
+                      "description": "the offset of this program counter in its module or an absolute pc",
+                      "type": "integer"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "processes": {

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1336,16 +1336,9 @@
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {
-                "items": [
-                  {
-                    "description": "module name",
-                    "type": "string"
-                  },
-                  {
-                    "description": "breakpad identifier",
-                    "type": "string"
-                  }
-                ],
+                "items": {
+                  "type": "string"
+                },
                 "maxItems": 2,
                 "minItems": 2,
                 "type": "array"
@@ -1353,20 +1346,13 @@
               "type": "array"
             },
             "stacks": {
-              "description": "a list of stacks",
+              "description": "A list of stacks",
               "items": {
-                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "description": "A list of stack frames, entries in the format [module index, program counter offset]. The module index can be -1 for invalid module indices. The program counter can be an offset in the module or an absolute pc.",
                 "items": {
-                  "items": [
-                    {
-                      "description": "the module index or -1 for invalid module indices",
-                      "type": "integer"
-                    },
-                    {
-                      "description": "the offset of this program counter in its module or an absolute pc",
-                      "type": "integer"
-                    }
-                  ],
+                  "items": {
+                    "type": "integer"
+                  },
                   "maxItems": 2,
                   "minItems": 2,
                   "type": "array"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -966,6 +978,12 @@
             "isWow64": {
               "type": "boolean"
             },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "memoryMB": {
               "type": "number"
             },
@@ -1155,6 +1173,26 @@
         },
         "info": {
           "properties": {
+            "addons": {
+              "description": "obsolete, use environment.addons",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "asyncPluginInit": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "flashVersion": {
+              "description": "obsolete, use environment.addons.activePlugins",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "previousBuildId": {
               "description": "null if this is the first run, or the previous build ID is unknown",
               "type": [
@@ -1293,7 +1331,51 @@
           "type": "object"
         },
         "lateWrites": {
-          "properties": {},
+          "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
+          "properties": {
+            "memoryMap": {
+              "description": "entries in the format [module name, breakpad identifier]",
+              "items": {
+                "items": [
+                  {
+                    "description": "module name",
+                    "type": "string"
+                  },
+                  {
+                    "description": "breakpad identifier",
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "stacks": {
+              "description": "a list of stacks",
+              "items": {
+                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "items": {
+                  "items": [
+                    {
+                      "description": "the module index or -1 for invalid module indices",
+                      "type": "integer"
+                    },
+                    {
+                      "description": "the offset of this program counter in its module or an absolute pc",
+                      "type": "integer"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "processes": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1336,16 +1336,9 @@
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {
-                "items": [
-                  {
-                    "description": "module name",
-                    "type": "string"
-                  },
-                  {
-                    "description": "breakpad identifier",
-                    "type": "string"
-                  }
-                ],
+                "items": {
+                  "type": "string"
+                },
                 "maxItems": 2,
                 "minItems": 2,
                 "type": "array"
@@ -1353,20 +1346,13 @@
               "type": "array"
             },
             "stacks": {
-              "description": "a list of stacks",
+              "description": "A list of stacks",
               "items": {
-                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "description": "A list of stack frames, entries in the format [module index, program counter offset]. The module index can be -1 for invalid module indices. The program counter can be an offset in the module or an absolute pc.",
                 "items": {
-                  "items": [
-                    {
-                      "description": "the module index or -1 for invalid module indices",
-                      "type": "integer"
-                    },
-                    {
-                      "description": "the offset of this program counter in its module or an absolute pc",
-                      "type": "integer"
-                    }
-                  ],
+                  "items": {
+                    "type": "integer"
+                  },
                   "maxItems": 2,
                   "minItems": 2,
                   "type": "array"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -966,6 +978,12 @@
             "isWow64": {
               "type": "boolean"
             },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "memoryMB": {
               "type": "number"
             },
@@ -1155,6 +1173,26 @@
         },
         "info": {
           "properties": {
+            "addons": {
+              "description": "obsolete, use environment.addons",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "asyncPluginInit": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "flashVersion": {
+              "description": "obsolete, use environment.addons.activePlugins",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "previousBuildId": {
               "description": "null if this is the first run, or the previous build ID is unknown",
               "type": [
@@ -1293,7 +1331,51 @@
           "type": "object"
         },
         "lateWrites": {
-          "properties": {},
+          "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
+          "properties": {
+            "memoryMap": {
+              "description": "entries in the format [module name, breakpad identifier]",
+              "items": {
+                "items": [
+                  {
+                    "description": "module name",
+                    "type": "string"
+                  },
+                  {
+                    "description": "breakpad identifier",
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "stacks": {
+              "description": "a list of stacks",
+              "items": {
+                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "items": {
+                  "items": [
+                    {
+                      "description": "the module index or -1 for invalid module indices",
+                      "type": "integer"
+                    },
+                    {
+                      "description": "the offset of this program counter in its module or an absolute pc",
+                      "type": "integer"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
           "type": "object"
         },
         "processes": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1336,16 +1336,9 @@
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {
-                "items": [
-                  {
-                    "description": "module name",
-                    "type": "string"
-                  },
-                  {
-                    "description": "breakpad identifier",
-                    "type": "string"
-                  }
-                ],
+                "items": {
+                  "type": "string"
+                },
                 "maxItems": 2,
                 "minItems": 2,
                 "type": "array"
@@ -1353,20 +1346,13 @@
               "type": "array"
             },
             "stacks": {
-              "description": "a list of stacks",
+              "description": "A list of stacks",
               "items": {
-                "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+                "description": "A list of stack frames, entries in the format [module index, program counter offset]. The module index can be -1 for invalid module indices. The program counter can be an offset in the module or an absolute pc.",
                 "items": {
-                  "items": [
-                    {
-                      "description": "the module index or -1 for invalid module indices",
-                      "type": "integer"
-                    },
-                    {
-                      "description": "the offset of this program counter in its module or an absolute pc",
-                      "type": "integer"
-                    }
-                  ],
+                  "items": {
+                    "type": "integer"
+                  },
                   "maxItems": 2,
                   "minItems": 2,
                   "type": "array"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -94,6 +94,12 @@
                   "isSystem": {
                     "type": "boolean"
                   },
+                  "isWebExtension": {
+                    "type": "boolean"
+                  },
+                  "multiprocessCompatible": {
+                    "type": "boolean"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -544,6 +550,12 @@
                 "null"
               ]
             },
+            "isInOptoutSample": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "launcherProcessState": {
               "type": "integer"
             },
@@ -965,6 +977,12 @@
             },
             "isWow64": {
               "type": "boolean"
+            },
+            "isWowARM64": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memoryMB": {
               "type": "number"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -55,6 +55,12 @@
               },
               "isSystem": {
                 "type": "boolean"
+              },
+              "isWebExtension": {
+                "type": "boolean"
+              },
+              "multiprocessCompatible": {
+                "type": "boolean"
               }
             }
           }
@@ -341,6 +347,9 @@
           "type": "boolean"
         },
         "isDefaultBrowser": {
+          "type": [ "boolean", "null" ]
+        },
+        "isInOptoutSample": {
           "type": [ "boolean", "null" ]
         },
         "defaultSearchEngine": {
@@ -768,6 +777,9 @@
         },
         "isWow64": {
           "type": "boolean"
+        },
+        "isWowARM64": {
+          "type": [ "boolean", "null" ]
         },
         "memoryMB": {
           "type": "number"

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -127,38 +127,20 @@
           "description": "entries in the format [module name, breakpad identifier]",
           "items": {
             "type": "array",
-            "items": [
-              {
-                "type": "string",
-                "description": "module name"
-              },
-              {
-                "type": "string",
-                "description": "breakpad identifier"
-              }
-            ],
+            "items": { "type": "string" },
             "minItems": 2,
             "maxItems": 2
           }
         },
         "stacks": {
           "type": "array",
-          "description": "a list of stacks",
+          "description": "A list of stacks",
           "items": {
             "type": "array",
-            "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+            "description": "A list of stack frames, entries in the format [module index, program counter offset]. The module index can be -1 for invalid module indices. The program counter can be an offset in the module or an absolute pc.",
             "items": {
               "type": "array",
-              "items": [
-                {
-                  "type": "integer",
-                  "description": "the module index or -1 for invalid module indices"
-                },
-                {
-                  "type": "integer",
-                  "description": "the offset of this program counter in its module or an absolute pc"
-                }
-              ],
+              "items": { "type": "integer" },
               "minItems": 2,
               "maxItems": 2
             }

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -36,6 +36,17 @@
     "info": {
       "type": "object",
       "properties": {
+        "addons": {
+          "type": ["string", "null"],
+          "description": "obsolete, use environment.addons"
+        },
+        "asyncPluginInit": {
+          "type": ["boolean", "null"]
+        },
+        "flashVersion": {
+          "type": ["string", "null"],
+          "description": "obsolete, use environment.addons.activePlugins"
+        },
         "previousBuildId": {
           "type": ["string", "null"],
           "description": "null if this is the first run, or the previous build ID is unknown"
@@ -109,7 +120,51 @@
     },
     "lateWrites": {
       "type": "object",
-      "properties": { }
+      "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
+      "properties": {
+        "memoryMap": {
+          "type": "array",
+          "description": "entries in the format [module name, breakpad identifier]",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string",
+                "description": "module name"
+              },
+              {
+                "type": "string",
+                "description": "breakpad identifier"
+              }
+            ],
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "stacks": {
+          "type": "array",
+          "description": "a list of stacks",
+          "items": {
+            "type": "array",
+            "description": "a list of stack frames, entries in the format [module index, program counter offset]",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "description": "the module index or -1 for invalid module indices"
+                },
+                {
+                  "type": "integer",
+                  "description": "the offset of this program counter in its module or an absolute pc"
+                }
+              ],
+              "minItems": 2,
+              "maxItems": 2
+            }
+          }
+        }
+      }
     },
     "simpleMeasurements": {
       "type": "object",

--- a/validation/telemetry/main.4.latewrites.fail.json
+++ b/validation/telemetry/main.4.latewrites.fail.json
@@ -1,0 +1,16909 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "displayVersion": "45.0b6",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "clientId": "6fd3eb50-8bec-4b9c-8778-59406171312a",
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "addons": {
+      "activeAddons": {
+        "adbhelper@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "An addon to ease connecting to Firefox OS devices.",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16232,
+          "name": "ADB Helper",
+          "scope": 1,
+          "signedState": 1,
+          "type": "extension",
+          "updateDay": 16729,
+          "userDisabled": false,
+          "version": "0.8.5"
+        },
+        "eliteproxyswitcher@my-proxy.com": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Automatically change the proxy for Firefox.",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16644,
+          "name": "Elite Proxy Switcher",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16644,
+          "userDisabled": false,
+          "version": "1.2.0.2.1-signed"
+        },
+        "foxyproxy@eric.h.jung": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "FoxyProxy - Premier proxy management for Firefox",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16637,
+          "name": "FoxyProxy Standard",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16637,
+          "userDisabled": false,
+          "version": "4.5.5"
+        },
+        "fxdevtools-adapters@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Protocol Adapters for Firefox Developer Tools. User documentation is available on MDN: https://devel",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16548,
+          "name": "Valence",
+          "scope": 1,
+          "signedState": 1,
+          "type": "extension",
+          "updateDay": 16729,
+          "userDisabled": false,
+          "version": "0.3.3"
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "a Firefox OS 1.4 simulator",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16232,
+          "name": "Firefox OS 1.4 Simulator",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16673,
+          "userDisabled": false,
+          "version": "1.4.20140506.1-signed"
+        },
+        "fxos_2_1_simulator@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "a Firefox OS 2.1 simulator",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16330,
+          "name": "Firefox OS 2.1 Simulator",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16673,
+          "userDisabled": false,
+          "version": "2.1.20141223.1-signed"
+        },
+        "masspasswordreset@johnathan.nightingale": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Sometimes you change a central password that ends up changing 12 others.  This add on helps you rese",
+          "foreignInstall": 0,
+          "hasBinaryComponents": false,
+          "installDay": 15988,
+          "name": "Mass Password Reset",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16565,
+          "userDisabled": false,
+          "version": "1.05.1-signed"
+        }
+      },
+      "activeExperiment": {},
+      "activeGMPlugins": {
+        "gmp-gmpopenh264": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": "1.4"
+        }
+      },
+      "activePlugins": [
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Version 5.41.0.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/googletalk"
+          ],
+          "name": "Google Talk Plugin",
+          "updateDay": 16520,
+          "version": "5.41.0.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Version 5.41.0.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/o1d"
+          ],
+          "name": "Google Talk Plugin Video Renderer",
+          "updateDay": 16520,
+          "version": "5.41.0.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Provides information about the default web browser",
+          "disabled": false,
+          "mimeTypes": [
+            "application/apple-default-browser"
+          ],
+          "name": "Default Browser Helper",
+          "updateDay": 16633,
+          "version": "600"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in web pages. For more ",
+          "disabled": false,
+          "mimeTypes": [
+            "video/x-msvideo",
+            "audio/mp3",
+            "audio/mpeg3",
+            "video/3gpp2",
+            "audio/x-caf",
+            "audio/mpeg",
+            "video/quicktime",
+            "audio/x-mpeg3",
+            "video/mp4",
+            "application/x-sdp",
+            "audio/wav",
+            "video/avi",
+            "audio/x-ac3",
+            "audio/mp4",
+            "video/x-m4v",
+            "application/sdp",
+            "audio/x-wav",
+            "audio/x-aiff",
+            "video/x-mpeg",
+            "video/3gpp",
+            "video/msvideo",
+            "audio/x-mpeg",
+            "audio/vnd.qcelp",
+            "audio/x-mp3",
+            "application/x-rtsp",
+            "audio/amr",
+            "video/sd-video",
+            "audio/aiff",
+            "video/mpeg",
+            "audio/3gpp2",
+            "audio/aac",
+            "audio/ac3",
+            "audio/x-m4b",
+            "audio/x-m4p",
+            "audio/x-gsm",
+            "application/x-mpeg",
+            "audio/x-aac",
+            "audio/basic",
+            "audio/x-m4a",
+            "audio/3gpp"
+          ],
+          "name": "QuickTime Plug-in 7.7.3",
+          "updateDay": 16638,
+          "version": "7.7.3"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "5.1.40728.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-silverlight",
+            "application/x-silverlight-2"
+          ],
+          "name": "Silverlight Plug-In",
+          "updateDay": 16644,
+          "version": "5.1.40728.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Displays Java applet content, or a placeholder if Java is not installed.",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-java-applet;version=1.4",
+            "application/x-java-applet;version=1.2.1",
+            "application/x-java-applet;jpi-version=1.8.0_60",
+            "application/x-java-applet;version=1.2.2",
+            "application/x-java-applet;version=1.3",
+            "application/x-java-applet;version=1.8",
+            "application/x-java-vm",
+            "application/x-java-applet;version=1.1.1",
+            "application/x-java-applet;version=1.2",
+            "application/x-java-applet;version=1.7",
+            "application/x-java-applet;version=1.4.1",
+            "application/x-java-applet;version=1.1.2",
+            "application/x-java-applet",
+            "application/x-java-applet;deploy=11.60.2",
+            "application/x-java-applet;version=1.1",
+            "application/x-java-applet;version=1.1.3",
+            "application/x-java-applet;version=1.6",
+            "application/x-java-applet;javafx=8.0.60",
+            "application/x-java-applet;version=1.4.2",
+            "application/x-java-applet;version=1.3.1",
+            "application/x-java-applet;version=1.5"
+          ],
+          "name": "Java Applet Plug-in",
+          "updateDay": 16651,
+          "version": "Java 8 Update 60 build 27"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Shockwave Flash 19.0 r0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-shockwave-flash",
+            "application/futuresplash"
+          ],
+          "name": "Shockwave Flash",
+          "updateDay": 16725,
+          "version": "19.0.0.226"
+        }
+      ],
+      "persona": null,
+      "theme": {
+        "appDisabled": false,
+        "blocklisted": false,
+        "description": "The default theme.",
+        "foreignInstall": false,
+        "hasBinaryComponents": false,
+        "id": "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+        "installDay": 15937,
+        "name": "Default",
+        "scope": 4,
+        "updateDay": 16742,
+        "userDisabled": false,
+        "version": "45.0"
+      }
+    },
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "displayVersion": "45.0b1",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "experiments": {
+      "test_id123": {
+        "branch": "brunch"
+      }
+    },
+    "partner": {
+      "distributionId": null,
+      "distributionVersion": null,
+      "distributor": null,
+      "distributorChannel": null,
+      "partnerId": null,
+      "partnerNames": []
+    },
+    "profile": {
+      "creationDate": 15987
+    },
+    "settings": {
+      "addonCompatibilityCheckEnabled": true,
+      "attribution": {
+        "source": "google.com",
+        "medium": "organic",
+        "campaign": "(not set)",
+        "content": "(not set)"
+      },
+      "blocklistEnabled": true,
+      "defaultSearchEngine": "google",
+      "defaultSearchEngineData": {
+        "loadPath": "jar:[app]/omni.ja!browser/google.xml",
+        "name": "Google",
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8",
+        "origin": "default"
+      },
+      "defaultPrivateSearchEngine": "random",
+      "defaultPrivateSearchEngineData": {
+        "loadPath": "[other]addEngineWithDetails:random@example.com",
+        "name": "Random",
+        "submissionURL": "https://www.example.com/search?q=",
+        "origin": "default"
+      },
+      "e10sEnabled": true,
+      "e10sCohort": "unknown",
+      "isDefaultBrowser": true,
+      "isInOptoutSample": false,
+      "locale": "en-US",
+      "telemetryEnabled": true,
+      "update": {
+        "autoDownload": true,
+        "channel": "beta",
+        "enabled": true
+      },
+      "userPrefs": {
+        "browser.cache.disk.capacity": 358400,
+        "browser.newtabpage.enhanced": true,
+        "browser.startup.page": 3,
+        "browser.urlbar.suggest.searches": true,
+        "browser.urlbar.userMadeSearchSuggestionsChoice": true,
+        "devtools.chrome.enabled": true
+      }
+    },
+    "system": {
+      "cpu": {
+        "cores": 4,
+        "count": 8,
+        "extensions": [
+          "hasMMX",
+          "hasSSE",
+          "hasSSE2",
+          "hasSSE3",
+          "hasSSSE3",
+          "hasSSE4_1",
+          "hasSSE4_2"
+        ],
+        "family": 6,
+        "l2cacheKB": 256,
+        "l3cacheKB": 6144,
+        "model": 70,
+        "speedMHz": 2800,
+        "stepping": 1,
+        "vendor": "GenuineIntel"
+      },
+      "gfx": {
+        "D2DEnabled": null,
+        "LowEndMachine": false,
+        "DWriteEnabled": null,
+        "adapters": [
+          {
+            "GPUActive": true,
+            "RAM": null,
+            "description": null,
+            "deviceID": "0x6821",
+            "driver": null,
+            "driverDate": null,
+            "driverVersion": null,
+            "subsysID": null,
+            "vendorID": "0x1002"
+          }
+        ],
+        "features": {
+          "compositor": "none"
+        },
+        "monitors": [
+          {
+            "scale": 2,
+            "screenHeight": 900,
+            "screenWidth": 1440
+          }
+        ]
+      },
+      "hdd": {
+        "binary": {
+          "model": null,
+          "revision": null
+        },
+        "profile": {
+          "model": null,
+          "revision": null
+        },
+        "system": {
+          "model": null,
+          "revision": null
+        }
+      },
+      "memoryMB": 16384,
+      "os": {
+        "locale": "en-US",
+        "name": "Darwin",
+        "version": "14.5.0"
+      },
+      "virtualMaxMB": null
+    }
+  },
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "payload": {
+    "UIMeasurements": [],
+    "addonDetails": {
+      "GMP": {
+        "gmp-eme-adobe": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": null
+        },
+        "gmp-gmpopenh264": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": "1.4"
+        }
+      },
+      "XPI": {
+        "adbhelper@mozilla.org": {
+          "creator": "Mozilla & Android Open Source Project",
+          "location": "app-profile",
+          "name": "ADB Helper",
+          "scan_MS": 3,
+          "scan_items": 23,
+          "shutdown_MS": 6,
+          "startup_MS": 44
+        },
+        "eliteproxyswitcher@my-proxy.com": {
+          "creator": "My-Proxy",
+          "location": "app-profile",
+          "name": "Elite Proxy Switcher",
+          "scan_MS": 0,
+          "scan_items": 1
+        },
+        "firefox-hotfix@mozilla.org": {
+          "creator": "Mozilla",
+          "location": "app-profile",
+          "name": "Firefox Certificate Store Hotfix",
+          "scan_MS": 0
+        },
+        "foxyproxy@eric.h.jung": {
+          "creator": "FoxyProxy, Inc.",
+          "location": "app-profile",
+          "name": "FoxyProxy Standard",
+          "scan_MS": 12,
+          "scan_items": 324
+        },
+        "fxdevtools-adapters@mozilla.org": {
+          "creator": "Mozilla",
+          "location": "app-profile",
+          "name": "Valence",
+          "scan_MS": 6,
+          "scan_items": 48,
+          "shutdown_MS": 13,
+          "startup_MS": 33
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 1.4 Simulator",
+          "scan_MS": 52,
+          "scan_items": 1094,
+          "shutdown_MS": 17,
+          "startup_MS": 33
+        },
+        "fxos_2_0_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 2.0 Simulator",
+          "scan_MS": 0
+        },
+        "fxos_2_1_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 2.1 Simulator",
+          "scan_MS": 38,
+          "scan_items": 1248,
+          "shutdown_MS": 2,
+          "startup_MS": 30
+        },
+        "hotdish@mozilla.com": {
+          "creator": "Mozilla Hotdish Team",
+          "location": "app-profile",
+          "name": "Hotdish",
+          "scan_MS": 0
+        },
+        "jid0-NgMDcEu2B88AbzZ6ulHodW9sJzA@jetpack": {
+          "creator": "Gregory Koberger",
+          "location": "app-profile",
+          "name": "BugzillaJS",
+          "scan_MS": 0
+        },
+        "masspasswordreset@johnathan.nightingale": {
+          "creator": "Johnathan Nightingale",
+          "location": "app-profile",
+          "name": "Mass Password Reset",
+          "scan_MS": 0,
+          "scan_items": 1
+        },
+        "testpilot@labs.mozilla.com": {
+          "creator": "Mozilla Corporation",
+          "location": "app-profile",
+          "name": "Test Pilot",
+          "scan_MS": 0
+        },
+        "{4d5b56bf-1df3-8cee-2177-2389a677b9a1}": {
+          "creator": "Dave Garrett",
+          "location": "app-profile",
+          "name": "JSM EXPORTED_SYMBOLS Test",
+          "scan_MS": 0
+        },
+        "{972ce4c6-7e08-4474-a285-3208198ce6fd}": {
+          "creator": "Mozilla",
+          "location": "app-global",
+          "modifiedFile": "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+          "name": "Default",
+          "scan_MS": 0,
+          "scan_items": 4
+        }
+      }
+    },
+    "childPayloads": [
+      {
+        "chromeHangs": {
+          "annotations": [],
+          "durations": [],
+          "firefoxUptime": [],
+          "memoryMap": [],
+          "stacks": [],
+          "systemUptime": []
+        },
+        "log": [],
+        "simpleMeasurements": {
+          "firstLoadURI": 2028,
+          "js": {
+            "customIter": 0,
+            "setProto": 19
+          },
+          "main": 0,
+          "maximalNumberOfConcurrentThreads": 36,
+          "startupInterrupted": 0,
+          "totalTime": 44178,
+          "uptime": 736
+        },
+        "threadHangStats": [
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {}
+            },
+            "hangs": [],
+            "name": ""
+          },
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "0": 0,
+                "1": 15,
+                "3": 0
+              }
+            },
+            "hangs": [],
+            "name": "ImageBridgeChild"
+          },
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "0": 0,
+                "1": 13,
+                "3": 0
+              }
+            },
+            "hangs": [],
+            "name": "ProcessHangMonitor"
+          }
+        ],
+        "ver": 4,
+        "webrtc": {
+          "IceCandidatesStats": {
+            "loop": {},
+            "webrtc": {}
+          }
+        }
+      }
+    ],
+    "chromeHangs": {
+      "annotations": [],
+      "durations": [],
+      "firefoxUptime": [],
+      "memoryMap": [],
+      "stacks": [],
+      "systemUptime": []
+    },
+    "fileIOReports": {},
+    "histograms": {
+      "A11Y_IATABLE_USAGE_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "A11Y_INSTANTIATED_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "A11Y_ISIMPLEDOM_USAGE_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "BROWSER_IS_USER_DEFAULT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_IS_USER_DEFAULT_ERROR": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_SET_DEFAULT_ALWAYS_CHECK": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_SET_DEFAULT_DIALOG_PROMPT_RAWCOUNT": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          250
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "BR_9_2_1_SUBJECT_ALT_NAMES": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 302,
+          "1": 0
+        }
+      },
+      "BR_9_2_2_SUBJECT_COMMON_NAME": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 301,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 3,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_CLOSEALLSTREAMS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_ONPROFILESHUTDOWN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 2,
+          "1": 0
+        }
+      },
+      "CANVAS_2D_USED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 200,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 200,
+        "values": {
+          "0": 0,
+          "1": 200,
+          "2": 0
+        }
+      },
+      "CERT_CHAIN_KEY_SIZE_STATUS": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 288,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 288,
+        "values": {
+          "0": 0,
+          "1": 288,
+          "2": 0
+        }
+      },
+      "CERT_CHAIN_SIGNATURE_DIGEST_STATUS": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 380,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 692,
+        "values": {
+          "0": 0,
+          "1": 276,
+          "4": 26,
+          "5": 0
+        }
+      },
+      "CERT_OCSP_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "CERT_OCSP_REQUIRED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "CERT_PINNING_MOZ_RESULTS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 23,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 23,
+        "values": {
+          "0": 0,
+          "1": 23,
+          "2": 0
+        }
+      },
+      "CERT_PINNING_MOZ_RESULTS_BY_HOST": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 341,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4403,
+        "values": {
+          "13": 26,
+          "14": 0,
+          "2": 0,
+          "3": 1
+        }
+      },
+      "CERT_PINNING_MOZ_TEST_RESULTS_BY_HOST": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 30,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 450,
+        "values": {
+          "14": 0,
+          "15": 2,
+          "16": 0
+        }
+      },
+      "CERT_PINNING_RESULTS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 153,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 153,
+        "values": {
+          "0": 0,
+          "1": 153,
+          "2": 0
+        }
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_CANCELED_TIME": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_RESULT": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 29,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29,
+        "values": {
+          "0": 0,
+          "1": 29,
+          "2": 0
+        }
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_SUCCEEDED_TIME": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 3438,
+        "values": {
+          "1092": 1,
+          "110": 1,
+          "1142": 0,
+          "12": 1,
+          "15": 1,
+          "16": 1,
+          "17": 2,
+          "18": 1,
+          "189": 1,
+          "27": 1,
+          "29": 1,
+          "41": 2,
+          "425": 1,
+          "445": 1,
+          "5": 0,
+          "55": 1,
+          "6": 2,
+          "61": 3,
+          "64": 1,
+          "67": 1,
+          "70": 2,
+          "73": 2,
+          "84": 1,
+          "96": 1
+        }
+      },
+      "CERT_VALIDATION_SUCCESS_BY_CA": {
+        "bucket_count": 257,
+        "histogram_type": 1,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 11834,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 692790,
+        "values": {
+          "106": 8,
+          "123": 1,
+          "154": 2,
+          "155": 4,
+          "163": 2,
+          "164": 0,
+          "20": 155,
+          "49": 67,
+          "5": 0,
+          "50": 50,
+          "6": 1,
+          "60": 12
+        }
+      },
+      "CHARSET_OVERRIDE_USED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CHECK_ADDONS_MODIFIED_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "COMPONENTS_SHIM_ACCESSED_BY_CONTENT": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "COMPOSITE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 106036,
+        "values": {
+          "0": 15572,
+          "1": 48180,
+          "10": 84,
+          "11": 116,
+          "12": 133,
+          "14": 323,
+          "152": 1,
+          "16": 712,
+          "171": 0,
+          "18": 57,
+          "2": 8211,
+          "20": 43,
+          "23": 20,
+          "26": 19,
+          "29": 13,
+          "3": 913,
+          "33": 15,
+          "37": 24,
+          "4": 547,
+          "42": 7,
+          "47": 3,
+          "5": 816,
+          "53": 6,
+          "6": 428,
+          "60": 2,
+          "67": 3,
+          "7": 238,
+          "75": 1,
+          "8": 118,
+          "84": 2,
+          "9": 81,
+          "95": 1
+        }
+      },
+      "CONTENT_DOCUMENTS_DESTROYED": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "COOKIE_SCHEME_SECURITY": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 2055,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5919,
+        "values": {
+          "0": 21,
+          "1": 123,
+          "3": 644,
+          "4": 0
+        }
+      },
+      "CRASH_STORE_COMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "CYCLE_COLLECTOR": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 90970,
+        "values": {
+          "114": 87,
+          "135": 126,
+          "160": 63,
+          "1782": 3,
+          "190": 88,
+          "2117": 1,
+          "226": 3,
+          "24": 0,
+          "268": 8,
+          "29": 1,
+          "318": 2,
+          "34": 8,
+          "378": 1,
+          "40": 4,
+          "4222": 1,
+          "449": 3,
+          "48": 1,
+          "5017": 0,
+          "533": 1,
+          "68": 18,
+          "752": 3,
+          "894": 4,
+          "96": 57
+        }
+      },
+      "CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 217,
+        "values": {
+          "0": 15669,
+          "1": 77,
+          "10": 1,
+          "12": 1,
+          "14": 0,
+          "2": 30,
+          "3": 9,
+          "4": 5,
+          "5": 2
+        }
+      },
+      "CYCLE_COLLECTOR_COLLECTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 517386,
+        "values": {
+          "0": 116,
+          "10": 17,
+          "10589": 6,
+          "1122": 7,
+          "119": 12,
+          "13": 10,
+          "13255": 2,
+          "1404": 13,
+          "149": 16,
+          "16": 13,
+          "16592": 2,
+          "1757": 6,
+          "186": 10,
+          "2": 11,
+          "20": 8,
+          "2199": 10,
+          "233": 13,
+          "25": 9,
+          "2753": 6,
+          "292": 4,
+          "31": 14,
+          "32541": 1,
+          "3446": 11,
+          "365": 11,
+          "39": 5,
+          "4": 9,
+          "40733": 0,
+          "4313": 7,
+          "457": 6,
+          "49": 4,
+          "5399": 8,
+          "572": 26,
+          "6": 5,
+          "61": 25,
+          "6758": 5,
+          "716": 7,
+          "76": 19,
+          "8": 5,
+          "8459": 4,
+          "896": 8,
+          "95": 12
+        }
+      },
+      "CYCLE_COLLECTOR_FINISH_IGC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_FULL": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 90975,
+        "values": {
+          "114": 87,
+          "135": 126,
+          "160": 63,
+          "1782": 3,
+          "190": 88,
+          "2117": 1,
+          "226": 3,
+          "24": 0,
+          "268": 8,
+          "29": 1,
+          "318": 2,
+          "34": 8,
+          "378": 1,
+          "40": 4,
+          "4222": 1,
+          "449": 3,
+          "48": 1,
+          "5017": 0,
+          "533": 1,
+          "68": 18,
+          "752": 3,
+          "894": 4,
+          "96": 57
+        }
+      },
+      "CYCLE_COLLECTOR_MAX_PAUSE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 2611,
+        "values": {
+          "10": 6,
+          "12": 1,
+          "14": 5,
+          "17": 2,
+          "24": 1,
+          "29": 0,
+          "3": 0,
+          "4": 4,
+          "5": 419,
+          "6": 35,
+          "7": 4,
+          "8": 6
+        }
+      },
+      "CYCLE_COLLECTOR_NEED_GC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_OOM": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_SYNC_SKIPPABLE": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_TIME_BETWEEN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          120
+        ],
+        "sum": 38150,
+        "values": {
+          "1": 0,
+          "10": 23,
+          "100": 1,
+          "106": 3,
+          "11": 11,
+          "113": 4,
+          "12": 8,
+          "120": 86,
+          "13": 5,
+          "14": 4,
+          "15": 1,
+          "16": 3,
+          "17": 2,
+          "18": 8,
+          "19": 2,
+          "2": 1,
+          "20": 4,
+          "21": 5,
+          "22": 4,
+          "23": 13,
+          "25": 28,
+          "27": 14,
+          "29": 10,
+          "3": 1,
+          "31": 5,
+          "33": 5,
+          "35": 5,
+          "37": 5,
+          "39": 2,
+          "42": 7,
+          "45": 4,
+          "48": 3,
+          "5": 4,
+          "51": 4,
+          "54": 5,
+          "57": 2,
+          "6": 161,
+          "61": 1,
+          "65": 5,
+          "69": 3,
+          "7": 5,
+          "73": 2,
+          "78": 4,
+          "8": 3,
+          "83": 1,
+          "88": 1,
+          "9": 3,
+          "94": 2
+        }
+      },
+      "CYCLE_COLLECTOR_VISITED_GCED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 6378709,
+        "values": {
+          "11508": 58,
+          "14789": 227,
+          "19005": 3,
+          "1988": 0,
+          "24423": 9,
+          "2555": 3,
+          "3283": 5,
+          "40334": 1,
+          "4219": 10,
+          "51833": 0,
+          "5422": 18,
+          "6968": 99,
+          "8955": 50
+        }
+      },
+      "CYCLE_COLLECTOR_VISITED_REF_COUNTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 1407559,
+        "values": {
+          "11508": 1,
+          "1204": 8,
+          "14789": 0,
+          "1547": 86,
+          "1988": 127,
+          "2555": 155,
+          "3283": 56,
+          "4219": 20,
+          "5422": 18,
+          "567": 0,
+          "6968": 8,
+          "729": 1,
+          "8955": 2,
+          "937": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 808,
+        "values": {
+          "0": 19628,
+          "1": 241,
+          "14": 1,
+          "2": 16,
+          "20": 1,
+          "24": 3,
+          "29": 4,
+          "3": 3,
+          "34": 8,
+          "40": 0,
+          "7": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_COLLECTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 255052,
+        "values": {
+          "0": 19434,
+          "10": 24,
+          "1122": 0,
+          "13": 111,
+          "16": 3,
+          "20": 5,
+          "25": 1,
+          "292": 1,
+          "31": 1,
+          "49": 5,
+          "5": 11,
+          "6": 10,
+          "61": 4,
+          "716": 136,
+          "76": 2,
+          "8": 18,
+          "896": 139,
+          "95": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_OOM": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_VISITED_GCED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 1476345,
+        "values": {
+          "10": 24,
+          "1204": 0,
+          "126": 1,
+          "162": 6610,
+          "17": 4,
+          "2": 0,
+          "28": 5,
+          "3": 12969,
+          "36": 6,
+          "46": 1,
+          "6": 11,
+          "729": 187,
+          "937": 88
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_VISITED_REF_COUNTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 22170,
+        "values": {
+          "0": 0,
+          "1": 19426,
+          "10": 5,
+          "126": 1,
+          "13": 1,
+          "162": 0,
+          "2": 8,
+          "28": 5,
+          "36": 6,
+          "4": 314,
+          "46": 1,
+          "6": 137,
+          "8": 2
+        }
+      },
+      "DATA_STORAGE_ENTRIES": {
+        "bucket_count": 16,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1024
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "DECODER_INSTANTIATED_IBM866": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_ISO2022JP": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_ISO_8859_5": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_KOI8R": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_KOI8U": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACARABIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCROATIAN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCYRILLIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACDEVANAGARI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACFARSI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGREEK": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGUJARATI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGURMUKHI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACHEBREW": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACICELANDIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACROMANIAN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACTURKISH": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEFERRED_FINALIZE_ASYNC": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 272,
+        "values": {
+          "0": 191,
+          "1": 37,
+          "2": 23,
+          "3": 15,
+          "4": 11,
+          "5": 20,
+          "6": 0
+        }
+      },
+      "DEVTOOLS_ABOUTDEBUGGING_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_ANIMATIONINSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_BROWSERCONSOLE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_CANVASDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_COMPUTEDVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_CUSTOM_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_DEVELOPERTOOLBAR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_FONTINSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_INSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSBROWSERDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSPROFILER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_LAYOUTVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_MENU_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_NETMONITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_OPTIONS_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PAINTFLASHING_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PERFTOOLS_RECORDING_EXPORT_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PERFTOOLS_RECORDING_IMPORT_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PICKER_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_RESPONSIVE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_RULEVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_SCRATCHPAD_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_SHADEREDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_STORAGE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_STYLEEDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TABS_OPEN_AVERAGE_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 46,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2116,
+        "values": {
+          "45": 0,
+          "46": 1,
+          "47": 0
+        }
+      },
+      "DEVTOOLS_TABS_OPEN_PEAK_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 72,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5184,
+        "values": {
+          "71": 0,
+          "72": 1,
+          "73": 0
+        }
+      },
+      "DEVTOOLS_TABS_PINNED_AVERAGE_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TABS_PINNED_PEAK_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TILT_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TOOLBOX_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBAUDIOEDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBCONSOLE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_IMPORT_PROJECT_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_NEW_PROJECT_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_PROJECT_EDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_PROJECT_EDITOR_SAVE_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DISPLAY_SCALING_OSX": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "DNS_BLACKLIST_COUNT": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          21
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 64,
+        "values": {
+          "0": 353,
+          "1": 4,
+          "2": 2,
+          "3": 4,
+          "4": 1,
+          "5": 0
+        }
+      },
+      "DNS_FAILED_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 434,
+        "values": {
+          "0": 2677,
+          "1": 95,
+          "118": 1,
+          "14": 1,
+          "146": 0,
+          "17": 2,
+          "2": 17,
+          "21": 1,
+          "3": 12,
+          "32": 1,
+          "4": 6,
+          "6": 1,
+          "7": 1
+        }
+      },
+      "DNS_LOOKUP_METHOD2": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 36255,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 166313,
+        "values": {
+          "0": 0,
+          "1": 7521,
+          "2": 1735,
+          "4": 12,
+          "6": 4142,
+          "7": 52,
+          "8": 0
+        }
+      },
+      "DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 23527,
+        "values": {
+          "0": 22,
+          "1": 1,
+          "11": 8,
+          "118": 2,
+          "14": 2,
+          "17": 4,
+          "1929": 1,
+          "2": 3,
+          "21": 33,
+          "2391": 0,
+          "26": 4,
+          "278": 4,
+          "3": 18,
+          "32": 9,
+          "345": 27,
+          "4": 9,
+          "40": 8,
+          "428": 2,
+          "5": 4,
+          "50": 6,
+          "531": 6,
+          "6": 4,
+          "62": 9,
+          "658": 2,
+          "7": 10,
+          "77": 1,
+          "9": 20,
+          "95": 3
+        }
+      },
+      "DNS_RENEWAL_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 178252,
+        "values": {
+          "0": 1110,
+          "1": 225,
+          "1012": 2,
+          "11": 18,
+          "118": 2,
+          "1255": 0,
+          "14": 16,
+          "146": 2,
+          "17": 62,
+          "181": 2,
+          "2": 85,
+          "21": 38,
+          "224": 8,
+          "26": 19,
+          "278": 114,
+          "3": 286,
+          "32": 110,
+          "345": 279,
+          "4": 194,
+          "40": 30,
+          "428": 9,
+          "5": 41,
+          "50": 23,
+          "531": 3,
+          "6": 71,
+          "62": 21,
+          "658": 1,
+          "7": 38,
+          "77": 12,
+          "816": 2,
+          "9": 14,
+          "95": 3
+        }
+      },
+      "DNT_USAGE": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 2,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "3": 0
+        }
+      },
+      "E10S_AUTOSTART": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_AUTOSTART_STATUS": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_BLOCKED_FROM_RUNNING": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_STILL_ACCEPTED_FROM_PROMPT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_WINDOW": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 4,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4,
+        "values": {
+          "0": 0,
+          "1": 4,
+          "2": 0
+        }
+      },
+      "ENABLE_PRIVILEGE_EVER_CALLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "FIND_PLUGINS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FONT_CACHE_HIT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 156,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 156,
+        "values": {
+          "0": 26,
+          "1": 156,
+          "2": 0
+        }
+      },
+      "FORGET_SKIPPABLE_MAX": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1028,
+        "values": {
+          "0": 50,
+          "1": 110,
+          "10": 1,
+          "12": 0,
+          "2": 102,
+          "3": 192,
+          "4": 21,
+          "5": 2,
+          "6": 2,
+          "7": 2,
+          "8": 1
+        }
+      },
+      "FXA_CONFIGURED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "FX_BOOKMARKS_TOOLBAR_INIT_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 34,
+        "values": {
+          "0": 4,
+          "50": 0
+        }
+      },
+      "FX_NEW_WINDOW_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1156,
+        "values": {
+          "103": 0,
+          "171": 1,
+          "284": 3,
+          "472": 0
+        }
+      },
+      "FX_PAGE_LOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 71344,
+        "values": {
+          "1": 0,
+          "10000": 1,
+          "103": 2,
+          "13": 1,
+          "1306": 10,
+          "171": 3,
+          "2": 10,
+          "2172": 4,
+          "22": 5,
+          "284": 4,
+          "3613": 3,
+          "472": 9,
+          "62": 1,
+          "785": 11
+        }
+      },
+      "FX_REFRESH_DRIVER_CHROME_FRAME_DELAY_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 117293,
+        "values": {
+          "0": 42239,
+          "1": 34401,
+          "10": 541,
+          "114": 1,
+          "12": 552,
+          "135": 2,
+          "14": 915,
+          "160": 4,
+          "17": 398,
+          "190": 4,
+          "2": 426,
+          "20": 122,
+          "24": 97,
+          "268": 1,
+          "29": 64,
+          "3": 323,
+          "318": 4,
+          "34": 59,
+          "378": 0,
+          "4": 313,
+          "40": 67,
+          "48": 72,
+          "5": 327,
+          "57": 94,
+          "6": 325,
+          "68": 60,
+          "7": 243,
+          "8": 544,
+          "81": 55,
+          "96": 21
+        }
+      },
+      "FX_SESSION_RESTORE_ALL_FILES_CORRUPT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_COLLECT_ALL_WINDOWS_DATA_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1260,
+        "values": {
+          "0": 2,
+          "1": 82,
+          "14": 1,
+          "4": 192,
+          "50": 0
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_COOKIES_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 4359,
+        "values": {
+          "1": 0,
+          "14": 235,
+          "180": 0,
+          "4": 41,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_DATA_LONGEST_OP_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 5836,
+        "values": {
+          "14": 276,
+          "180": 0,
+          "4": 0,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_DATA_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 5845,
+        "values": {
+          "14": 276,
+          "180": 0,
+          "4": 0,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_CONTENT_COLLECT_DATA_LONGEST_OP_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 3232,
+        "values": {
+          "0": 197,
+          "1": 386,
+          "14": 0,
+          "4": 471
+        }
+      },
+      "FX_SESSION_RESTORE_CORRUPT_FILE": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_FILE_SIZE_BYTES": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          50000000
+        ],
+        "sum": 110907314,
+        "values": {
+          "168359": 0,
+          "316945": 277,
+          "596667": 0
+        }
+      },
+      "FX_SESSION_RESTORE_READ_FILE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_RESTORE_WINDOW_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_STARTUP_INIT_SESSION_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_STARTUP_ONLOAD_INITIAL_WINDOW_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_WRITE_FILE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 962,
+        "values": {
+          "0": 4,
+          "1": 171,
+          "21": 9,
+          "3": 83,
+          "57": 0,
+          "8": 10
+        }
+      },
+      "FX_TAB_ANIM_ANY_FRAME_INTERVAL_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          7,
+          500
+        ],
+        "sum": 379,
+        "values": {
+          "15": 0,
+          "16": 6,
+          "17": 6,
+          "19": 1,
+          "23": 1,
+          "29": 3,
+          "42": 1,
+          "46": 0
+        }
+      },
+      "FX_TAB_CLICK_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 153,
+        "values": {
+          "13": 0,
+          "4": 0,
+          "6": 9,
+          "9": 9
+        }
+      },
+      "FX_TAB_SWITCH_SPINNER_VISIBLE_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 296,
+        "values": {
+          "165": 0,
+          "237": 1,
+          "340": 0
+        }
+      },
+      "FX_TAB_SWITCH_TOTAL_E10S_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 8085,
+        "values": {
+          "1000": 0,
+          "115": 8,
+          "165": 3,
+          "19": 5,
+          "27": 9,
+          "39": 13,
+          "4": 0,
+          "56": 23,
+          "6": 1,
+          "698": 1,
+          "80": 34,
+          "9": 3
+        }
+      },
+      "FX_TAB_SWITCH_UPDATE_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 733,
+        "values": {
+          "13": 1,
+          "19": 0,
+          "3": 0,
+          "4": 3,
+          "6": 81,
+          "9": 15
+        }
+      },
+      "FX_THUMBNAILS_CAPTURE_TIME_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 5350,
+        "values": {
+          "129": 1,
+          "13": 0,
+          "203": 1,
+          "21": 8,
+          "319": 2,
+          "33": 53,
+          "500": 1,
+          "52": 9,
+          "82": 5
+        }
+      },
+      "FX_THUMBNAILS_STORE_TIME_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 144,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 10,
+          "3": 11,
+          "5": 16,
+          "8": 0
+        }
+      },
+      "FX_TOTAL_TOP_VISITS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 67,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 67,
+        "values": {
+          "0": 0,
+          "1": 67,
+          "2": 0
+        }
+      },
+      "GC_ANIMATION_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 4980,
+        "values": {
+          "0": 2,
+          "10": 131,
+          "12": 109,
+          "14": 98,
+          "17": 23,
+          "2": 2,
+          "20": 8,
+          "24": 5,
+          "29": 1,
+          "3": 3,
+          "34": 1,
+          "4": 1,
+          "40": 0,
+          "5": 2,
+          "7": 2,
+          "8": 1
+        }
+      },
+      "GC_BUDGET_MS": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 43030,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1604100,
+        "values": {
+          "0": 0,
+          "1": 389,
+          "13": 1,
+          "38": 978,
+          "51": 0
+        }
+      },
+      "GC_INCREMENTAL_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 278,
+          "1": 0
+        }
+      },
+      "GC_IS_COMPARTMENTAL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6,
+        "values": {
+          "0": 272,
+          "1": 6,
+          "2": 0
+        }
+      },
+      "GC_MARK_GRAY_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 1309,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6535,
+        "values": {
+          "0": 0,
+          "1": 121,
+          "13": 0,
+          "5": 154,
+          "9": 3
+        }
+      },
+      "GC_MARK_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 21834,
+        "values": {
+          "114": 2,
+          "135": 1,
+          "160": 0,
+          "40": 0,
+          "48": 4,
+          "57": 30,
+          "68": 147,
+          "81": 85,
+          "96": 9
+        }
+      },
+      "GC_MARK_ROOTS_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 1728,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14746,
+        "values": {
+          "0": 0,
+          "1": 150,
+          "13": 24,
+          "18": 5,
+          "22": 0,
+          "5": 70,
+          "9": 29
+        }
+      },
+      "GC_MAX_PAUSE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 11687,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 514373,
+        "values": {
+          "0": 0,
+          "1": 5,
+          "105": 1,
+          "126": 1,
+          "147": 0,
+          "22": 218,
+          "43": 50,
+          "63": 3
+        }
+      },
+      "GC_MINOR_REASON": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 30538,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1106536,
+        "values": {
+          "0": 1,
+          "1": 6,
+          "10": 13,
+          "11": 25,
+          "12": 665,
+          "14": 5,
+          "36": 159,
+          "42": 2,
+          "47": 141,
+          "48": 87,
+          "52": 105,
+          "53": 0,
+          "6": 1
+        }
+      },
+      "GC_MINOR_REASON_LONG": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 15622,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 492458,
+        "values": {
+          "0": 1,
+          "1": 2,
+          "10": 2,
+          "11": 10,
+          "12": 541,
+          "14": 4,
+          "36": 76,
+          "42": 2,
+          "47": 30,
+          "48": 5,
+          "52": 86,
+          "53": 0
+        }
+      },
+      "GC_MINOR_US": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1731016,
+        "values": {
+          "1026": 126,
+          "114": 0,
+          "1168": 110,
+          "12092": 1,
+          "130": 1,
+          "1330": 108,
+          "148": 1,
+          "1514": 85,
+          "168": 9,
+          "1724": 75,
+          "191": 4,
+          "1963": 61,
+          "217": 17,
+          "2235": 55,
+          "247": 11,
+          "2545": 41,
+          "26357": 1,
+          "281": 10,
+          "2898": 32,
+          "320": 16,
+          "3300": 13,
+          "34174": 1,
+          "364": 16,
+          "3758": 8,
+          "38913": 0,
+          "414": 25,
+          "4279": 5,
+          "471": 37,
+          "4872": 6,
+          "536": 34,
+          "5548": 4,
+          "610": 62,
+          "6317": 1,
+          "695": 62,
+          "7193": 1,
+          "791": 78,
+          "901": 93
+        }
+      },
+      "GC_MMU_50": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 4532,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 87730,
+        "values": {
+          "0": 29,
+          "1": 7,
+          "12": 11,
+          "18": 207,
+          "23": 3,
+          "29": 3,
+          "34": 2,
+          "45": 1,
+          "51": 0,
+          "7": 15
+        }
+      },
+      "GC_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 36722,
+        "values": {
+          "114": 113,
+          "135": 34,
+          "160": 36,
+          "190": 11,
+          "226": 4,
+          "268": 1,
+          "318": 0,
+          "68": 0,
+          "81": 4,
+          "96": 75
+        }
+      },
+      "GC_NON_INCREMENTAL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 2,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2,
+        "values": {
+          "0": 276,
+          "1": 2,
+          "2": 0
+        }
+      },
+      "GC_REASON_2": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 62692,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2912984,
+        "values": {
+          "0": 1,
+          "1": 6,
+          "14": 5,
+          "36": 159,
+          "42": 2,
+          "47": 978,
+          "48": 112,
+          "52": 105,
+          "53": 0,
+          "6": 1
+        }
+      },
+      "GC_RESET": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1369,
+          "1": 0
+        }
+      },
+      "GC_SCC_SWEEP_MAX_PAUSE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 1206,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 10800,
+        "values": {
+          "0": 0,
+          "1": 252,
+          "11": 22,
+          "22": 3,
+          "32": 1,
+          "43": 0
+        }
+      },
+      "GC_SCC_SWEEP_TOTAL_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 1548,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14010,
+        "values": {
+          "0": 0,
+          "1": 246,
+          "11": 28,
+          "22": 3,
+          "32": 1,
+          "43": 0
+        }
+      },
+      "GC_SLICE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 36329,
+        "values": {
+          "0": 5,
+          "1": 27,
+          "10": 140,
+          "114": 1,
+          "12": 122,
+          "135": 0,
+          "14": 109,
+          "17": 36,
+          "2": 20,
+          "20": 67,
+          "24": 120,
+          "29": 178,
+          "3": 9,
+          "34": 111,
+          "4": 4,
+          "40": 366,
+          "48": 25,
+          "5": 4,
+          "57": 4,
+          "6": 3,
+          "68": 3,
+          "7": 5,
+          "8": 9,
+          "96": 1
+        }
+      },
+      "GC_SLOW_PHASE": {
+        "bucket_count": 76,
+        "histogram_type": 1,
+        "range": [
+          1,
+          75
+        ],
+        "sum": 120,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 936,
+        "values": {
+          "10": 0,
+          "5": 0,
+          "6": 8,
+          "9": 8
+        }
+      },
+      "GC_SWEEP_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 8788,
+        "values": {
+          "14": 0,
+          "17": 1,
+          "20": 29,
+          "24": 83,
+          "29": 93,
+          "34": 35,
+          "40": 17,
+          "48": 14,
+          "57": 6,
+          "68": 0
+        }
+      },
+      "GEOLOCATION_ERROR": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "GHOST_WINDOWS": {
+        "bucket_count": 32,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 0,
+        "values": {
+          "0": 166,
+          "1": 0
+        }
+      },
+      "GRADIENT_DURATION": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          50000000
+        ],
+        "sum": 1153732,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "1056": 5,
+          "149": 737,
+          "21": 6871,
+          "2810": 0,
+          "3": 310,
+          "397": 852,
+          "56": 1454,
+          "8": 7602
+        }
+      },
+      "GRADIENT_RETENTION_TIME": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_COLLECT_CONSTANT_DATA_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 85,
+        "values": {
+          "19": 3,
+          "41": 0,
+          "9": 0
+        }
+      },
+      "HEALTHREPORT_COLLECT_DAILY_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 102,
+        "values": {
+          "193": 0,
+          "41": 0,
+          "89": 1
+        }
+      },
+      "HEALTHREPORT_DB_OPEN_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_GENERATE_JSON_PAYLOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 134,
+        "values": {
+          "114": 1,
+          "199": 0,
+          "65": 0
+        }
+      },
+      "HEALTHREPORT_INIT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_JSON_PAYLOAD_SERIALIZE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 2,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "HEALTHREPORT_PAYLOAD_COMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 1,
+        "range": [
+          1,
+          2000000
+        ],
+        "sum": 8013,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 64208169,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "10001": 0
+        }
+      },
+      "HEALTHREPORT_PAYLOAD_UNCOMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 1,
+        "range": [
+          1,
+          2000000
+        ],
+        "sum": 138621,
+        "sum_squares_hi": 4,
+        "sum_squares_lo": 2035912457,
+        "values": {
+          "120001": 0,
+          "130001": 1,
+          "140001": 0
+        }
+      },
+      "HEALTHREPORT_POST_COLLECT_CHECKPOINT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 13,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "19": 0,
+          "2": 1,
+          "9": 1
+        }
+      },
+      "HEALTHREPORT_SHUTDOWN_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 161,
+        "values": {
+          "193": 0,
+          "41": 0,
+          "89": 1
+        }
+      },
+      "HEALTHREPORT_UPLOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 60,
+        "values": {
+          "24": 0,
+          "44": 1,
+          "80": 0
+        }
+      },
+      "HTML_FOREGROUND_REFLOW_MS_2": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 65,
+        "values": {
+          "0": 91,
+          "1": 1,
+          "2": 1,
+          "37": 1,
+          "62": 0,
+          "8": 1
+        }
+      },
+      "HTTPCONNMGR_TOTAL_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1244,
+        "values": {
+          "0": 0,
+          "1": 1244,
+          "2": 0
+        }
+      },
+      "HTTPCONNMGR_UNUSED_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 174,
+        "values": {
+          "0": 0,
+          "1": 174,
+          "2": 0
+        }
+      },
+      "HTTPCONNMGR_USED_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1070,
+        "values": {
+          "0": 0,
+          "1": 1070,
+          "2": 0
+        }
+      },
+      "HTTP_AUTH_DIALOG_STATS": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 2,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "HTTP_CACHE_DISPOSITION_2_V2": {
+        "bucket_count": 6,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5
+        ],
+        "sum": 25613,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 97767,
+        "values": {
+          "0": 0,
+          "1": 1309,
+          "2": 41,
+          "3": 198,
+          "4": 5907,
+          "5": 0
+        }
+      },
+      "HTTP_CACHE_ENTRY_ALIVE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          7200000
+        ],
+        "sum": 46151811302,
+        "values": {
+          "1066088": 118,
+          "114814": 24,
+          "12365": 40,
+          "1332": 10,
+          "1465715": 26,
+          "157853": 35,
+          "17000": 64,
+          "1831": 45,
+          "2015144": 135,
+          "217025": 63,
+          "23373": 51,
+          "2517": 21,
+          "271": 0,
+          "2770529": 105,
+          "298378": 13,
+          "32134": 18,
+          "3461": 22,
+          "373": 4,
+          "3809073": 177,
+          "410226": 27,
+          "44180": 51,
+          "4758": 50,
+          "513": 22,
+          "5236919": 72,
+          "564001": 150,
+          "60741": 106,
+          "6542": 6,
+          "705": 67,
+          "7200000": 1502,
+          "775419": 37,
+          "83510": 75,
+          "8994": 14,
+          "969": 57
+        }
+      },
+      "HTTP_CACHE_ENTRY_RELOAD_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          900000
+        ],
+        "sum": 35104963,
+        "values": {
+          "101437": 14,
+          "110": 1,
+          "11433": 6,
+          "133261": 8,
+          "15020": 12,
+          "1693": 4,
+          "175069": 6,
+          "191": 1,
+          "19732": 5,
+          "2224": 8,
+          "229993": 15,
+          "25922": 4,
+          "2922": 8,
+          "302148": 3,
+          "330": 3,
+          "34054": 2,
+          "3839": 11,
+          "396941": 5,
+          "44738": 9,
+          "5043": 7,
+          "521473": 5,
+          "569": 1,
+          "58774": 7,
+          "64": 0,
+          "6625": 2,
+          "685073": 22,
+          "747": 2,
+          "77213": 6,
+          "84": 2,
+          "8703": 20,
+          "900000": 2,
+          "981": 3
+        }
+      },
+      "HTTP_CACHE_ENTRY_REUSE_COUNT": {
+        "bucket_count": 19,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 3830,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 13966,
+        "values": {
+          "0": 119,
+          "1": 2875,
+          "10": 3,
+          "11": 1,
+          "13": 1,
+          "18": 2,
+          "2": 116,
+          "20": 11,
+          "3": 32,
+          "4": 14,
+          "5": 27,
+          "7": 2,
+          "8": 2,
+          "9": 2
+        }
+      },
+      "HTTP_CACHE_MISS_HALFLIFE_EXPERIMENT_2": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 5907,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5907,
+        "values": {
+          "0": 0,
+          "1": 5907,
+          "2": 0
+        }
+      },
+      "HTTP_CONTENT_ENCODING": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 97,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 97,
+        "values": {
+          "0": 0,
+          "1": 97,
+          "2": 0
+        }
+      },
+      "HTTP_KBREAD_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 109871,
+        "values": {
+          "0": 90,
+          "1": 14,
+          "10": 5,
+          "106": 6,
+          "12": 6,
+          "123": 1,
+          "14": 4,
+          "142": 4,
+          "16": 7,
+          "164": 3,
+          "19": 4,
+          "190": 1,
+          "2": 11,
+          "22": 10,
+          "220": 1,
+          "25": 5,
+          "29": 5,
+          "3": 5,
+          "3000": 1,
+          "34": 1,
+          "340": 2,
+          "39": 1,
+          "4": 2,
+          "45": 2,
+          "5": 3,
+          "52": 4,
+          "525": 1,
+          "6": 2,
+          "60": 3,
+          "607": 1,
+          "69": 4,
+          "7": 2,
+          "8": 2,
+          "80": 6,
+          "9": 2,
+          "92": 3
+        }
+      },
+      "HTTP_OFFLINE_CACHE_DOCUMENT_LOAD": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 99,
+          "1": 0
+        }
+      },
+      "HTTP_PAGELOAD_IS_SSL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 76,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 76,
+        "values": {
+          "0": 14,
+          "1": 76,
+          "2": 0
+        }
+      },
+      "HTTP_PAGE_COMPLETE_LOAD_NET_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 68,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_COMPLETE_LOAD_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 68,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_DNS_ISSUE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 35,
+        "values": {
+          "29": 0,
+          "35": 1,
+          "43": 0
+        }
+      },
+      "HTTP_PAGE_DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 3,
+        "values": {
+          "2": 0,
+          "3": 1,
+          "4": 0
+        }
+      },
+      "HTTP_PAGE_FIRST_SENT_TO_LAST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 6,
+        "values": {
+          "5": 0,
+          "6": 1,
+          "7": 0
+        }
+      },
+      "HTTP_PAGE_OPEN_TO_FIRST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 66,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_OPEN_TO_FIRST_SENT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 61,
+        "values": {
+          "43": 0,
+          "52": 1,
+          "63": 0
+        }
+      },
+      "HTTP_PROXY_TYPE": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 6808,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6808,
+        "values": {
+          "0": 0,
+          "1": 6808,
+          "2": 0
+        }
+      },
+      "HTTP_REQUEST_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 1319,
+        "values": {
+          "0": 728,
+          "1": 740,
+          "10": 2,
+          "11": 1,
+          "12": 2,
+          "14": 1,
+          "16": 1,
+          "18": 1,
+          "2": 32,
+          "20": 3,
+          "23": 3,
+          "29": 1,
+          "3": 31,
+          "33": 0,
+          "4": 9,
+          "5": 6,
+          "6": 4,
+          "7": 3,
+          "8": 2,
+          "9": 3
+        }
+      },
+      "HTTP_REQUEST_PER_PAGE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 15,
+        "values": {
+          "12": 0,
+          "14": 1,
+          "16": 0
+        }
+      },
+      "HTTP_REQUEST_PER_PAGE_FROM_CACHE": {
+        "bucket_count": 102,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "HTTP_RESPONSE_VERSION": {
+        "bucket_count": 49,
+        "histogram_type": 1,
+        "range": [
+          1,
+          48
+        ],
+        "sum": 116386,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2255846,
+        "values": {
+          "10": 0,
+          "11": 726,
+          "20": 5420,
+          "21": 0
+        }
+      },
+      "HTTP_SAW_QUIC_ALT_PROTOCOL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 5415,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5415,
+        "values": {
+          "0": 731,
+          "1": 5415,
+          "2": 0
+        }
+      },
+      "HTTP_SCHEME_UPGRADE": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 187,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 205,
+        "values": {
+          "0": 7942,
+          "1": 178,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "HTTP_SUBITEM_FIRST_BYTE_LATENCY_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1313,
+        "values": {
+          "115": 3,
+          "140": 3,
+          "209": 1,
+          "255": 0,
+          "52": 0,
+          "63": 1,
+          "77": 1,
+          "94": 1
+        }
+      },
+      "HTTP_SUBITEM_OPEN_LATENCY_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1185,
+        "values": {
+          "0": 1,
+          "115": 1,
+          "140": 1,
+          "171": 0,
+          "63": 12
+        }
+      },
+      "HTTP_SUB_COMPLETE_LOAD_NET_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 509,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "29": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_COMPLETE_LOAD_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 509,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "29": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_DNS_ISSUE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 112,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "29": 1,
+          "35": 1,
+          "43": 0,
+          "7": 4,
+          "9": 2
+        }
+      },
+      "HTTP_SUB_DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 15,
+        "values": {
+          "0": 3,
+          "2": 3,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "HTTP_SUB_FIRST_SENT_TO_LAST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 127,
+        "values": {
+          "11": 5,
+          "13": 2,
+          "24": 1,
+          "29": 0,
+          "5": 0,
+          "6": 1,
+          "9": 1
+        }
+      },
+      "HTTP_SUB_OPEN_TO_FIRST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 495,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "20": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_OPEN_TO_FIRST_SENT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 375,
+        "values": {
+          "16": 1,
+          "24": 1,
+          "29": 3,
+          "52": 3,
+          "6": 0,
+          "63": 1,
+          "7": 1,
+          "77": 0
+        }
+      },
+      "HTTP_TRANSACTION_IS_SSL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6026,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6026,
+        "values": {
+          "0": 120,
+          "1": 6026,
+          "2": 0
+        }
+      },
+      "HTTP_TRANSACTION_USE_ALTSVC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 8151,
+          "1": 0
+        }
+      },
+      "IDLE_NOTIFY_IDLE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 5,
+        "values": {
+          "0": 10,
+          "1": 5,
+          "3": 0
+        }
+      },
+      "IMAGE_DECODE_CHUNKS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 768,
+        "values": {
+          "0": 0,
+          "1": 731,
+          "2": 9,
+          "6": 2,
+          "7": 1,
+          "8": 0
+        }
+      },
+      "IMAGE_DECODE_COUNT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "IMAGE_DECODE_ON_DRAW_LATENCY": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          50000000
+        ],
+        "sum": 12610301,
+        "values": {
+          "0": 11,
+          "101216": 33,
+          "116539": 12,
+          "12216": 1,
+          "134181": 11,
+          "14065": 3,
+          "154494": 1,
+          "16194": 5,
+          "177882": 0,
+          "18646": 4,
+          "66311": 7,
+          "6951": 1,
+          "76350": 19,
+          "8003": 2,
+          "87908": 37
+        }
+      },
+      "IMAGE_DECODE_SPEED_PNG": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          500,
+          50000000
+        ],
+        "sum": 8766850,
+        "values": {
+          "0": 1,
+          "1027": 2,
+          "11306": 102,
+          "1305": 3,
+          "14370": 90,
+          "1659": 1,
+          "18265": 64,
+          "2109": 2,
+          "23216": 35,
+          "2681": 19,
+          "29509": 16,
+          "3408": 32,
+          "37507": 25,
+          "4332": 37,
+          "47673": 0,
+          "500": 4,
+          "5506": 60,
+          "636": 3,
+          "6998": 69,
+          "808": 3,
+          "8895": 91
+        }
+      },
+      "IMAGE_DECODE_TIME": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          50000000
+        ],
+        "sum": 692307,
+        "values": {
+          "0": 332,
+          "102": 10,
+          "1112": 1,
+          "117": 7,
+          "1280": 2,
+          "135": 4,
+          "1474": 1,
+          "155": 3,
+          "1697": 37,
+          "178": 3,
+          "1954": 45,
+          "205": 1,
+          "2250": 38,
+          "236": 1,
+          "2591": 48,
+          "2983": 25,
+          "313": 1,
+          "3435": 23,
+          "360": 2,
+          "3955": 9,
+          "415": 2,
+          "478": 3,
+          "50": 53,
+          "5243": 1,
+          "550": 1,
+          "58": 24,
+          "6037": 6,
+          "67": 28,
+          "6951": 2,
+          "77": 18,
+          "8003": 1,
+          "89": 10,
+          "9215": 0,
+          "966": 1
+        }
+      },
+      "IMAGE_MAX_DECODE_COUNT": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "INNERWINDOWS_WITH_MUTATION_LISTENERS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 102,
+          "1": 0
+        }
+      },
+      "IPV4_AND_IPV6_ADDRESS_CONNECTIVITY": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 119,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 219,
+        "values": {
+          "0": 717,
+          "1": 28,
+          "2": 41,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "LINK_ICON_SIZES_ATTR_USAGE": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "LOCALDOMSTORAGE_SHUTDOWN_DATABASE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 5,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "MAC_INITFONTLIST_TOTAL": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "MASTER_PASSWORD_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "MEMORY_HEAP_ALLOCATED": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 55816789,
+        "values": {
+          "184722": 0,
+          "194001": 2,
+          "203746": 2,
+          "213980": 7,
+          "224728": 11,
+          "236016": 6,
+          "247871": 5,
+          "260322": 11,
+          "273398": 7,
+          "287131": 3,
+          "301554": 6,
+          "316701": 10,
+          "332609": 1,
+          "349316": 25,
+          "366862": 35,
+          "385290": 20,
+          "404644": 7,
+          "424970": 3,
+          "446317": 2,
+          "542979": 1,
+          "628980": 2,
+          "660574": 0
+        }
+      },
+      "MEMORY_HEAP_COMMITTED_UNUSED_RATIO": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 232,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 368,
+        "values": {
+          "0": 0,
+          "1": 166,
+          "5": 0
+        }
+      },
+      "MEMORY_IMAGES_CONTENT_USED_UNCOMPRESSED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          1048576
+        ],
+        "sum": 178932,
+        "values": {
+          "0": 112,
+          "1024": 11,
+          "10317": 2,
+          "1183": 1,
+          "11920": 0,
+          "1579": 19,
+          "1824": 8,
+          "2434": 6,
+          "3249": 2,
+          "8930": 5
+        }
+      },
+      "MEMORY_JS_COMPARTMENTS_SYSTEM": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 102689,
+        "values": {
+          "492": 0,
+          "554": 91,
+          "623": 75,
+          "701": 0
+        }
+      },
+      "MEMORY_JS_COMPARTMENTS_USER": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 889,
+        "values": {
+          "10": 0,
+          "4": 0,
+          "5": 115,
+          "6": 47,
+          "7": 2,
+          "9": 2
+        }
+      },
+      "MEMORY_JS_GC_HEAP": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 12229632,
+        "values": {
+          "59836": 0,
+          "62842": 40,
+          "65999": 3,
+          "69314": 64,
+          "80293": 59,
+          "84326": 0
+        }
+      },
+      "MEMORY_JS_MAIN_RUNTIME_TEMPORARY_PEAK": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 217792,
+        "values": {
+          "1246": 0,
+          "1309": 166,
+          "1375": 0
+        }
+      },
+      "MEMORY_RESIDENT": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          32768,
+          16777216
+        ],
+        "sum": 122195140,
+        "values": {
+          "1016084": 1,
+          "1048607": 12,
+          "1082171": 6,
+          "1116809": 4,
+          "1152556": 1,
+          "1189447": 3,
+          "1227519": 0,
+          "420537": 0,
+          "433998": 1,
+          "447889": 3,
+          "462225": 2,
+          "477020": 1,
+          "492288": 5,
+          "508045": 6,
+          "524306": 8,
+          "541088": 7,
+          "558407": 3,
+          "576280": 5,
+          "594726": 4,
+          "613762": 18,
+          "633407": 11,
+          "653681": 13,
+          "674604": 7,
+          "696197": 1,
+          "718481": 9,
+          "741478": 7,
+          "765211": 1,
+          "789704": 10,
+          "814981": 2,
+          "841067": 3,
+          "867988": 2,
+          "895771": 5,
+          "924443": 2,
+          "954033": 3
+        }
+      },
+      "MEMORY_STORAGE_SQLITE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          524288
+        ],
+        "sum": 2850088,
+        "values": {
+          "13777": 0,
+          "15689": 138,
+          "17866": 28,
+          "20346": 0
+        }
+      },
+      "MEMORY_VSIZE": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          32768,
+          16777216
+        ],
+        "sum": 723760328,
+        "values": {
+          "3416485": 0,
+          "3641037": 16,
+          "3880348": 21,
+          "4135388": 31,
+          "4407191": 85,
+          "4696859": 13,
+          "5005565": 0
+        }
+      },
+      "MIXED_CONTENT_HSTS": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 8,
+          "1": 0
+        }
+      },
+      "MOZ_SQLITE_COOKIES_OPEN_READAHEAD_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "MOZ_SQLITE_OPEN_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 980,
+        "values": {
+          "0": 2792,
+          "1": 176,
+          "154": 2,
+          "21": 2,
+          "3": 14,
+          "414": 0
+        }
+      },
+      "MOZ_SQLITE_OTHER_READ_B": {
+        "bucket_count": 3,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32768
+        ],
+        "sum": 3976276,
+        "sum_squares_hi": 29,
+        "sum_squares_lo": 2583783760,
+        "values": {
+          "0": 0,
+          "1": 197,
+          "32768": 118
+        }
+      },
+      "MOZ_SQLITE_OTHER_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 2,
+        "values": {
+          "0": 40,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "MOZ_SQLITE_OTHER_WRITE_B": {
+        "bucket_count": 3,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32768
+        ],
+        "sum": 150749056,
+        "sum_squares_hi": 1149,
+        "sum_squares_lo": 504556576,
+        "values": {
+          "0": 0,
+          "1": 4594,
+          "32768": 4596
+        }
+      },
+      "MOZ_SQLITE_PLACES_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 234,
+        "values": {
+          "0": 316,
+          "1": 130,
+          "3": 15,
+          "8": 0
+        }
+      },
+      "MOZ_SQLITE_PLACES_WRITE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 30,
+        "values": {
+          "0": 9016,
+          "1": 21,
+          "3": 2,
+          "8": 0
+        }
+      },
+      "MOZ_SQLITE_WEBAPPS_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 36,
+        "values": {
+          "0": 23,
+          "1": 19,
+          "3": 2,
+          "8": 0
+        }
+      },
+      "NETWORK_CACHE_HASH_STATS": {
+        "bucket_count": 161,
+        "histogram_type": 1,
+        "range": [
+          1,
+          160
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NETWORK_CACHE_HIT_MISS_STAT_PER_CACHE_SIZE": {
+        "bucket_count": 41,
+        "histogram_type": 1,
+        "range": [
+          1,
+          40
+        ],
+        "sum": 47000,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 322796,
+        "values": {
+          "5": 0,
+          "6": 1034,
+          "7": 5828,
+          "8": 0
+        }
+      },
+      "NETWORK_CACHE_HIT_RATE_PER_CACHE_SIZE": {
+        "bucket_count": 401,
+        "histogram_type": 1,
+        "range": [
+          1,
+          400
+        ],
+        "sum": 338,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 28374,
+        "values": {
+          "123": 1,
+          "124": 0,
+          "2": 0,
+          "23": 1,
+          "3": 1,
+          "43": 1,
+          "63": 1,
+          "83": 1
+        }
+      },
+      "NETWORK_CACHE_METADATA_FIRST_READ_SIZE": {
+        "bucket_count": 256,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5119
+        ],
+        "sum": 3007666,
+        "sum_squares_hi": 2,
+        "sum_squares_lo": 1604968888,
+        "values": {
+          "1008": 3,
+          "102": 3,
+          "1029": 1,
+          "1049": 6,
+          "1069": 3,
+          "1089": 3,
+          "1109": 1,
+          "1129": 8,
+          "1150": 4,
+          "1170": 3,
+          "1190": 6,
+          "1210": 1,
+          "122": 1,
+          "1230": 1,
+          "1250": 7,
+          "1270": 6,
+          "1291": 5,
+          "1311": 1,
+          "1331": 6,
+          "1351": 2,
+          "1391": 1,
+          "1411": 1,
+          "1452": 3,
+          "1472": 4,
+          "1492": 5,
+          "1512": 1,
+          "1532": 2,
+          "1553": 2,
+          "1573": 4,
+          "1593": 2,
+          "1613": 4,
+          "1633": 1,
+          "1653": 1,
+          "1673": 2,
+          "1694": 44,
+          "1714": 2,
+          "1754": 3,
+          "1774": 2,
+          "1794": 2,
+          "1814": 5,
+          "182": 10,
+          "1855": 3,
+          "1875": 3,
+          "1895": 2,
+          "1915": 1,
+          "1935": 2,
+          "1956": 4,
+          "1976": 9,
+          "1996": 4,
+          "2016": 2,
+          "202": 3,
+          "2036": 4,
+          "2076": 7,
+          "2097": 3,
+          "2117": 7,
+          "2137": 6,
+          "2157": 2,
+          "2177": 4,
+          "2197": 4,
+          "2217": 4,
+          "2238": 2,
+          "2258": 1,
+          "2278": 8,
+          "2298": 8,
+          "2318": 2,
+          "2359": 1,
+          "2379": 3,
+          "2399": 9,
+          "2419": 4,
+          "243": 8,
+          "2439": 2,
+          "2459": 17,
+          "2479": 21,
+          "2500": 3,
+          "2520": 5,
+          "2540": 5,
+          "2560": 6,
+          "2580": 6,
+          "2600": 7,
+          "2620": 7,
+          "263": 1,
+          "2641": 2,
+          "2661": 4,
+          "2681": 1,
+          "2701": 7,
+          "2721": 8,
+          "2741": 10,
+          "2761": 7,
+          "2782": 10,
+          "2802": 6,
+          "2822": 1,
+          "283": 6,
+          "2842": 11,
+          "2862": 4,
+          "2882": 3,
+          "2903": 3,
+          "2923": 5,
+          "2943": 10,
+          "2963": 9,
+          "2983": 10,
+          "3003": 3,
+          "3023": 14,
+          "303": 5,
+          "3044": 8,
+          "3064": 4,
+          "3084": 1,
+          "3124": 9,
+          "3144": 3,
+          "3185": 6,
+          "3205": 21,
+          "3225": 9,
+          "3245": 3,
+          "3265": 21,
+          "3285": 10,
+          "3306": 3,
+          "3326": 6,
+          "3346": 14,
+          "3366": 17,
+          "3386": 7,
+          "3406": 14,
+          "3426": 8,
+          "344": 7,
+          "3447": 8,
+          "3467": 4,
+          "3487": 9,
+          "3507": 7,
+          "3527": 1,
+          "3547": 6,
+          "3567": 10,
+          "3588": 3,
+          "3608": 6,
+          "3628": 3,
+          "364": 6,
+          "3648": 3,
+          "3668": 9,
+          "3688": 3,
+          "3709": 6,
+          "3729": 10,
+          "3749": 8,
+          "3769": 7,
+          "3789": 6,
+          "3809": 4,
+          "3829": 3,
+          "3850": 6,
+          "3870": 1,
+          "3890": 2,
+          "3910": 5,
+          "3930": 3,
+          "3950": 4,
+          "3970": 7,
+          "3991": 2,
+          "4011": 1,
+          "4031": 5,
+          "404": 1,
+          "4091": 4,
+          "41": 0,
+          "4112": 1,
+          "4132": 4,
+          "4152": 5,
+          "4172": 16,
+          "4192": 1,
+          "4212": 5,
+          "4232": 3,
+          "4253": 2,
+          "4273": 5,
+          "4293": 6,
+          "4313": 3,
+          "4333": 2,
+          "4353": 2,
+          "4373": 4,
+          "4414": 10,
+          "4434": 4,
+          "444": 1,
+          "4454": 3,
+          "4474": 6,
+          "4494": 3,
+          "4515": 2,
+          "4535": 4,
+          "4555": 2,
+          "4575": 6,
+          "4595": 10,
+          "4615": 6,
+          "4635": 5,
+          "464": 1,
+          "4656": 3,
+          "4676": 2,
+          "4716": 7,
+          "4736": 4,
+          "4756": 7,
+          "4797": 3,
+          "4857": 1,
+          "4897": 9,
+          "4918": 4,
+          "4938": 3,
+          "4958": 6,
+          "4978": 5,
+          "4998": 3,
+          "5018": 2,
+          "5059": 3,
+          "5079": 1,
+          "5099": 1,
+          "5119": 0,
+          "61": 4,
+          "686": 1,
+          "747": 2,
+          "82": 2
+        }
+      },
+      "NETWORK_CACHE_METADATA_FIRST_READ_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1021,
+        "values": {
+          "0": 712,
+          "1": 147,
+          "10": 9,
+          "12": 14,
+          "2": 57,
+          "29": 1,
+          "3": 44,
+          "34": 0,
+          "4": 8,
+          "5": 13,
+          "6": 21,
+          "7": 9,
+          "8": 5
+        }
+      },
+      "NETWORK_CACHE_METADATA_SECOND_READ_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 298,
+        "values": {
+          "0": 252,
+          "1": 41,
+          "10": 4,
+          "12": 2,
+          "14": 0,
+          "2": 10,
+          "3": 6,
+          "4": 13,
+          "5": 1,
+          "6": 2,
+          "7": 10,
+          "8": 2
+        }
+      },
+      "NETWORK_CACHE_METADATA_SIZE": {
+        "bucket_count": 256,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5119
+        ],
+        "sum": 3209747,
+        "sum_squares_hi": 3,
+        "sum_squares_lo": 1737291685,
+        "values": {
+          "1008": 2,
+          "102": 3,
+          "122": 1,
+          "1472": 1,
+          "1613": 1,
+          "1694": 40,
+          "182": 10,
+          "202": 3,
+          "2076": 1,
+          "2137": 4,
+          "2238": 1,
+          "2278": 1,
+          "2298": 2,
+          "2318": 1,
+          "2338": 3,
+          "2359": 28,
+          "2379": 5,
+          "2399": 3,
+          "2419": 27,
+          "243": 8,
+          "2439": 64,
+          "2459": 26,
+          "2479": 20,
+          "2500": 5,
+          "2520": 2,
+          "2540": 6,
+          "2560": 21,
+          "2580": 10,
+          "2600": 10,
+          "2620": 40,
+          "263": 1,
+          "2641": 8,
+          "2661": 15,
+          "2681": 4,
+          "2701": 4,
+          "2741": 4,
+          "2761": 3,
+          "2782": 13,
+          "2802": 1,
+          "2822": 1,
+          "283": 6,
+          "2842": 1,
+          "2862": 2,
+          "2882": 2,
+          "2943": 1,
+          "2963": 1,
+          "2983": 1,
+          "3023": 11,
+          "303": 6,
+          "3044": 3,
+          "3064": 4,
+          "3084": 7,
+          "3104": 17,
+          "3124": 35,
+          "3144": 19,
+          "3164": 59,
+          "3185": 30,
+          "3205": 38,
+          "3225": 31,
+          "323": 1,
+          "3245": 26,
+          "3265": 76,
+          "3285": 2,
+          "3306": 5,
+          "3326": 13,
+          "3346": 5,
+          "3366": 29,
+          "3386": 19,
+          "3406": 10,
+          "3426": 8,
+          "344": 7,
+          "3447": 8,
+          "3547": 4,
+          "3567": 9,
+          "3588": 5,
+          "3608": 2,
+          "3628": 1,
+          "364": 6,
+          "3648": 4,
+          "3668": 2,
+          "3688": 4,
+          "3729": 4,
+          "3809": 1,
+          "3829": 1,
+          "3890": 1,
+          "3991": 1,
+          "4031": 1,
+          "404": 1,
+          "4051": 4,
+          "4071": 9,
+          "41": 0,
+          "4152": 1,
+          "4172": 1,
+          "4192": 1,
+          "424": 1,
+          "4293": 1,
+          "4313": 1,
+          "444": 1,
+          "4454": 1,
+          "4494": 1,
+          "4555": 1,
+          "464": 4,
+          "4716": 1,
+          "4756": 1,
+          "4978": 1,
+          "505": 3,
+          "5079": 1,
+          "5119": 43,
+          "525": 1,
+          "545": 4,
+          "565": 4,
+          "585": 2,
+          "605": 2,
+          "61": 4,
+          "626": 1,
+          "646": 1,
+          "666": 1,
+          "747": 3,
+          "767": 1,
+          "787": 1,
+          "82": 2,
+          "908": 1,
+          "928": 2
+        }
+      },
+      "NETWORK_CACHE_V2_HIT_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 2967,
+        "values": {
+          "0": 399,
+          "1": 158,
+          "10": 17,
+          "12": 20,
+          "14": 19,
+          "17": 9,
+          "2": 174,
+          "20": 7,
+          "24": 9,
+          "29": 3,
+          "3": 88,
+          "34": 5,
+          "4": 53,
+          "40": 0,
+          "5": 32,
+          "6": 5,
+          "7": 20,
+          "8": 16
+        }
+      },
+      "NETWORK_CACHE_V2_INPUT_STREAM_STATUS": {
+        "bucket_count": 8,
+        "histogram_type": 1,
+        "range": [
+          1,
+          7
+        ],
+        "sum": 54,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 324,
+        "values": {
+          "0": 1555,
+          "6": 9,
+          "7": 0
+        }
+      },
+      "NETWORK_CACHE_V2_MISS_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 8,
+        "values": {
+          "0": 5824,
+          "2": 4,
+          "3": 0
+        }
+      },
+      "NETWORK_CACHE_V2_OUTPUT_STREAM_STATUS": {
+        "bucket_count": 8,
+        "histogram_type": 1,
+        "range": [
+          1,
+          7
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 5969,
+          "1": 0
+        }
+      },
+      "NETWORK_DISK_CACHE_TRASHRENAME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_BLOCKED_SITES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_ENHANCED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_LIFE_SPAN": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1200
+        ],
+        "sum": 187,
+        "values": {
+          "0": 2,
+          "12": 1,
+          "138": 1,
+          "145": 0,
+          "3": 2,
+          "4": 1,
+          "6": 1,
+          "7": 1,
+          "8": 1
+        }
+      },
+      "NEWTAB_PAGE_LIFE_SPAN_SUGGESTED": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1200
+        ],
+        "sum": 81,
+        "values": {
+          "12": 1,
+          "20": 1,
+          "42": 1,
+          "44": 0,
+          "6": 0,
+          "7": 1
+        }
+      },
+      "NEWTAB_PAGE_PINNED_SITES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          9
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "OSFILE_WORKER_LAUNCH_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "OSFILE_WORKER_READY_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "OSFILE_WRITEATOMIC_JANK_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 4,
+        "values": {
+          "0": 157,
+          "1": 4,
+          "3": 0
+        }
+      },
+      "PAGE_FAULTS_HARD": {
+        "bucket_count": 13,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          8,
+          65536
+        ],
+        "sum": 453,
+        "values": {
+          "0": 160,
+          "18": 3,
+          "211": 1,
+          "479": 0,
+          "8": 1,
+          "93": 1
+        }
+      },
+      "PAINT_BUILD_DISPLAYLIST_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 5384,
+        "values": {
+          "0": 6469,
+          "1": 4697,
+          "10": 2,
+          "2": 297,
+          "29": 2,
+          "3": 1,
+          "33": 0,
+          "8": 1
+        }
+      },
+      "PAINT_RASTERIZE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 23492,
+        "values": {
+          "0": 1335,
+          "1": 4667,
+          "10": 93,
+          "11": 42,
+          "12": 42,
+          "14": 10,
+          "16": 8,
+          "18": 3,
+          "192": 1,
+          "2": 3799,
+          "20": 2,
+          "216": 0,
+          "23": 5,
+          "26": 2,
+          "29": 3,
+          "3": 622,
+          "33": 10,
+          "37": 3,
+          "4": 157,
+          "42": 9,
+          "47": 5,
+          "5": 130,
+          "6": 125,
+          "60": 1,
+          "7": 81,
+          "75": 1,
+          "8": 137,
+          "84": 1,
+          "9": 175
+        }
+      },
+      "PLACES_ANNOS_BOOKMARKS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_ANNOS_PAGES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_AUTOCOMPLETE_1ST_RESULT_TIME_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          500
+        ],
+        "sum": 6752,
+        "values": {
+          "0": 51,
+          "119": 1,
+          "159": 11,
+          "212": 8,
+          "282": 1,
+          "375": 0,
+          "50": 4,
+          "67": 21,
+          "89": 2
+        }
+      },
+      "PLACES_AUTOCOMPLETE_6_FIRST_RESULTS_TIME_MS": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          1000
+        ],
+        "sum": 8561,
+        "values": {
+          "107": 2,
+          "132": 7,
+          "147": 4,
+          "164": 1,
+          "182": 2,
+          "202": 2,
+          "225": 1,
+          "250": 0,
+          "50": 0,
+          "56": 1,
+          "62": 7,
+          "69": 19,
+          "77": 24,
+          "86": 13,
+          "96": 5
+        }
+      },
+      "PLACES_BACKUPS_BOOKMARKSTREE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          2000
+        ],
+        "sum": 64,
+        "values": {
+          "0": 0,
+          "50": 1,
+          "79": 0
+        }
+      },
+      "PLACES_BACKUPS_TOJSON_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          2000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 1,
+          "50": 0
+        }
+      },
+      "PLACES_BOOKMARKS_COUNT": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          100,
+          8000
+        ],
+        "sum": 90,
+        "values": {
+          "0": 1,
+          "100": 0
+        }
+      },
+      "PLACES_DATABASE_FILESIZE_MB": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          5,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_DATABASE_PAGESIZE_B": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          32768
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_DATABASE_SIZE_PER_PAGE_B": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          500,
+          10240
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_FAVICON_ICO_SIZES": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          524288
+        ],
+        "sum": 897712,
+        "values": {
+          "1008": 0,
+          "1140": 3,
+          "1289": 6,
+          "16925": 1,
+          "21629": 1,
+          "362923": 1,
+          "3886": 2,
+          "410267": 1,
+          "463787": 0,
+          "4966": 1
+        }
+      },
+      "PLACES_FAVICON_PNG_SIZES": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          524288
+        ],
+        "sum": 10247,
+        "values": {
+          "141": 0,
+          "159": 1,
+          "2380": 1,
+          "3438": 1,
+          "3886": 0,
+          "427": 1,
+          "789": 4
+        }
+      },
+      "PLACES_IDLE_FRECENCY_DECAY_TIME_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_KEYWORDS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_MAINTENANCE_DAYSFROMLAST": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          7,
+          60
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_PAGES_COUNT": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1000,
+          150000
+        ],
+        "sum": 30798,
+        "values": {
+          "21371": 0,
+          "28231": 1,
+          "37292": 0
+        }
+      },
+      "PLACES_SORTED_BOOKMARKS_PERC": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PLACES_TAGGED_BOOKMARKS_PERC": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PLACES_TAGS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLUGIN_CALLED_DIRECTLY": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 20,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 25,
+        "values": {
+          "0": 757,
+          "1": 25,
+          "2": 0
+        }
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 15,
+          "1": 0
+        }
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 5,
+        "values": {
+          "0": 760,
+          "1": 5,
+          "2": 0
+        }
+      },
+      "PRCONNECT_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 23,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "PRCONNECT_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCONNECT_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 35,
+        "values": {
+          "0": 740,
+          "1": 35,
+          "2": 0
+        }
+      },
+      "PREDICTOR_BASE_CONFIDENCE": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 46520,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4041014,
+        "values": {
+          "0": 626,
+          "1": 30,
+          "100": 125,
+          "11": 16,
+          "13": 17,
+          "15": 6,
+          "18": 6,
+          "20": 4,
+          "22": 2,
+          "24": 17,
+          "26": 16,
+          "32": 6,
+          "36": 1,
+          "38": 16,
+          "40": 24,
+          "42": 6,
+          "44": 2,
+          "46": 1,
+          "48": 14,
+          "5": 52,
+          "51": 3,
+          "53": 3,
+          "57": 2,
+          "59": 6,
+          "61": 1,
+          "65": 10,
+          "69": 4,
+          "7": 33,
+          "71": 1,
+          "73": 3,
+          "75": 14,
+          "77": 1,
+          "79": 11,
+          "81": 9,
+          "84": 6,
+          "86": 6,
+          "88": 6,
+          "9": 35,
+          "90": 9,
+          "92": 16,
+          "94": 51,
+          "96": 52,
+          "98": 102
+        }
+      },
+      "PREDICTOR_CONFIDENCE": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 42687,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3553705,
+        "values": {
+          "0": 701,
+          "1": 19,
+          "100": 60,
+          "11": 21,
+          "13": 16,
+          "15": 13,
+          "22": 3,
+          "24": 12,
+          "26": 1,
+          "28": 2,
+          "3": 1,
+          "30": 4,
+          "32": 4,
+          "36": 1,
+          "38": 28,
+          "40": 8,
+          "42": 1,
+          "44": 1,
+          "46": 6,
+          "48": 8,
+          "5": 56,
+          "51": 6,
+          "55": 2,
+          "59": 9,
+          "63": 1,
+          "65": 11,
+          "69": 6,
+          "7": 5,
+          "73": 10,
+          "75": 5,
+          "77": 1,
+          "79": 10,
+          "81": 10,
+          "84": 13,
+          "86": 10,
+          "88": 210,
+          "9": 21,
+          "90": 31,
+          "92": 2,
+          "94": 39,
+          "96": 2,
+          "98": 1
+        }
+      },
+      "PREDICTOR_GLOBAL_DEGRADATION": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 980,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 47700,
+        "values": {
+          "0": 165,
+          "48": 19,
+          "5": 4,
+          "51": 0,
+          "9": 1
+        }
+      },
+      "PREDICTOR_LEARN_ATTEMPTS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1915,
+        "values": {
+          "0": 0,
+          "1": 1915,
+          "2": 0
+        }
+      },
+      "PREDICTOR_LEARN_WORK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 682,
+        "values": {
+          "0": 3390,
+          "1": 63,
+          "154": 0,
+          "21": 1,
+          "3": 39,
+          "57": 2,
+          "8": 23
+        }
+      },
+      "PREDICTOR_PREDICTIONS_CALCULATED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1528,
+        "values": {
+          "0": 0,
+          "1": 1528,
+          "2": 0
+        }
+      },
+      "PREDICTOR_PREDICT_TIME_TO_ACTION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 231,
+        "values": {
+          "0": 100,
+          "1": 17,
+          "154": 0,
+          "3": 14,
+          "57": 1,
+          "8": 7
+        }
+      },
+      "PREDICTOR_PREDICT_TIME_TO_INACTION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 119,
+        "values": {
+          "0": 36,
+          "1": 9,
+          "154": 0,
+          "3": 1,
+          "57": 1,
+          "8": 3
+        }
+      },
+      "PREDICTOR_PREDICT_WORK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 350,
+        "values": {
+          "0": 136,
+          "1": 26,
+          "154": 0,
+          "3": 15,
+          "57": 2,
+          "8": 10
+        }
+      },
+      "PREDICTOR_SUBRESOURCE_DEGRADATION": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 18400,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 591060,
+        "values": {
+          "0": 141,
+          "1": 535,
+          "24": 357,
+          "48": 139,
+          "51": 0,
+          "9": 199
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 135,
+        "values": {
+          "0": 167,
+          "1": 10,
+          "12": 1,
+          "16": 1,
+          "28": 2,
+          "3": 5,
+          "37": 0,
+          "5": 1,
+          "7": 1,
+          "9": 1
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_CREATED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 38,
+        "values": {
+          "0": 0,
+          "1": 38,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_UNUSED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 35,
+        "values": {
+          "0": 0,
+          "1": 35,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_USED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PREDICTIONS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 424,
+        "values": {
+          "0": 50,
+          "1": 68,
+          "12": 2,
+          "16": 1,
+          "2": 16,
+          "28": 2,
+          "3": 28,
+          "37": 0,
+          "5": 19,
+          "7": 2,
+          "9": 1
+        }
+      },
+      "PREDICTOR_TOTAL_PRERESOLVES": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 289,
+        "values": {
+          "0": 71,
+          "1": 58,
+          "12": 1,
+          "16": 0,
+          "2": 17,
+          "3": 23,
+          "5": 18,
+          "7": 1
+        }
+      },
+      "PREDICTOR_WAIT_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 1004,
+        "values": {
+          "0": 3540,
+          "1": 79,
+          "154": 0,
+          "21": 1,
+          "3": 51,
+          "57": 4,
+          "8": 32
+        }
+      },
+      "PUSH_API_USED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "PWMGR_BLOCKLIST_NUM_SITES": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_FORM_ACTION_EFFECT": {
+        "bucket_count": 6,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 2,
+          "1": 0
+        }
+      },
+      "PWMGR_LOGIN_LAST_USED_DAYS": {
+        "bucket_count": 40,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_HTTPAUTH_PASSWORDS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_PASSWORDS_PER_HOSTNAME": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          21
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_SAVED_PASSWORDS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_SAVING_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PWMGR_USERNAME_PRESENT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "REFRESH_DRIVER_TICK": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 40006,
+        "values": {
+          "0": 61092,
+          "1": 908,
+          "10": 80,
+          "11": 49,
+          "12": 127,
+          "14": 60,
+          "16": 22,
+          "18": 17,
+          "2": 2698,
+          "20": 9,
+          "23": 13,
+          "243": 1,
+          "26": 6,
+          "273": 0,
+          "29": 10,
+          "3": 2888,
+          "33": 9,
+          "37": 12,
+          "4": 2160,
+          "42": 8,
+          "47": 8,
+          "5": 784,
+          "53": 4,
+          "6": 271,
+          "7": 153,
+          "75": 3,
+          "8": 126,
+          "84": 1,
+          "9": 114
+        }
+      },
+      "SAFE_MODE_USAGE": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_INIT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_INIT_SYNC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_TIMEZONE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SEARCH_SERVICE_US_TIMEZONE_MISMATCHED_COUNTRY": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SERVICE_WORKER_REGISTRATION_LOADING": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SHOULD_AUTO_DETECT_LANGUAGE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SHOULD_TRANSLATION_UI_APPEAR": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SHUTDOWN_OK": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SHUTDOWN_PHASE_DURATION_TICKS_PROFILE_CHANGE_TEARDOWN": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          65
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SOCIAL_ENABLED_ON_SESSION": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SOCIAL_SIDEBAR_OPEN_DURATION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000000
+        ],
+        "sum": 8680007019,
+        "values": {
+          "10000000": 6,
+          "1320121": 0
+        }
+      },
+      "SPDY_CHUNK_RECVD": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 13602,
+        "values": {
+          "0": 21613,
+          "1": 496,
+          "10": 25,
+          "11": 6,
+          "12": 26,
+          "13": 11,
+          "14": 10,
+          "15": 58,
+          "16": 318,
+          "17": 0,
+          "2": 165,
+          "3": 148,
+          "4": 1023,
+          "5": 73,
+          "6": 44,
+          "7": 23,
+          "8": 58,
+          "9": 13
+        }
+      },
+      "SPDY_GOAWAY_LOCAL": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 48,
+        "values": {
+          "0": 328,
+          "2": 12,
+          "3": 0
+        }
+      },
+      "SPDY_GOAWAY_PEER": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 1343,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 32963,
+        "values": {
+          "0": 17,
+          "1": 289,
+          "31": 34,
+          "32": 0
+        }
+      },
+      "SPDY_KBREAD_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 16555,
+        "values": {
+          "0": 229,
+          "1": 31,
+          "10": 1,
+          "106": 5,
+          "1086": 1,
+          "12": 2,
+          "123": 2,
+          "14": 2,
+          "142": 2,
+          "16": 3,
+          "164": 1,
+          "190": 1,
+          "2": 4,
+          "22": 3,
+          "220": 4,
+          "2244": 1,
+          "254": 2,
+          "29": 1,
+          "294": 2,
+          "3": 4,
+          "3000": 1,
+          "39": 3,
+          "4": 4,
+          "45": 7,
+          "5": 2,
+          "525": 2,
+          "6": 4,
+          "60": 2,
+          "607": 3,
+          "69": 4,
+          "7": 1,
+          "702": 1,
+          "8": 2,
+          "80": 2,
+          "9": 1,
+          "92": 1,
+          "939": 1
+        }
+      },
+      "SPDY_NPN_CONNECT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 338,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 338,
+        "values": {
+          "0": 266,
+          "1": 338,
+          "2": 0
+        }
+      },
+      "SPDY_NPN_JOIN": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 58335,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 58335,
+        "values": {
+          "0": 844,
+          "1": 58335,
+          "2": 0
+        }
+      },
+      "SPDY_PARALLEL_STREAMS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 487,
+        "values": {
+          "0": 46,
+          "1": 233,
+          "14": 2,
+          "2": 27,
+          "3": 16,
+          "4": 13,
+          "47": 1,
+          "5": 2,
+          "53": 0,
+          "6": 2
+        }
+      },
+      "SPDY_REQUEST_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 7582,
+        "values": {
+          "0": 0,
+          "1": 2,
+          "10": 6,
+          "107": 1,
+          "11": 6,
+          "12": 8,
+          "120": 2,
+          "135": 2,
+          "14": 5,
+          "152": 3,
+          "16": 5,
+          "171": 1,
+          "18": 2,
+          "20": 2,
+          "216": 4,
+          "23": 3,
+          "26": 1,
+          "273": 1,
+          "29": 5,
+          "33": 1,
+          "37": 1,
+          "42": 2,
+          "437": 1,
+          "492": 1,
+          "6": 46,
+          "60": 2,
+          "7": 153,
+          "789": 1,
+          "8": 54,
+          "84": 1,
+          "888": 0,
+          "9": 18,
+          "95": 2
+        }
+      },
+      "SPDY_SERVER_INITIATED_STREAMS": {
+        "bucket_count": 250,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 342,
+          "1": 0
+        }
+      },
+      "SPDY_SETTINGS_IW": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 6632445,
+        "values": {
+          "1000": 336,
+          "888": 0
+        }
+      },
+      "SPDY_SETTINGS_MAX_STREAMS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 32844,
+        "values": {
+          "100": 321,
+          "123": 3,
+          "132": 0,
+          "27": 0,
+          "29": 12
+        }
+      },
+      "SPDY_SYN_RATIO": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          99
+        ],
+        "sum": 235213,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 13977361,
+        "values": {
+          "0": 0,
+          "1": 298,
+          "12": 453,
+          "17": 93,
+          "23": 132,
+          "28": 422,
+          "34": 574,
+          "39": 123,
+          "45": 119,
+          "50": 23,
+          "55": 219,
+          "6": 756,
+          "61": 306,
+          "66": 711,
+          "72": 1240,
+          "99": 2
+        }
+      },
+      "SPDY_SYN_REPLY_RATIO": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          99
+        ],
+        "sum": 75685,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2101841,
+        "values": {
+          "0": 0,
+          "1": 454,
+          "12": 198,
+          "17": 216,
+          "23": 307,
+          "28": 92,
+          "34": 33,
+          "39": 49,
+          "45": 19,
+          "50": 45,
+          "55": 138,
+          "6": 3698,
+          "61": 157,
+          "66": 13,
+          "88": 2,
+          "99": 1
+        }
+      },
+      "SPDY_SYN_REPLY_SIZE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          16,
+          20000
+        ],
+        "sum": 330321,
+        "values": {
+          "0": 313,
+          "101": 104,
+          "117": 59,
+          "136": 68,
+          "158": 96,
+          "16": 110,
+          "183": 41,
+          "19": 23,
+          "212": 128,
+          "22": 7,
+          "245": 83,
+          "26": 37,
+          "284": 88,
+          "30": 1501,
+          "329": 10,
+          "35": 2025,
+          "381": 12,
+          "41": 173,
+          "441": 3,
+          "48": 43,
+          "511": 5,
+          "56": 83,
+          "592": 12,
+          "65": 31,
+          "686": 0,
+          "75": 111,
+          "87": 256
+        }
+      },
+      "SPDY_SYN_SIZE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          20,
+          20000
+        ],
+        "sum": 8201935,
+        "values": {
+          "1126": 276,
+          "113": 34,
+          "130": 37,
+          "1300": 281,
+          "150": 56,
+          "1501": 108,
+          "173": 216,
+          "1733": 215,
+          "20": 0,
+          "200": 135,
+          "2001": 494,
+          "23": 1,
+          "231": 215,
+          "2311": 117,
+          "2669": 963,
+          "267": 142,
+          "27": 4,
+          "308": 57,
+          "3082": 394,
+          "31": 21,
+          "3559": 78,
+          "356": 181,
+          "36": 5,
+          "411": 38,
+          "4110": 0,
+          "42": 33,
+          "475": 14,
+          "48": 37,
+          "548": 35,
+          "55": 55,
+          "633": 21,
+          "64": 244,
+          "731": 242,
+          "74": 30,
+          "844": 263,
+          "85": 68,
+          "975": 328,
+          "98": 33
+        }
+      },
+      "SPDY_VERSION2": {
+        "bucket_count": 49,
+        "histogram_type": 1,
+        "range": [
+          1,
+          48
+        ],
+        "sum": 1688,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 8432,
+        "values": {
+          "3": 0,
+          "4": 2,
+          "5": 336,
+          "6": 0
+        }
+      },
+      "SSL_AUTH_ALGORITHM_FULL": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 647,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2039,
+        "values": {
+          "0": 0,
+          "1": 183,
+          "4": 116,
+          "5": 0
+        }
+      },
+      "SSL_AUTH_ECDSA_CURVE_FULL": {
+        "bucket_count": 37,
+        "histogram_type": 1,
+        "range": [
+          1,
+          36
+        ],
+        "sum": 2668,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 61364,
+        "values": {
+          "22": 0,
+          "23": 116,
+          "24": 0
+        }
+      },
+      "SSL_AUTH_RSA_KEY_SIZE_FULL": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 2136,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 25632,
+        "values": {
+          "11": 0,
+          "12": 178,
+          "13": 0
+        }
+      },
+      "SSL_BYTES_BEFORE_CERT_CALLBACK": {
+        "bucket_count": 64,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          32000
+        ],
+        "sum": 1176341,
+        "values": {
+          "2105": 0,
+          "2449": 3,
+          "2849": 50,
+          "3314": 83,
+          "3855": 140,
+          "4484": 5,
+          "5216": 8,
+          "6067": 13,
+          "7057": 0
+        }
+      },
+      "SSL_CERT_ERROR_OVERRIDES": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 302,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 302,
+        "values": {
+          "0": 0,
+          "1": 302,
+          "2": 0
+        }
+      },
+      "SSL_CIPHER_SUITE_FULL": {
+        "bucket_count": 129,
+        "histogram_type": 1,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 735,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 19367,
+        "values": {
+          "0": 0,
+          "1": 173,
+          "2": 116,
+          "5": 5,
+          "61": 5,
+          "62": 0
+        }
+      },
+      "SSL_CIPHER_SUITE_RESUMED": {
+        "bucket_count": 129,
+        "histogram_type": 1,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 2459,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 123615,
+        "values": {
+          "0": 0,
+          "1": 115,
+          "2": 158,
+          "5": 3,
+          "61": 33,
+          "62": 0
+        }
+      },
+      "SSL_HANDSHAKE_TYPE": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 959,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1811,
+        "values": {
+          "0": 0,
+          "1": 309,
+          "2": 270,
+          "3": 6,
+          "4": 23,
+          "5": 0
+        }
+      },
+      "SSL_HANDSHAKE_VERSION": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1810,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5416,
+        "values": {
+          "0": 0,
+          "1": 7,
+          "3": 601,
+          "4": 0
+        }
+      },
+      "SSL_KEA_ECDHE_CURVE_FULL": {
+        "bucket_count": 37,
+        "histogram_type": 1,
+        "range": [
+          1,
+          36
+        ],
+        "sum": 6762,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 155526,
+        "values": {
+          "22": 0,
+          "23": 294,
+          "24": 0
+        }
+      },
+      "SSL_KEA_RSA_KEY_SIZE_FULL": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 60,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 720,
+        "values": {
+          "11": 0,
+          "12": 5,
+          "13": 0
+        }
+      },
+      "SSL_KEY_EXCHANGE_ALGORITHM_FULL": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1181,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4709,
+        "values": {
+          "0": 0,
+          "1": 5,
+          "4": 294,
+          "5": 0
+        }
+      },
+      "SSL_KEY_EXCHANGE_ALGORITHM_RESUMED": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1137,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4449,
+        "values": {
+          "0": 0,
+          "1": 33,
+          "4": 276,
+          "5": 0
+        }
+      },
+      "SSL_NPN_TYPE": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1212,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3552,
+        "values": {
+          "0": 177,
+          "1": 42,
+          "3": 390,
+          "4": 0
+        }
+      },
+      "SSL_OBSERVED_END_ENTITY_CERTIFICATE_LIFETIME": {
+        "bucket_count": 126,
+        "histogram_type": 1,
+        "range": [
+          1,
+          125
+        ],
+        "sum": 14777,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1276745,
+        "values": {
+          "104": 7,
+          "105": 98,
+          "106": 0,
+          "11": 0,
+          "12": 153,
+          "15": 1,
+          "16": 11,
+          "45": 2,
+          "52": 17,
+          "53": 8,
+          "54": 1,
+          "56": 1,
+          "64": 1,
+          "74": 1,
+          "86": 1
+        }
+      },
+      "SSL_OCSP_STAPLING": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 518,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 950,
+        "values": {
+          "0": 0,
+          "1": 86,
+          "2": 216,
+          "3": 0
+        }
+      },
+      "SSL_PERMANENT_CERT_ERROR_OVERRIDES": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1024
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SSL_REASONS_FOR_NOT_FALSE_STARTING": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 124,
+        "values": {
+          "0": 271,
+          "2": 2,
+          "3": 2,
+          "7": 2,
+          "8": 0
+        }
+      },
+      "SSL_RESUMED_SESSION": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 309,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 309,
+        "values": {
+          "0": 299,
+          "1": 309,
+          "2": 0
+        }
+      },
+      "SSL_SERVER_AUTH_EKU": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 604,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1208,
+        "values": {
+          "1": 0,
+          "2": 302,
+          "3": 0
+        }
+      },
+      "SSL_SUCCESFUL_CERT_VALIDATION_TIME_MOZILLAPKIX": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 4087,
+        "values": {
+          "0": 8,
+          "1": 153,
+          "1012": 1,
+          "11": 1,
+          "1255": 0,
+          "14": 1,
+          "17": 4,
+          "181": 1,
+          "2": 72,
+          "26": 2,
+          "3": 26,
+          "4": 6,
+          "40": 4,
+          "428": 2,
+          "5": 5,
+          "50": 1,
+          "62": 8,
+          "7": 1,
+          "77": 3,
+          "9": 1,
+          "95": 2
+        }
+      },
+      "SSL_SYMMETRIC_CIPHER_FULL": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 2960,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29390,
+        "values": {
+          "10": 289,
+          "11": 0,
+          "6": 0,
+          "7": 10
+        }
+      },
+      "SSL_SYMMETRIC_CIPHER_RESUMED": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 2982,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29064,
+        "values": {
+          "10": 273,
+          "11": 0,
+          "6": 0,
+          "7": 36
+        }
+      },
+      "SSL_TIME_UNTIL_HANDSHAKE_FINISHED": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 44537,
+        "values": {
+          "10": 1,
+          "100": 4,
+          "105": 13,
+          "11": 3,
+          "110": 5,
+          "115": 5,
+          "12": 7,
+          "120": 4,
+          "126": 11,
+          "13": 22,
+          "132": 7,
+          "138": 6,
+          "14": 34,
+          "144": 7,
+          "15": 29,
+          "151": 6,
+          "158": 1,
+          "16": 23,
+          "165": 1,
+          "17": 20,
+          "173": 1,
+          "18": 17,
+          "181": 3,
+          "189": 2,
+          "19": 12,
+          "198": 2,
+          "20": 7,
+          "207": 1,
+          "21": 13,
+          "217": 1,
+          "22": 11,
+          "227": 5,
+          "23": 13,
+          "237": 12,
+          "24": 16,
+          "248": 6,
+          "25": 17,
+          "259": 2,
+          "26": 12,
+          "27": 13,
+          "28": 8,
+          "283": 2,
+          "29": 8,
+          "296": 1,
+          "30": 4,
+          "31": 5,
+          "310": 1,
+          "32": 5,
+          "324": 3,
+          "33": 10,
+          "339": 8,
+          "35": 7,
+          "355": 5,
+          "37": 10,
+          "371": 3,
+          "39": 7,
+          "41": 6,
+          "43": 2,
+          "445": 1,
+          "45": 3,
+          "47": 1,
+          "486": 1,
+          "49": 7,
+          "51": 3,
+          "53": 7,
+          "55": 10,
+          "555": 2,
+          "58": 15,
+          "608": 1,
+          "61": 6,
+          "636": 0,
+          "64": 8,
+          "67": 2,
+          "70": 6,
+          "73": 3,
+          "76": 5,
+          "8": 0,
+          "80": 10,
+          "84": 17,
+          "88": 15,
+          "9": 1,
+          "92": 9,
+          "96": 5
+        }
+      },
+      "SSL_TIME_UNTIL_READY": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 35761,
+        "values": {
+          "10": 1,
+          "100": 4,
+          "105": 12,
+          "11": 3,
+          "110": 4,
+          "115": 4,
+          "12": 7,
+          "120": 10,
+          "126": 3,
+          "13": 22,
+          "132": 3,
+          "138": 1,
+          "14": 37,
+          "144": 1,
+          "15": 34,
+          "151": 4,
+          "158": 3,
+          "16": 28,
+          "165": 2,
+          "17": 28,
+          "173": 3,
+          "18": 26,
+          "181": 5,
+          "189": 5,
+          "19": 15,
+          "20": 13,
+          "207": 1,
+          "21": 24,
+          "217": 2,
+          "22": 13,
+          "227": 10,
+          "23": 12,
+          "237": 11,
+          "24": 16,
+          "248": 5,
+          "25": 17,
+          "259": 2,
+          "26": 12,
+          "27": 6,
+          "28": 5,
+          "283": 1,
+          "29": 4,
+          "296": 1,
+          "30": 1,
+          "31": 1,
+          "310": 1,
+          "32": 3,
+          "33": 10,
+          "35": 6,
+          "355": 1,
+          "37": 3,
+          "388": 1,
+          "39": 14,
+          "41": 11,
+          "43": 7,
+          "45": 6,
+          "47": 4,
+          "486": 1,
+          "49": 7,
+          "51": 2,
+          "53": 6,
+          "55": 12,
+          "58": 12,
+          "608": 1,
+          "61": 12,
+          "636": 0,
+          "64": 13,
+          "67": 4,
+          "70": 4,
+          "73": 4,
+          "76": 4,
+          "8": 0,
+          "80": 5,
+          "84": 11,
+          "88": 14,
+          "9": 1,
+          "92": 5,
+          "96": 2
+        }
+      },
+      "STARTUP_CACHE_INVALID": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "STARTUP_CRASH_DETECTED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "STS_NUMBER_OF_ONSOCKETREADY_CALLS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 58775,
+        "values": {
+          "0": 46630,
+          "1": 56822,
+          "2": 604,
+          "3": 121,
+          "4": 51,
+          "5": 22,
+          "6": 9,
+          "7": 2,
+          "8": 0
+        }
+      },
+      "STS_NUMBER_OF_PENDING_EVENTS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 78594,
+        "values": {
+          "1": 0,
+          "10": 10,
+          "11": 7,
+          "12": 8,
+          "13": 8,
+          "14": 4,
+          "15": 3,
+          "16": 3,
+          "17": 1,
+          "18": 2,
+          "19": 2,
+          "2": 31581,
+          "20": 1,
+          "22": 2,
+          "25": 3,
+          "27": 2,
+          "3": 3147,
+          "31": 3,
+          "33": 3,
+          "35": 1,
+          "37": 2,
+          "39": 1,
+          "4": 650,
+          "5": 184,
+          "52": 1,
+          "55": 1,
+          "58": 1,
+          "6": 72,
+          "62": 0,
+          "7": 48,
+          "8": 26,
+          "9": 19
+        }
+      },
+      "STS_NUMBER_OF_PENDING_EVENTS_IN_THE_LAST_CYCLE": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 2,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "3": 0
+        }
+      },
+      "STS_POLL_AND_EVENTS_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 77521,
+        "values": {
+          "0": 27522,
+          "1": 774,
+          "10": 380,
+          "11": 173,
+          "110": 1,
+          "115": 1,
+          "118": 1,
+          "12": 181,
+          "13": 229,
+          "14": 215,
+          "148": 1,
+          "15": 177,
+          "153": 1,
+          "155": 2,
+          "16": 134,
+          "164": 1,
+          "166": 1,
+          "17": 143,
+          "18": 129,
+          "19": 107,
+          "2": 1040,
+          "20": 91,
+          "205": 1,
+          "206": 0,
+          "21": 66,
+          "22": 57,
+          "23": 55,
+          "24": 31,
+          "25": 54,
+          "26": 47,
+          "27": 39,
+          "28": 33,
+          "29": 33,
+          "3": 934,
+          "30": 29,
+          "31": 14,
+          "32": 18,
+          "33": 19,
+          "34": 11,
+          "35": 13,
+          "36": 16,
+          "37": 9,
+          "38": 6,
+          "39": 15,
+          "4": 529,
+          "40": 8,
+          "41": 12,
+          "42": 13,
+          "43": 4,
+          "44": 12,
+          "45": 9,
+          "46": 9,
+          "47": 10,
+          "48": 8,
+          "49": 8,
+          "5": 307,
+          "50": 8,
+          "51": 8,
+          "52": 4,
+          "54": 4,
+          "55": 4,
+          "56": 4,
+          "57": 5,
+          "58": 2,
+          "59": 3,
+          "6": 347,
+          "61": 1,
+          "62": 3,
+          "63": 1,
+          "64": 4,
+          "65": 2,
+          "67": 1,
+          "68": 1,
+          "69": 2,
+          "7": 581,
+          "70": 3,
+          "71": 1,
+          "74": 1,
+          "75": 2,
+          "78": 2,
+          "8": 484,
+          "81": 1,
+          "82": 1,
+          "83": 2,
+          "84": 1,
+          "85": 1,
+          "87": 2,
+          "9": 573,
+          "96": 2,
+          "97": 1,
+          "99": 1
+        }
+      },
+      "STS_POLL_AND_EVENT_THE_LAST_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "STS_POLL_BLOCK_TIME": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 38277641,
+        "values": {
+          "0": 65851,
+          "1": 4074,
+          "10": 164,
+          "100": 37,
+          "10005": 56,
+          "1006": 63,
+          "10077": 8,
+          "101": 32,
+          "1013": 27,
+          "10149": 10,
+          "102": 34,
+          "1020": 85,
+          "10222": 9,
+          "1027": 25,
+          "10295": 12,
+          "103": 32,
+          "1034": 23,
+          "10369": 8,
+          "104": 37,
+          "1041": 14,
+          "10443": 17,
+          "1048": 23,
+          "105": 27,
+          "10518": 9,
+          "1056": 18,
+          "10593": 6,
+          "106": 22,
+          "1064": 18,
+          "10669": 5,
+          "107": 30,
+          "1072": 23,
+          "10745": 13,
+          "108": 27,
+          "1080": 22,
+          "10822": 9,
+          "1088": 19,
+          "109": 26,
+          "10900": 6,
+          "1096": 22,
+          "10978": 7,
+          "11": 169,
+          "110": 36,
+          "1104": 36,
+          "11057": 7,
+          "111": 34,
+          "1112": 22,
+          "11136": 5,
+          "112": 42,
+          "1120": 78,
+          "11216": 9,
+          "1128": 32,
+          "11296": 7,
+          "113": 53,
+          "1136": 18,
+          "11377": 7,
+          "114": 46,
+          "1144": 29,
+          "11458": 10,
+          "115": 35,
+          "1152": 17,
+          "11540": 3,
+          "116": 41,
+          "1160": 22,
+          "11623": 15,
+          "1168": 24,
+          "117": 38,
+          "11706": 10,
+          "1176": 21,
+          "11790": 8,
+          "118": 40,
+          "1184": 23,
+          "11874": 6,
+          "119": 29,
+          "1192": 24,
+          "11959": 7,
+          "12": 153,
+          "120": 29,
+          "1201": 33,
+          "12045": 11,
+          "121": 21,
+          "1210": 27,
+          "12131": 14,
+          "1219": 37,
+          "122": 34,
+          "12218": 11,
+          "1228": 65,
+          "123": 34,
+          "12306": 5,
+          "1237": 27,
+          "12394": 2,
+          "124": 35,
+          "1246": 28,
+          "12483": 7,
+          "125": 28,
+          "1255": 26,
+          "12572": 5,
+          "126": 27,
+          "1264": 18,
+          "12662": 7,
+          "127": 29,
+          "1273": 20,
+          "12753": 6,
+          "128": 31,
+          "1282": 17,
+          "12844": 7,
+          "129": 28,
+          "1291": 28,
+          "12936": 8,
+          "13": 142,
+          "130": 32,
+          "1300": 27,
+          "13029": 2,
+          "1309": 26,
+          "131": 38,
+          "13122": 3,
+          "1318": 36,
+          "132": 26,
+          "13216": 2,
+          "1327": 88,
+          "133": 36,
+          "13311": 4,
+          "1337": 24,
+          "134": 32,
+          "13406": 4,
+          "1347": 27,
+          "135": 32,
+          "13502": 9,
+          "1357": 11,
+          "13599": 3,
+          "136": 32,
+          "1367": 24,
+          "13696": 3,
+          "137": 31,
+          "1377": 19,
+          "13794": 11,
+          "138": 29,
+          "1387": 21,
+          "13893": 3,
+          "139": 25,
+          "1397": 25,
+          "13993": 7,
+          "14": 173,
+          "140": 26,
+          "1407": 25,
+          "14093": 12,
+          "141": 25,
+          "1417": 24,
+          "14194": 5,
+          "142": 29,
+          "1427": 43,
+          "14296": 5,
+          "143": 22,
+          "1437": 21,
+          "14398": 10,
+          "144": 27,
+          "1447": 22,
+          "145": 30,
+          "14501": 5,
+          "1457": 17,
+          "146": 29,
+          "14605": 3,
+          "1467": 18,
+          "147": 31,
+          "14710": 6,
+          "1478": 19,
+          "148": 27,
+          "14815": 1,
+          "1489": 22,
+          "149": 48,
+          "14921": 19,
+          "15": 281,
+          "150": 26,
+          "1500": 25,
+          "15028": 2,
+          "151": 21,
+          "1511": 22,
+          "15136": 4,
+          "152": 29,
+          "1522": 37,
+          "15244": 4,
+          "153": 32,
+          "1533": 59,
+          "15353": 4,
+          "154": 27,
+          "1544": 28,
+          "15463": 8,
+          "155": 24,
+          "1555": 23,
+          "156": 21,
+          "1566": 20,
+          "15686": 4,
+          "157": 30,
+          "1577": 27,
+          "15798": 2,
+          "158": 19,
+          "1588": 14,
+          "159": 34,
+          "15911": 3,
+          "1599": 33,
+          "16": 800,
+          "160": 39,
+          "16025": 3,
+          "161": 25,
+          "1610": 17,
+          "16140": 3,
+          "162": 32,
+          "1622": 24,
+          "163": 30,
+          "1634": 43,
+          "16372": 3,
+          "164": 36,
+          "1646": 24,
+          "16489": 6,
+          "165": 27,
+          "1658": 20,
+          "166": 21,
+          "16607": 3,
+          "167": 22,
+          "1670": 16,
+          "16726": 5,
+          "168": 32,
+          "1682": 18,
+          "16846": 6,
+          "169": 22,
+          "1694": 30,
+          "16967": 3,
+          "17": 577,
+          "170": 23,
+          "1706": 15,
+          "17089": 1,
+          "171": 19,
+          "1718": 26,
+          "172": 28,
+          "17211": 2,
+          "173": 26,
+          "1730": 51,
+          "17334": 1,
+          "174": 24,
+          "1742": 36,
+          "17458": 4,
+          "175": 28,
+          "1754": 22,
+          "17583": 3,
+          "176": 22,
+          "1767": 20,
+          "177": 24,
+          "17709": 4,
+          "178": 24,
+          "1780": 12,
+          "17836": 1,
+          "179": 24,
+          "1793": 17,
+          "17964": 1,
+          "18": 464,
+          "180": 25,
+          "1806": 18,
+          "18093": 3,
+          "181": 16,
+          "1819": 22,
+          "182": 26,
+          "18223": 3,
+          "183": 18,
+          "1832": 83,
+          "18353": 1,
+          "184": 23,
+          "1845": 49,
+          "18484": 2,
+          "185": 27,
+          "1858": 28,
+          "186": 18,
+          "18616": 3,
+          "187": 17,
+          "1871": 26,
+          "18749": 1,
+          "188": 16,
+          "1884": 16,
+          "18883": 1,
+          "189": 25,
+          "1897": 23,
+          "19": 452,
+          "190": 19,
+          "19018": 1,
+          "191": 19,
+          "1911": 16,
+          "192": 9,
+          "1925": 38,
+          "19291": 1,
+          "193": 19,
+          "1939": 38,
+          "194": 17,
+          "19429": 1,
+          "195": 15,
+          "1953": 16,
+          "19568": 1,
+          "196": 20,
+          "1967": 14,
+          "197": 16,
+          "19708": 2,
+          "198": 18,
+          "1981": 17,
+          "199": 57,
+          "1995": 45,
+          "2": 1614,
+          "20": 550,
+          "200": 14,
+          "2009": 19,
+          "201": 21,
+          "20134": 1,
+          "202": 22,
+          "2023": 22,
+          "203": 15,
+          "2037": 49,
+          "204": 20,
+          "205": 15,
+          "2052": 19,
+          "20569": 1,
+          "206": 21,
+          "2067": 25,
+          "207": 14,
+          "20716": 1,
+          "208": 21,
+          "2082": 21,
+          "20864": 2,
+          "209": 29,
+          "2097": 22,
+          "21": 331,
+          "21013": 1,
+          "211": 30,
+          "2112": 18,
+          "2127": 29,
+          "213": 27,
+          "2142": 63,
+          "215": 21,
+          "2157": 27,
+          "217": 19,
+          "2172": 21,
+          "2188": 26,
+          "219": 26,
+          "22": 89,
+          "2204": 17,
+          "221": 15,
+          "2220": 17,
+          "223": 15,
+          "2236": 23,
+          "225": 21,
+          "2252": 41,
+          "2268": 18,
+          "227": 13,
+          "22731": 1,
+          "2284": 19,
+          "229": 20,
+          "23": 80,
+          "2300": 16,
+          "231": 26,
+          "2316": 15,
+          "233": 30,
+          "2333": 36,
+          "23389": 2,
+          "235": 24,
+          "2350": 42,
+          "2367": 17,
+          "237": 17,
+          "2384": 23,
+          "239": 33,
+          "24": 62,
+          "2401": 13,
+          "241": 27,
+          "2418": 32,
+          "24239": 1,
+          "243": 21,
+          "2435": 22,
+          "245": 16,
+          "2452": 46,
+          "247": 24,
+          "2470": 25,
+          "24764": 1,
+          "2488": 22,
+          "249": 58,
+          "25": 77,
+          "2506": 21,
+          "251": 16,
+          "2524": 22,
+          "253": 20,
+          "25300": 1,
+          "2542": 39,
+          "255": 15,
+          "2560": 19,
+          "257": 22,
+          "2578": 14,
+          "25848": 1,
+          "259": 26,
+          "2596": 24,
+          "26": 90,
+          "261": 26,
+          "2615": 19,
+          "263": 22,
+          "2634": 27,
+          "26407": 1,
+          "265": 19,
+          "2653": 52,
+          "267": 20,
+          "2672": 25,
+          "269": 25,
+          "2691": 20,
+          "27": 113,
+          "271": 21,
+          "2710": 13,
+          "2729": 34,
+          "273": 13,
+          "2749": 71,
+          "275": 18,
+          "2769": 23,
+          "277": 11,
+          "2789": 21,
+          "279": 21,
+          "28": 104,
+          "2809": 20,
+          "281": 15,
+          "2829": 21,
+          "283": 16,
+          "2849": 42,
+          "285": 27,
+          "2869": 27,
+          "287": 20,
+          "28768": 1,
+          "289": 21,
+          "2890": 25,
+          "29": 82,
+          "291": 27,
+          "2911": 20,
+          "293": 24,
+          "2932": 20,
+          "295": 19,
+          "2953": 43,
+          "297": 22,
+          "2974": 21,
+          "299": 48,
+          "2995": 39,
+          "3": 1089,
+          "30": 97,
+          "301": 9,
+          "3016": 37,
+          "303": 25,
+          "3038": 30,
+          "305": 34,
+          "3060": 57,
+          "307": 30,
+          "3082": 25,
+          "309": 18,
+          "31": 72,
+          "3104": 18,
+          "311": 18,
+          "3126": 15,
+          "313": 16,
+          "3148": 25,
+          "315": 11,
+          "317": 15,
+          "3171": 36,
+          "319": 18,
+          "3194": 21,
+          "32": 80,
+          "321": 24,
+          "3217": 26,
+          "323": 21,
+          "3240": 28,
+          "325": 16,
+          "3263": 47,
+          "327": 9,
+          "3286": 22,
+          "329": 15,
+          "33": 70,
+          "331": 19,
+          "3310": 26,
+          "333": 13,
+          "3334": 19,
+          "335": 16,
+          "3358": 36,
+          "337": 13,
+          "3382": 24,
+          "339": 18,
+          "33901": 1,
+          "34": 109,
+          "3406": 18,
+          "341": 20,
+          "34144": 0,
+          "343": 24,
+          "3430": 23,
+          "345": 18,
+          "3455": 26,
+          "347": 18,
+          "3480": 31,
+          "349": 33,
+          "35": 96,
+          "3505": 21,
+          "352": 20,
+          "3530": 19,
+          "355": 25,
+          "3555": 24,
+          "358": 23,
+          "3580": 35,
+          "36": 94,
+          "3606": 17,
+          "361": 28,
+          "3632": 27,
+          "364": 31,
+          "3658": 18,
+          "367": 24,
+          "3684": 51,
+          "37": 120,
+          "370": 24,
+          "3710": 26,
+          "373": 24,
+          "3737": 21,
+          "376": 20,
+          "3764": 34,
+          "379": 22,
+          "3791": 26,
+          "38": 155,
+          "3818": 23,
+          "382": 29,
+          "3845": 23,
+          "385": 24,
+          "3873": 34,
+          "388": 20,
+          "39": 225,
+          "3901": 25,
+          "391": 25,
+          "3929": 22,
+          "394": 27,
+          "3957": 15,
+          "397": 56,
+          "3985": 48,
+          "4": 959,
+          "40": 185,
+          "400": 44,
+          "4014": 18,
+          "403": 27,
+          "4043": 21,
+          "406": 36,
+          "4072": 36,
+          "409": 81,
+          "41": 122,
+          "4101": 23,
+          "412": 19,
+          "4130": 15,
+          "415": 27,
+          "4160": 29,
+          "418": 28,
+          "4190": 43,
+          "42": 92,
+          "421": 20,
+          "4220": 22,
+          "424": 24,
+          "4250": 16,
+          "427": 32,
+          "4280": 46,
+          "43": 94,
+          "430": 26,
+          "4311": 18,
+          "433": 21,
+          "4342": 9,
+          "436": 20,
+          "4373": 33,
+          "439": 23,
+          "44": 88,
+          "4404": 16,
+          "442": 19,
+          "4436": 18,
+          "445": 32,
+          "4468": 26,
+          "448": 45,
+          "45": 87,
+          "4500": 44,
+          "451": 23,
+          "4532": 10,
+          "454": 28,
+          "4564": 18,
+          "457": 28,
+          "4597": 38,
+          "46": 87,
+          "460": 20,
+          "463": 20,
+          "4630": 22,
+          "466": 21,
+          "4663": 18,
+          "469": 12,
+          "4696": 36,
+          "47": 93,
+          "472": 18,
+          "4730": 24,
+          "475": 32,
+          "4764": 21,
+          "478": 17,
+          "4798": 32,
+          "48": 86,
+          "481": 22,
+          "4832": 21,
+          "484": 17,
+          "4867": 30,
+          "487": 17,
+          "49": 299,
+          "490": 29,
+          "4902": 34,
+          "4937": 14,
+          "494": 28,
+          "4972": 27,
+          "498": 41,
+          "5": 832,
+          "50": 97,
+          "5008": 24,
+          "502": 42,
+          "5044": 21,
+          "506": 35,
+          "5080": 22,
+          "51": 107,
+          "510": 110,
+          "5116": 22,
+          "514": 30,
+          "5153": 11,
+          "518": 27,
+          "5190": 33,
+          "52": 144,
+          "522": 16,
+          "5227": 21,
+          "526": 28,
+          "5264": 15,
+          "53": 139,
+          "530": 28,
+          "5302": 19,
+          "534": 33,
+          "5340": 12,
+          "5378": 10,
+          "538": 22,
+          "54": 123,
+          "5417": 20,
+          "542": 19,
+          "5456": 23,
+          "546": 31,
+          "5495": 36,
+          "55": 112,
+          "550": 22,
+          "5534": 14,
+          "554": 23,
+          "5574": 18,
+          "558": 23,
+          "56": 98,
+          "5614": 40,
+          "562": 22,
+          "5654": 15,
+          "566": 25,
+          "5694": 22,
+          "57": 116,
+          "570": 22,
+          "5735": 24,
+          "574": 24,
+          "5776": 16,
+          "578": 28,
+          "58": 105,
+          "5817": 26,
+          "582": 31,
+          "5859": 15,
+          "586": 22,
+          "59": 129,
+          "590": 29,
+          "5901": 31,
+          "594": 27,
+          "5943": 16,
+          "598": 39,
+          "5986": 15,
+          "6": 748,
+          "60": 115,
+          "602": 31,
+          "6029": 20,
+          "606": 32,
+          "6072": 16,
+          "61": 104,
+          "610": 49,
+          "6115": 28,
+          "614": 68,
+          "6159": 10,
+          "618": 27,
+          "62": 95,
+          "6203": 23,
+          "622": 15,
+          "6247": 19,
+          "626": 24,
+          "6292": 9,
+          "63": 77,
+          "630": 19,
+          "6337": 22,
+          "635": 23,
+          "6382": 14,
+          "64": 75,
+          "640": 29,
+          "6428": 30,
+          "645": 21,
+          "6474": 16,
+          "65": 75,
+          "650": 31,
+          "6520": 18,
+          "655": 30,
+          "6567": 19,
+          "66": 68,
+          "660": 13,
+          "6614": 12,
+          "665": 15,
+          "6661": 8,
+          "67": 64,
+          "670": 24,
+          "6709": 21,
+          "675": 22,
+          "6757": 18,
+          "68": 61,
+          "680": 25,
+          "6805": 14,
+          "685": 22,
+          "6854": 12,
+          "69": 56,
+          "690": 30,
+          "6903": 27,
+          "695": 33,
+          "6952": 12,
+          "7": 452,
+          "70": 53,
+          "700": 33,
+          "7002": 13,
+          "705": 31,
+          "7052": 23,
+          "71": 43,
+          "710": 37,
+          "7103": 11,
+          "715": 80,
+          "7154": 18,
+          "72": 47,
+          "720": 18,
+          "7205": 12,
+          "725": 28,
+          "7257": 12,
+          "73": 48,
+          "730": 29,
+          "7309": 16,
+          "735": 16,
+          "7361": 21,
+          "74": 43,
+          "740": 22,
+          "7414": 11,
+          "745": 26,
+          "7467": 21,
+          "75": 53,
+          "750": 23,
+          "7520": 17,
+          "755": 26,
+          "7574": 9,
+          "76": 40,
+          "760": 17,
+          "7628": 27,
+          "765": 25,
+          "7683": 11,
+          "77": 48,
+          "770": 26,
+          "7738": 17,
+          "776": 26,
+          "7793": 10,
+          "78": 35,
+          "782": 31,
+          "7849": 18,
+          "788": 31,
+          "79": 44,
+          "7905": 10,
+          "794": 33,
+          "7962": 11,
+          "8": 312,
+          "80": 41,
+          "800": 28,
+          "8019": 7,
+          "806": 32,
+          "8076": 14,
+          "81": 55,
+          "812": 36,
+          "8134": 12,
+          "818": 97,
+          "8192": 9,
+          "82": 41,
+          "824": 29,
+          "8251": 16,
+          "83": 51,
+          "830": 27,
+          "8310": 11,
+          "836": 26,
+          "8370": 9,
+          "84": 65,
+          "842": 26,
+          "8430": 14,
+          "848": 24,
+          "8490": 13,
+          "85": 49,
+          "854": 26,
+          "8551": 18,
+          "86": 40,
+          "860": 20,
+          "8612": 12,
+          "866": 27,
+          "8674": 12,
+          "87": 52,
+          "872": 24,
+          "8736": 13,
+          "878": 28,
+          "8799": 16,
+          "88": 54,
+          "884": 24,
+          "8862": 19,
+          "89": 47,
+          "890": 28,
+          "8925": 9,
+          "896": 35,
+          "8989": 11,
+          "9": 218,
+          "90": 69,
+          "902": 31,
+          "9053": 18,
+          "908": 41,
+          "91": 47,
+          "9118": 4,
+          "915": 97,
+          "9183": 13,
+          "92": 47,
+          "922": 44,
+          "9249": 11,
+          "929": 37,
+          "93": 35,
+          "9315": 8,
+          "936": 26,
+          "9382": 11,
+          "94": 42,
+          "943": 44,
+          "9449": 3,
+          "95": 42,
+          "950": 36,
+          "9517": 14,
+          "957": 26,
+          "9585": 14,
+          "96": 43,
+          "964": 34,
+          "9654": 4,
+          "97": 43,
+          "971": 28,
+          "9723": 12,
+          "978": 71,
+          "9793": 9,
+          "98": 43,
+          "985": 72,
+          "9863": 11,
+          "99": 66,
+          "992": 38,
+          "9934": 61,
+          "999": 235
+        }
+      },
+      "STS_POLL_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 2734,
+        "values": {
+          "0": 103413,
+          "1": 408,
+          "10": 7,
+          "11": 7,
+          "12": 4,
+          "13": 6,
+          "14": 1,
+          "15": 2,
+          "16": 3,
+          "17": 4,
+          "18": 3,
+          "2": 165,
+          "21": 1,
+          "23": 1,
+          "27": 1,
+          "3": 91,
+          "32": 2,
+          "33": 6,
+          "34": 3,
+          "35": 1,
+          "4": 56,
+          "5": 37,
+          "6": 12,
+          "7": 13,
+          "8": 8,
+          "85": 1,
+          "86": 0,
+          "9": 5
+        }
+      },
+      "SUBJECT_PRINCIPAL_ACCESSED_WITHOUT_SCRIPT_ON_STACK": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 5709,
+        "values": {
+          "0": 8,
+          "1": 2,
+          "2": 6,
+          "3": 2,
+          "39": 1,
+          "4": 1,
+          "5399": 1,
+          "6758": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK_FIRST": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          40000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK_SCRIPT": {
+        "bucket_count": 111,
+        "histogram_type": 1,
+        "range": [
+          1,
+          110
+        ],
+        "sum": 572,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14872,
+        "values": {
+          "25": 0,
+          "26": 22,
+          "27": 0
+        }
+      },
+      "TELEMETRY_ARCHIVE_CHECKING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_DIRECTORIES_COUNT": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTED_OLD_DIRS": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTED_OVER_QUOTA": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTING_DIRS_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_OLDEST_DIRECTORY_AGE": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_SCAN_PING_COUNT": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_SESSION_PING_COUNT": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_ARCHIVE_SIZE_MB": {
+        "bucket_count": 60,
+        "histogram_type": 1,
+        "range": [
+          1,
+          300
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_COMPRESS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 6,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "TELEMETRY_MEMORY_REPORTER_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 284,
+        "values": {
+          "0": 3,
+          "1": 153,
+          "3": 10,
+          "9": 0
+        }
+      },
+      "TELEMETRY_PENDING_CHECKING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_EVICTING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_AGE": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          365
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_EVICTED_OVER_QUOTA": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_SIZE_MB": {
+        "bucket_count": 16,
+        "histogram_type": 1,
+        "range": [
+          1,
+          17
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_PING": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 426,
+        "values": {
+          "1114": 0,
+          "154": 0,
+          "414": 1
+        }
+      },
+      "TELEMETRY_SEND": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 426,
+        "values": {
+          "1114": 0,
+          "154": 0,
+          "414": 1
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_LOAD": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_PARSE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_SAVE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_VALIDATION": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_STRINGIFY": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 5,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "TELEMETRY_SUCCESS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "TELEMETRY_TEST_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_TEST_RELEASE_OPTIN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_TEST_RELEASE_OPTOUT": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TOTAL_CONTENT_PAGE_LOAD_TIME": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          100,
+          30000
+        ],
+        "sum": 254,
+        "values": {
+          "227": 0,
+          "241": 1,
+          "255": 0
+        }
+      },
+      "TOTAL_COUNT_HIGH_ERRORS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "TRACKING_PROTECTION_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TRACKING_PROTECTION_PBM_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TRANSACTION_WAIT_TIME_HTTP": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 48061,
+        "values": {
+          "0": 388,
+          "1": 4,
+          "10": 46,
+          "100": 2,
+          "107": 6,
+          "1080": 1,
+          "11": 25,
+          "115": 8,
+          "1158": 0,
+          "12": 16,
+          "123": 6,
+          "13": 15,
+          "132": 9,
+          "14": 12,
+          "142": 4,
+          "15": 4,
+          "152": 6,
+          "16": 5,
+          "163": 5,
+          "17": 2,
+          "175": 1,
+          "18": 9,
+          "19": 6,
+          "2": 6,
+          "20": 2,
+          "202": 3,
+          "21": 6,
+          "217": 1,
+          "23": 8,
+          "233": 1,
+          "25": 7,
+          "268": 3,
+          "27": 4,
+          "287": 6,
+          "29": 5,
+          "3": 5,
+          "31": 7,
+          "33": 12,
+          "330": 5,
+          "35": 18,
+          "354": 7,
+          "38": 11,
+          "380": 7,
+          "4": 12,
+          "407": 7,
+          "41": 14,
+          "436": 3,
+          "44": 17,
+          "467": 3,
+          "47": 13,
+          "5": 10,
+          "50": 6,
+          "501": 2,
+          "537": 3,
+          "54": 12,
+          "576": 3,
+          "58": 11,
+          "6": 42,
+          "618": 1,
+          "62": 7,
+          "66": 4,
+          "663": 1,
+          "7": 38,
+          "71": 12,
+          "711": 2,
+          "76": 12,
+          "8": 20,
+          "81": 9,
+          "817": 2,
+          "87": 8,
+          "9": 27,
+          "93": 4,
+          "939": 2
+        }
+      },
+      "TRANSACTION_WAIT_TIME_SPDY": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 7088,
+        "values": {
+          "0": 3189,
+          "1": 1092,
+          "107": 1,
+          "11": 1,
+          "115": 1,
+          "12": 1,
+          "123": 1,
+          "15": 1,
+          "16": 2,
+          "163": 1,
+          "18": 2,
+          "19": 1,
+          "2": 460,
+          "20": 2,
+          "21": 2,
+          "23": 2,
+          "25": 2,
+          "29": 1,
+          "3": 315,
+          "308": 1,
+          "31": 2,
+          "33": 1,
+          "35": 9,
+          "38": 5,
+          "380": 1,
+          "4": 62,
+          "407": 0,
+          "41": 4,
+          "44": 4,
+          "47": 7,
+          "5": 5,
+          "50": 6,
+          "54": 3,
+          "58": 1,
+          "62": 2,
+          "7": 1,
+          "71": 3,
+          "8": 1,
+          "81": 1
+        }
+      },
+      "UPDATE_CHECK_CODE_NOTIFY": {
+        "bucket_count": 51,
+        "histogram_type": 1,
+        "range": [
+          1,
+          50
+        ],
+        "sum": 55,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 525,
+        "values": {
+          "10": 5,
+          "11": 0,
+          "4": 0,
+          "5": 1
+        }
+      },
+      "UPDATE_CHECK_NO_UPDATE_NOTIFY": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "UPDATE_DOWNLOAD_CODE_COMPLETE": {
+        "bucket_count": 51,
+        "histogram_type": 1,
+        "range": [
+          1,
+          50
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "UPDATE_LAST_NOTIFY_INTERVAL_DAYS_NOTIFY": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          180
+        ],
+        "sum": 0,
+        "values": {
+          "0": 6,
+          "1": 0
+        }
+      },
+      "UPDATE_PING_COUNT_NOTIFY": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6,
+        "values": {
+          "0": 6,
+          "1": 0
+        }
+      },
+      "UPDATE_STATE_CODE_COMPLETE_STAGE": {
+        "bucket_count": 21,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 7,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 49,
+        "values": {
+          "6": 0,
+          "7": 1,
+          "8": 0
+        }
+      },
+      "UPDATE_STATE_CODE_COMPLETE_STARTUP": {
+        "bucket_count": 21,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "URLCLASSIFIER_CL_CHECK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 6,
+        "values": {
+          "0": 2168,
+          "1": 3,
+          "2": 1,
+          "4": 0
+        }
+      },
+      "URLCLASSIFIER_CL_UPDATE_TIME": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          20,
+          15000
+        ],
+        "sum": 2808,
+        "values": {
+          "1175": 0,
+          "153": 1,
+          "20": 0,
+          "33": 1,
+          "424": 1,
+          "55": 6,
+          "706": 1,
+          "92": 5
+        }
+      },
+      "URLCLASSIFIER_LC_COMPLETIONS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 4,
+        "values": {
+          "0": 8,
+          "4": 1,
+          "8": 0
+        }
+      },
+      "URLCLASSIFIER_LC_PREFIXES": {
+        "bucket_count": 15,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1500000
+        ],
+        "sum": 3406810,
+        "sum_squares_hi": 447,
+        "sum_squares_lo": 39363718,
+        "values": {
+          "0": 0,
+          "1": 4,
+          "461539": 3,
+          "576924": 2,
+          "692308": 0
+        }
+      },
+      "URLCLASSIFIER_LOOKUP_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 370,
+        "values": {
+          "0": 1728,
+          "1": 85,
+          "100": 1,
+          "2": 34,
+          "224": 0,
+          "4": 9
+        }
+      },
+      "URLCLASSIFIER_PS_CONSTRUCT_TIME": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 91,
+        "values": {
+          "15": 2,
+          "2": 0,
+          "29": 0,
+          "4": 2,
+          "8": 5
+        }
+      },
+      "URLCLASSIFIER_PS_FALLOCATE_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 9,
+          "1": 0
+        }
+      },
+      "URLCLASSIFIER_PS_FILELOAD_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "URL_PATH_CONTAINS_EXCLAMATION_DOUBLE_SLASH": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 22078,
+          "1": 0
+        }
+      },
+      "URL_PATH_CONTAINS_EXCLAMATION_SLASH": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1878,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1878,
+        "values": {
+          "0": 20200,
+          "1": 1878,
+          "2": 0
+        }
+      },
+      "URL_PATH_ENDS_IN_EXCLAMATION": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 22078,
+          "1": 0
+        }
+      },
+      "USE_COUNTER2_DEPRECATED_GetPreventDefault_DOCUMENT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "VIDEO_ADOBE_GMP_DISAPPEARED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "VIDEO_CAN_CREATE_AAC_DECODER": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 3,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "VIDEO_CAN_CREATE_H264_DECODER": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 3,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "VIDEO_EME_ADOBE_HIDDEN_REASON": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "VIDEO_EME_ADOBE_UNSUPPORTED_REASON": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "VIDEO_OPENH264_GMP_DISAPPEARED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "VIDEO_OPENH264_GMP_MISSING_FILES": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "WEAVE_CAN_FETCH_KEYS": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "WEAVE_CONFIGURED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "WEBSOCKETS_HANDSHAKE_TYPE": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 82,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 460,
+        "values": {
+          "3": 0,
+          "4": 4,
+          "6": 11,
+          "7": 0
+        }
+      },
+      "WORD_CACHE_HITS_CHROME": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 432068,
+        "values": {
+          "0": 0,
+          "1": 35471,
+          "11": 2217,
+          "13": 626,
+          "15": 998,
+          "18": 574,
+          "2": 5263,
+          "21": 792,
+          "25": 713,
+          "3": 4716,
+          "30": 254,
+          "35": 0,
+          "4": 9322,
+          "5": 5757,
+          "6": 9173,
+          "7": 8316,
+          "8": 2155,
+          "9": 7212
+        }
+      },
+      "WORD_CACHE_HITS_CONTENT": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 180509,
+        "values": {
+          "0": 0,
+          "1": 3003,
+          "11": 401,
+          "13": 182,
+          "15": 2699,
+          "18": 1474,
+          "2": 4871,
+          "21": 931,
+          "25": 786,
+          "3": 427,
+          "30": 453,
+          "35": 0,
+          "4": 83,
+          "5": 1705,
+          "6": 488,
+          "7": 159,
+          "8": 471,
+          "9": 1543
+        }
+      },
+      "WORD_CACHE_MISSES_CHROME": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 60170,
+        "values": {
+          "0": 0,
+          "1": 1972,
+          "11": 302,
+          "13": 135,
+          "15": 202,
+          "18": 126,
+          "2": 603,
+          "21": 132,
+          "25": 178,
+          "3": 730,
+          "30": 99,
+          "35": 0,
+          "4": 972,
+          "5": 830,
+          "6": 911,
+          "7": 996,
+          "8": 439,
+          "9": 953
+        }
+      },
+      "WORD_CACHE_MISSES_CONTENT": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 22966,
+        "values": {
+          "0": 0,
+          "1": 36,
+          "11": 63,
+          "13": 216,
+          "15": 375,
+          "18": 157,
+          "2": 125,
+          "21": 90,
+          "25": 23,
+          "3": 138,
+          "30": 11,
+          "35": 0,
+          "4": 249,
+          "5": 339,
+          "6": 157,
+          "7": 100,
+          "8": 72,
+          "9": 195
+        }
+      },
+      "XMLHTTPREQUEST_ASYNC_OR_SYNC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 248,
+          "1": 0
+        }
+      },
+      "XUL_CACHE_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "YOUTUBE_EMBED_SEEN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      }
+    },
+    "processes": {
+      "parent": {
+        "scalars": {
+          "telemetry.test.unsigned_int_kind": 2,
+          "telemetry.test.string_kind": "I'm a cool test string.",
+          "telemetry.test.boolean_kind": true
+        },
+        "keyedScalars": {
+          "telemetry.test.keyed_unsigned_int": {
+            "search_enter": 1,
+            "some_key": 37
+          },
+          "telemetry.test.keyed_boolean_kind": {
+            "key1": false,
+            "key2": true
+          }
+        },
+        "events": [
+          [
+            12141232,
+            "navigation",
+            "search",
+            "searchbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ],
+          [
+            12144813,
+            "navigation",
+            "search",
+            "searchbar",
+            "oneoff",
+            {
+              "engine": "amazondotcom"
+            }
+          ],
+          [
+            12152377,
+            "navigation",
+            "search",
+            "urlbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ]
+        ]
+      },
+      "content": {
+        "histograms": {
+          "A11Y_IATABLE_USAGE_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "A11Y_INSTANTIATED_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "A11Y_ISIMPLEDOM_USAGE_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CANVAS_2D_USED": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 113,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 113,
+            "values": {
+              "0": 0,
+              "1": 113,
+              "2": 0
+            }
+          },
+          "CHARSET_OVERRIDE_USED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CHECK_JAVA_ENABLED": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 8,
+              "1": 0
+            }
+          },
+          "COMPONENTS_SHIM_ACCESSED_BY_CONTENT": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CONTENT_DOCUMENTS_DESTROYED": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 347,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 347,
+            "values": {
+              "0": 347,
+              "1": 0
+            }
+          },
+          "CYCLE_COLLECTOR": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 297534,
+            "values": {
+              "1062": 1,
+              "114": 14,
+              "135": 18,
+              "14": 1,
+              "1500": 1,
+              "160": 13,
+              "190": 13,
+              "2117": 1,
+              "226": 13,
+              "2516": 1,
+              "268": 10,
+              "29": 124,
+              "2990": 0,
+              "3": 0,
+              "318": 9,
+              "34": 5791,
+              "378": 9,
+              "4": 13,
+              "40": 168,
+              "449": 4,
+              "48": 5,
+              "5": 7,
+              "533": 2,
+              "57": 20,
+              "633": 2,
+              "68": 206,
+              "752": 5,
+              "81": 4,
+              "96": 216
+            }
+          },
+          "CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 1147,
+            "values": {
+              "0": 136266,
+              "1": 273,
+              "10": 9,
+              "12": 3,
+              "17": 1,
+              "2": 88,
+              "24": 1,
+              "29": 0,
+              "3": 65,
+              "4": 33,
+              "5": 15,
+              "6": 5,
+              "7": 1,
+              "8": 10
+            }
+          },
+          "CYCLE_COLLECTOR_COLLECTED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              100000
+            ],
+            "sum": 5904304,
+            "values": {
+              "0": 5171,
+              "10": 22,
+              "100000": 5,
+              "10589": 14,
+              "1122": 14,
+              "119": 22,
+              "13": 8,
+              "13255": 15,
+              "1404": 31,
+              "149": 10,
+              "16": 9,
+              "16592": 21,
+              "1757": 19,
+              "186": 9,
+              "2": 42,
+              "20": 13,
+              "20769": 9,
+              "2199": 11,
+              "233": 24,
+              "25": 5,
+              "25997": 14,
+              "2753": 20,
+              "292": 61,
+              "3": 29,
+              "31": 7,
+              "32541": 4,
+              "3446": 13,
+              "365": 42,
+              "39": 15,
+              "4": 23,
+              "40733": 14,
+              "4313": 15,
+              "457": 154,
+              "49": 3,
+              "5": 1,
+              "50987": 9,
+              "5399": 14,
+              "572": 522,
+              "6": 60,
+              "61": 4,
+              "63822": 3,
+              "6758": 22,
+              "716": 71,
+              "76": 2,
+              "79889": 2,
+              "8": 13,
+              "8459": 17,
+              "896": 15,
+              "95": 28
+            }
+          },
+          "CYCLE_COLLECTOR_FINISH_IGC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 6670,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_FULL": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 297746,
+            "values": {
+              "1062": 1,
+              "114": 14,
+              "135": 18,
+              "14": 1,
+              "1500": 1,
+              "160": 14,
+              "190": 13,
+              "2117": 1,
+              "226": 13,
+              "2516": 1,
+              "268": 10,
+              "29": 121,
+              "2990": 0,
+              "3": 0,
+              "318": 9,
+              "34": 5791,
+              "378": 9,
+              "4": 13,
+              "40": 171,
+              "449": 4,
+              "48": 5,
+              "5": 7,
+              "533": 2,
+              "57": 18,
+              "633": 2,
+              "68": 207,
+              "752": 5,
+              "81": 4,
+              "96": 216
+            }
+          },
+          "CYCLE_COLLECTOR_MAX_PAUSE": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 44247,
+            "values": {
+              "10": 112,
+              "12": 11,
+              "135": 2,
+              "14": 7,
+              "160": 1,
+              "17": 5,
+              "2": 0,
+              "24": 1,
+              "268": 1,
+              "29": 1,
+              "3": 6,
+              "4": 131,
+              "5": 1480,
+              "57": 1,
+              "6": 2574,
+              "7": 1353,
+              "752": 1,
+              "8": 984,
+              "894": 0
+            }
+          },
+          "CYCLE_COLLECTOR_NEED_GC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 6670,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_OOM": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CYCLE_COLLECTOR_SYNC_SKIPPABLE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 5,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 5,
+            "values": {
+              "0": 6666,
+              "1": 5,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_TIME_BETWEEN": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              120
+            ],
+            "sum": 40309,
+            "values": {
+              "14": 1,
+              "2": 0,
+              "3": 18,
+              "4": 15,
+              "45": 1,
+              "5": 27,
+              "57": 1,
+              "6": 6353,
+              "61": 0,
+              "7": 218,
+              "8": 27,
+              "9": 9
+            }
+          },
+          "CYCLE_COLLECTOR_VISITED_GCED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              300000
+            ],
+            "sum": 9692588,
+            "values": {
+              "0": 7,
+              "11508": 5,
+              "1204": 442,
+              "141361": 1,
+              "14789": 14,
+              "1547": 146,
+              "19005": 10,
+              "1988": 177,
+              "24423": 15,
+              "2555": 24,
+              "267": 65,
+              "300000": 2,
+              "31386": 5,
+              "3283": 27,
+              "343": 745,
+              "40334": 9,
+              "4219": 20,
+              "441": 1261,
+              "51833": 2,
+              "5422": 8,
+              "567": 309,
+              "66610": 3,
+              "6968": 23,
+              "729": 385,
+              "85599": 2,
+              "8955": 9,
+              "937": 2955
+            }
+          },
+          "CYCLE_COLLECTOR_VISITED_REF_COUNTED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              300000
+            ],
+            "sum": 19987661,
+            "values": {
+              "11508": 18,
+              "1204": 1182,
+              "14789": 25,
+              "1547": 562,
+              "19005": 5,
+              "1988": 137,
+              "24423": 8,
+              "2555": 2724,
+              "31386": 5,
+              "3283": 1696,
+              "343": 0,
+              "40334": 0,
+              "4219": 195,
+              "441": 2,
+              "5422": 48,
+              "567": 2,
+              "6968": 30,
+              "729": 2,
+              "8955": 29,
+              "937": 1
+            }
+          },
+          "CYCLE_COLLECTOR_WORKER_OOM": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_IBM866": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_ISO2022JP": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_ISO_8859_5": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_KOI8R": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_KOI8U": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACARABIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCROATIAN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCYRILLIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACDEVANAGARI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACFARSI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGREEK": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGUJARATI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGURMUKHI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACHEBREW": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACICELANDIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACROMANIAN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACTURKISH": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEFERRED_FINALIZE_ASYNC": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 344,
+            "values": {
+              "0": 1186,
+              "1": 13,
+              "2": 13,
+              "3": 5,
+              "4": 5,
+              "5": 54,
+              "6": 0
+            }
+          },
+          "DEVTOOLS_ABOUTDEBUGGING_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_ANIMATIONINSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_BROWSERCONSOLE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_CANVASDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_COMPUTEDVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_CUSTOM_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_DEVELOPERTOOLBAR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_FONTINSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_INSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSBROWSERDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSPROFILER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_LAYOUTVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_MENU_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_NETMONITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_OPTIONS_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PAINTFLASHING_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PERFTOOLS_RECORDING_EXPORT_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PERFTOOLS_RECORDING_IMPORT_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PICKER_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_RESPONSIVE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_RULEVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_SCRATCHPAD_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_SHADEREDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_STORAGE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_STYLEEDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_TILT_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_TOOLBOX_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBAUDIOEDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBCONSOLE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_IMPORT_PROJECT_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_NEW_PROJECT_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_PROJECT_EDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_PROJECT_EDITOR_SAVE_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_AUTOSTART": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "E10S_AUTOSTART_STATUS": {
+            "bucket_count": 7,
+            "histogram_type": 1,
+            "range": [
+              1,
+              6
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_BLOCKED_FROM_RUNNING": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_STILL_ACCEPTED_FROM_PROMPT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "ENABLE_PRIVILEGE_EVER_CALLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "FETCH_IS_MAINTHREAD": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "FIND_PLUGINS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0.6931471824645996,
+            "log_sum_squares": 0.4804530143737793,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "3": 0
+            }
+          },
+          "FLASH_PLUGIN_AREA": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              256,
+              16777216
+            ],
+            "sum": 144000,
+            "values": {
+              "32807": 0,
+              "41332": 3,
+              "52073": 0
+            }
+          },
+          "FLASH_PLUGIN_HEIGHT": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 600,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 120000,
+            "values": {
+              "126": 0,
+              "168": 3,
+              "209": 0
+            }
+          },
+          "FLASH_PLUGIN_STATES": {
+            "bucket_count": 21,
+            "histogram_type": 1,
+            "range": [
+              1,
+              20
+            ],
+            "sum": 24,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 192,
+            "values": {
+              "7": 0,
+              "8": 3,
+              "9": 0
+            }
+          },
+          "FLASH_PLUGIN_WIDTH": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 720,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 172800,
+            "values": {
+              "168": 0,
+              "209": 3,
+              "251": 0
+            }
+          },
+          "FONT_CACHE_HIT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1965,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1965,
+            "values": {
+              "0": 865,
+              "1": 1965,
+              "2": 0
+            }
+          },
+          "FORGET_SKIPPABLE_MAX": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 122221,
+            "values": {
+              "10": 21,
+              "10000": 1,
+              "114": 1,
+              "12": 64,
+              "14": 596,
+              "17": 451,
+              "2": 0,
+              "20": 66,
+              "24": 4,
+              "29": 1,
+              "3": 776,
+              "4": 4498,
+              "5": 169,
+              "57": 1,
+              "6": 11,
+              "7": 5,
+              "8": 6
+            }
+          },
+          "FXA_CONFIGURED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "GC_ANIMATION_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 46725,
+            "values": {
+              "0": 7,
+              "1": 15,
+              "10": 1448,
+              "12": 35,
+              "135": 1,
+              "14": 134,
+              "160": 2,
+              "17": 156,
+              "190": 2,
+              "2": 9,
+              "20": 436,
+              "226": 1,
+              "24": 373,
+              "268": 1,
+              "29": 75,
+              "3": 8,
+              "34": 46,
+              "4": 9,
+              "40": 24,
+              "449": 1,
+              "48": 4,
+              "5": 16,
+              "533": 0,
+              "6": 16,
+              "68": 1,
+              "7": 15,
+              "8": 22,
+              "81": 2
+            }
+          },
+          "GC_BUDGET_MS": {
+            "bucket_count": 10,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 370890,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 13927100,
+            "values": {
+              "0": 0,
+              "1": 2859,
+              "13": 127,
+              "38": 8494,
+              "51": 0
+            }
+          },
+          "GC_INCREMENTAL_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1203,
+              "1": 0
+            }
+          },
+          "GC_IS_COMPARTMENTAL": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 18,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 18,
+            "values": {
+              "0": 1185,
+              "1": 18,
+              "2": 0
+            }
+          },
+          "GC_MARK_GRAY_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              200
+            ],
+            "sum": 14378,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 194858,
+            "values": {
+              "0": 4,
+              "1": 1,
+              "13": 200,
+              "18": 15,
+              "22": 9,
+              "26": 9,
+              "30": 8,
+              "34": 4,
+              "38": 2,
+              "5": 15,
+              "51": 1,
+              "55": 1,
+              "80": 1,
+              "84": 0,
+              "9": 933
+            }
+          },
+          "GC_MARK_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 250845,
+            "values": {
+              "114": 68,
+              "135": 170,
+              "160": 74,
+              "190": 466,
+              "226": 343,
+              "268": 40,
+              "318": 5,
+              "378": 14,
+              "40": 1,
+              "449": 6,
+              "5": 0,
+              "533": 2,
+              "57": 1,
+              "6": 1,
+              "633": 0,
+              "96": 12
+            }
+          },
+          "GC_MARK_ROOTS_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              200
+            ],
+            "sum": 9510,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 109020,
+            "values": {
+              "0": 0,
+              "1": 27,
+              "13": 33,
+              "138": 1,
+              "142": 0,
+              "18": 18,
+              "22": 10,
+              "26": 8,
+              "30": 2,
+              "34": 2,
+              "38": 1,
+              "5": 933,
+              "9": 168
+            }
+          },
+          "GC_MAX_PAUSE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 20643017,
+            "sum_squares_hi": 98652,
+            "sum_squares_lo": 40718323,
+            "values": {
+              "0": 0,
+              "1": 8,
+              "1000": 1,
+              "105": 1,
+              "147": 2,
+              "168": 3,
+              "188": 1,
+              "209": 1,
+              "22": 1000,
+              "230": 3,
+              "251": 2,
+              "272": 6,
+              "292": 7,
+              "313": 3,
+              "334": 2,
+              "376": 2,
+              "43": 138,
+              "521": 2,
+              "605": 1,
+              "63": 18,
+              "84": 2
+            }
+          },
+          "GC_MINOR_REASON": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 524628,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 23805526,
+            "values": {
+              "10": 1057,
+              "11": 230,
+              "12": 103,
+              "14": 17,
+              "16": 2,
+              "36": 1061,
+              "37": 2,
+              "42": 2,
+              "47": 8338,
+              "48": 1528,
+              "5": 0,
+              "52": 123,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_MINOR_REASON_LONG": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 36457,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1342071,
+            "values": {
+              "10": 598,
+              "11": 118,
+              "12": 94,
+              "14": 13,
+              "16": 1,
+              "36": 187,
+              "37": 1,
+              "42": 1,
+              "47": 332,
+              "48": 42,
+              "5": 0,
+              "52": 65,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_MINOR_US": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000000
+            ],
+            "sum": 7411559,
+            "values": {
+              "0": 1,
+              "1026": 251,
+              "10619": 3,
+              "114": 3,
+              "1168": 234,
+              "130": 21,
+              "1330": 157,
+              "148": 96,
+              "1514": 209,
+              "15678": 1,
+              "168": 280,
+              "1724": 107,
+              "17852": 1,
+              "191": 479,
+              "1963": 66,
+              "20328": 0,
+              "217": 826,
+              "2235": 65,
+              "247": 963,
+              "2545": 59,
+              "281": 1621,
+              "2898": 61,
+              "320": 2517,
+              "3300": 37,
+              "364": 1285,
+              "3758": 44,
+              "414": 597,
+              "4279": 30,
+              "471": 380,
+              "4872": 34,
+              "536": 411,
+              "5548": 19,
+              "610": 429,
+              "6317": 18,
+              "695": 437,
+              "7193": 10,
+              "791": 388,
+              "8190": 8,
+              "901": 322
+            }
+          },
+          "GC_MMU_50": {
+            "bucket_count": 20,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 18829,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 340167,
+            "values": {
+              "0": 118,
+              "1": 24,
+              "12": 108,
+              "18": 901,
+              "23": 3,
+              "29": 1,
+              "7": 47,
+              "73": 1,
+              "78": 0
+            }
+          },
+          "GC_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 20945376,
+            "values": {
+              "10000": 1,
+              "135": 1,
+              "14": 0,
+              "160": 30,
+              "17": 1,
+              "190": 193,
+              "226": 59,
+              "268": 500,
+              "318": 339,
+              "378": 37,
+              "449": 16,
+              "533": 17,
+              "633": 5,
+              "752": 2,
+              "96": 2
+            }
+          },
+          "GC_NON_INCREMENTAL": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 34,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 34,
+            "values": {
+              "0": 1169,
+              "1": 34,
+              "2": 0
+            }
+          },
+          "GC_REASON_2": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 529565,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24574529,
+            "values": {
+              "14": 17,
+              "16": 2,
+              "36": 1061,
+              "37": 3,
+              "42": 2,
+              "47": 8494,
+              "48": 1776,
+              "5": 0,
+              "52": 123,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_RESET": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 11483,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "GC_SCC_SWEEP_MAX_PAUSE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 3744,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 14814,
+            "values": {
+              "0": 3,
+              "1": 1194,
+              "11": 5,
+              "22": 1,
+              "32": 0
+            }
+          },
+          "GC_SCC_SWEEP_TOTAL_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 10657,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 132547,
+            "values": {
+              "0": 2,
+              "1": 984,
+              "105": 0,
+              "11": 184,
+              "22": 23,
+              "32": 5,
+              "43": 2,
+              "74": 2,
+              "95": 1
+            }
+          },
+          "GC_SLICE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 20943254,
+            "values": {
+              "0": 24,
+              "1": 42,
+              "10": 1564,
+              "10000": 1,
+              "114": 1,
+              "12": 142,
+              "135": 2,
+              "14": 241,
+              "160": 3,
+              "17": 278,
+              "190": 2,
+              "2": 32,
+              "20": 793,
+              "226": 5,
+              "24": 848,
+              "268": 13,
+              "29": 514,
+              "3": 37,
+              "318": 5,
+              "34": 349,
+              "378": 2,
+              "4": 62,
+              "40": 6149,
+              "449": 1,
+              "48": 65,
+              "5": 50,
+              "533": 2,
+              "57": 26,
+              "6": 47,
+              "68": 10,
+              "7": 51,
+              "8": 121,
+              "81": 2,
+              "96": 1
+            }
+          },
+          "GC_SLOW_PHASE": {
+            "bucket_count": 76,
+            "histogram_type": 1,
+            "range": [
+              1,
+              75
+            ],
+            "sum": 6046,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 39196,
+            "values": {
+              "2": 0,
+              "3": 45,
+              "46": 1,
+              "47": 0,
+              "6": 895,
+              "9": 55
+            }
+          },
+          "GC_SWEEP_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 83018,
+            "values": {
+              "0": 2,
+              "114": 31,
+              "135": 10,
+              "160": 6,
+              "17": 1,
+              "226": 1,
+              "268": 2,
+              "29": 1,
+              "3": 1,
+              "34": 1,
+              "40": 55,
+              "48": 171,
+              "533": 1,
+              "57": 492,
+              "633": 0,
+              "68": 318,
+              "81": 69,
+              "96": 41
+            }
+          },
+          "GEOLOCATION_ERROR": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "GHOST_WINDOWS": {
+            "bucket_count": 32,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              128
+            ],
+            "sum": 0,
+            "values": {
+              "0": 702,
+              "1": 0
+            }
+          },
+          "GRADIENT_DURATION": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              50000000
+            ],
+            "sum": 4451764,
+            "values": {
+              "1": 0,
+              "1056": 112,
+              "149": 1318,
+              "19895": 69,
+              "21": 2822,
+              "2810": 6,
+              "3": 15,
+              "397": 360,
+              "52939": 0,
+              "56": 9253,
+              "7477": 18,
+              "8": 395
+            }
+          },
+          "GRADIENT_RETENTION_TIME": {
+            "bucket_count": 20,
+            "histogram_type": 1,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 7969,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 63504961,
+            "values": {
+              "7223": 0,
+              "7778": 1,
+              "8334": 0
+            }
+          },
+          "HTML_FOREGROUND_REFLOW_MS_2": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 3415,
+            "values": {
+              "0": 25997,
+              "1": 842,
+              "13": 13,
+              "171": 1,
+              "2": 148,
+              "22": 4,
+              "284": 0,
+              "3": 117,
+              "37": 1,
+              "5": 57,
+              "62": 2,
+              "8": 74
+            }
+          },
+          "HTTP_CONTENT_ENCODING": {
+            "bucket_count": 7,
+            "histogram_type": 1,
+            "range": [
+              1,
+              6
+            ],
+            "sum": 4677,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4683,
+            "values": {
+              "0": 0,
+              "1": 4674,
+              "3": 1,
+              "4": 0
+            }
+          },
+          "HTTP_PAGE_COMPLETE_LOAD_NET_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 723.1046214103699,
+            "log_sum_squares": 3904.6454129219055,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 43641,
+            "values": {
+              "1023": 2,
+              "11": 0,
+              "115": 12,
+              "13": 2,
+              "140": 11,
+              "1522": 1,
+              "171": 6,
+              "1857": 2,
+              "20": 1,
+              "209": 11,
+              "24": 3,
+              "255": 13,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 2,
+              "379": 4,
+              "4111": 0,
+              "43": 3,
+              "462": 4,
+              "52": 1,
+              "564": 9,
+              "63": 15,
+              "688": 4,
+              "77": 12,
+              "839": 4,
+              "94": 8
+            }
+          },
+          "HTTP_PAGE_COMPLETE_LOAD_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 723.1046214103699,
+            "log_sum_squares": 3904.6454129219055,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 43641,
+            "values": {
+              "1023": 2,
+              "11": 0,
+              "115": 12,
+              "13": 2,
+              "140": 11,
+              "1522": 1,
+              "171": 6,
+              "1857": 2,
+              "20": 1,
+              "209": 11,
+              "24": 3,
+              "255": 13,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 2,
+              "379": 4,
+              "4111": 0,
+              "43": 3,
+              "462": 4,
+              "52": 1,
+              "564": 9,
+              "63": 15,
+              "688": 4,
+              "77": 12,
+              "839": 4,
+              "94": 8
+            }
+          },
+          "HTTP_PAGE_DNS_ISSUE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 28.51285696029663,
+            "log_sum_squares": 45.067949295043945,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 77,
+            "values": {
+              "0": 105,
+              "1": 8,
+              "11": 1,
+              "13": 1,
+              "16": 0,
+              "2": 4,
+              "3": 2,
+              "4": 4,
+              "7": 2
+            }
+          },
+          "HTTP_PAGE_DNS_LOOKUP_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 140.3366141319275,
+            "log_sum_squares": 561.517746925354,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 3100,
+            "values": {
+              "0": 87,
+              "1": 2,
+              "11": 3,
+              "13": 1,
+              "16": 1,
+              "20": 1,
+              "24": 1,
+              "29": 3,
+              "3": 1,
+              "311": 1,
+              "35": 4,
+              "379": 2,
+              "4": 3,
+              "43": 4,
+              "52": 5,
+              "564": 1,
+              "63": 5,
+              "688": 0,
+              "77": 1,
+              "9": 1
+            }
+          },
+          "HTTP_PAGE_FIRST_SENT_TO_LAST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 683.3113679885864,
+            "log_sum_squares": 3522.5544171333313,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 35602,
+            "values": {
+              "1023": 1,
+              "115": 17,
+              "13": 4,
+              "140": 7,
+              "1522": 1,
+              "171": 7,
+              "1857": 1,
+              "20": 5,
+              "209": 5,
+              "24": 4,
+              "255": 8,
+              "311": 5,
+              "3370": 1,
+              "35": 4,
+              "379": 3,
+              "4111": 0,
+              "43": 2,
+              "462": 5,
+              "52": 4,
+              "564": 6,
+              "63": 17,
+              "688": 4,
+              "7": 0,
+              "77": 11,
+              "839": 3,
+              "9": 1,
+              "94": 13
+            }
+          },
+          "HTTP_PAGE_OPEN_TO_FIRST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 704.9309685230255,
+            "log_sum_squares": 3702.2162618637085,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 37618,
+            "values": {
+              "1023": 1,
+              "11": 1,
+              "115": 19,
+              "13": 1,
+              "140": 16,
+              "1522": 1,
+              "16": 1,
+              "171": 8,
+              "1857": 2,
+              "209": 9,
+              "24": 3,
+              "255": 10,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 3,
+              "379": 3,
+              "4111": 0,
+              "43": 2,
+              "462": 2,
+              "52": 1,
+              "564": 7,
+              "63": 17,
+              "688": 4,
+              "77": 11,
+              "839": 1,
+              "9": 0,
+              "94": 7
+            }
+          },
+          "HTTP_PAGE_OPEN_TO_FIRST_SENT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 324.95460772514343,
+            "log_sum_squares": 1228.9125940799713,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 7960,
+            "values": {
+              "0": 28,
+              "1": 8,
+              "11": 2,
+              "115": 7,
+              "1248": 1,
+              "13": 5,
+              "140": 1,
+              "1522": 0,
+              "16": 7,
+              "171": 2,
+              "2": 3,
+              "20": 3,
+              "209": 2,
+              "24": 1,
+              "255": 2,
+              "29": 2,
+              "3": 9,
+              "35": 3,
+              "379": 1,
+              "4": 15,
+              "43": 3,
+              "462": 1,
+              "5": 7,
+              "52": 8,
+              "564": 2,
+              "6": 4,
+              "63": 2,
+              "7": 4,
+              "77": 4,
+              "9": 1,
+              "94": 1
+            }
+          },
+          "HTTP_PAGE_TCP_CONNECTION": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 2.079441547393799,
+            "log_sum_squares": 4.324077129364014,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 7,
+            "values": {
+              "6": 0,
+              "7": 1,
+              "9": 0
+            }
+          },
+          "HTTP_REQUEST_PER_PAGE": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 364.44632732868195,
+            "log_sum_squares": 814.5372350215912,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 1687,
+            "values": {
+              "0": 5,
+              "1": 40,
+              "10": 5,
+              "11": 3,
+              "12": 3,
+              "14": 4,
+              "16": 13,
+              "18": 4,
+              "2": 36,
+              "20": 12,
+              "23": 1,
+              "26": 1,
+              "29": 2,
+              "3": 8,
+              "33": 5,
+              "37": 2,
+              "4": 28,
+              "47": 1,
+              "5": 7,
+              "6": 13,
+              "7": 8,
+              "8": 6,
+              "84": 1,
+              "9": 1,
+              "95": 0
+            }
+          },
+          "HTTP_REQUEST_PER_PAGE_FROM_CACHE": {
+            "bucket_count": 102,
+            "histogram_type": 1,
+            "range": [
+              1,
+              101
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 204,
+              "1": 0
+            }
+          },
+          "HTTP_SUBITEM_FIRST_BYTE_LATENCY_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 4616.2988312244415,
+            "log_sum_squares": 29666.51225376129,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5230826,
+            "values": {
+              "1023": 49,
+              "11": 0,
+              "11106": 2,
+              "115": 29,
+              "1248": 31,
+              "13": 2,
+              "140": 28,
+              "1522": 23,
+              "171": 39,
+              "1857": 14,
+              "20": 1,
+              "209": 32,
+              "2265": 13,
+              "24": 3,
+              "255": 36,
+              "2763": 10,
+              "29": 1,
+              "30000": 4,
+              "311": 41,
+              "3370": 7,
+              "35": 1,
+              "379": 87,
+              "43": 6,
+              "462": 56,
+              "5015": 2,
+              "52": 2,
+              "564": 48,
+              "6118": 9,
+              "63": 18,
+              "688": 69,
+              "7463": 1,
+              "77": 13,
+              "839": 52,
+              "94": 14
+            }
+          },
+          "HTTP_SUBITEM_OPEN_LATENCY_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 9152.890920162201,
+            "log_sum_squares": 57017.12989783287,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5842391,
+            "values": {
+              "0": 76,
+              "1": 56,
+              "1023": 49,
+              "11": 5,
+              "11106": 5,
+              "115": 23,
+              "1248": 42,
+              "13548": 1,
+              "140": 53,
+              "1522": 62,
+              "16": 8,
+              "171": 101,
+              "1857": 31,
+              "2": 39,
+              "20": 6,
+              "209": 69,
+              "2265": 17,
+              "24": 4,
+              "255": 120,
+              "2763": 9,
+              "29": 15,
+              "3": 7,
+              "30000": 4,
+              "311": 57,
+              "3370": 10,
+              "35": 49,
+              "379": 184,
+              "4": 5,
+              "4111": 1,
+              "43": 6,
+              "462": 110,
+              "5": 2,
+              "5015": 20,
+              "52": 11,
+              "564": 88,
+              "6": 2,
+              "6118": 21,
+              "63": 17,
+              "688": 114,
+              "7": 4,
+              "77": 31,
+              "839": 110,
+              "9": 5,
+              "94": 38
+            }
+          },
+          "HTTP_SUB_COMPLETE_LOAD_NET_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3341.598597764969,
+            "log_sum_squares": 15924.448185920715,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 126848,
+            "values": {
+              "1023": 3,
+              "11": 7,
+              "115": 52,
+              "13": 12,
+              "140": 40,
+              "1522": 2,
+              "16": 19,
+              "171": 31,
+              "1857": 3,
+              "20": 36,
+              "209": 19,
+              "24": 29,
+              "255": 31,
+              "29": 42,
+              "311": 24,
+              "3370": 1,
+              "35": 30,
+              "379": 23,
+              "4111": 0,
+              "43": 51,
+              "462": 16,
+              "52": 52,
+              "564": 11,
+              "6": 0,
+              "63": 64,
+              "688": 13,
+              "7": 8,
+              "77": 64,
+              "839": 14,
+              "9": 4,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_COMPLETE_LOAD_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3341.598597764969,
+            "log_sum_squares": 15924.448185920715,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 126848,
+            "values": {
+              "1023": 3,
+              "11": 7,
+              "115": 52,
+              "13": 12,
+              "140": 40,
+              "1522": 2,
+              "16": 19,
+              "171": 31,
+              "1857": 3,
+              "20": 36,
+              "209": 19,
+              "24": 29,
+              "255": 31,
+              "29": 42,
+              "311": 24,
+              "3370": 1,
+              "35": 30,
+              "379": 23,
+              "4111": 0,
+              "43": 51,
+              "462": 16,
+              "52": 52,
+              "564": 11,
+              "6": 0,
+              "63": 64,
+              "688": 13,
+              "7": 8,
+              "77": 64,
+              "839": 14,
+              "9": 4,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_DNS_ISSUE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 362.8482222557068,
+            "log_sum_squares": 869.1513342857361,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 2486,
+            "values": {
+              "0": 380,
+              "1": 59,
+              "11": 2,
+              "13": 21,
+              "16": 35,
+              "2": 26,
+              "20": 1,
+              "209": 3,
+              "24": 4,
+              "29": 1,
+              "3": 18,
+              "311": 1,
+              "379": 0,
+              "4": 20,
+              "5": 3,
+              "6": 4,
+              "63": 1,
+              "7": 6
+            }
+          },
+          "HTTP_SUB_DNS_LOOKUP_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 375.6888391971588,
+            "log_sum_squares": 1165.4497253894806,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5224,
+            "values": {
+              "0": 415,
+              "1": 38,
+              "11": 3,
+              "13": 1,
+              "16": 6,
+              "171": 2,
+              "2": 13,
+              "20": 2,
+              "24": 1,
+              "29": 5,
+              "3": 14,
+              "311": 1,
+              "35": 6,
+              "379": 3,
+              "4": 10,
+              "43": 6,
+              "5": 9,
+              "52": 8,
+              "564": 1,
+              "6": 8,
+              "63": 6,
+              "688": 0,
+              "7": 21,
+              "77": 3,
+              "9": 1,
+              "94": 2
+            }
+          },
+          "HTTP_SUB_FIRST_SENT_TO_LAST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3043.365156650543,
+            "log_sum_squares": 13596.140334129333,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 98996,
+            "values": {
+              "1023": 2,
+              "11": 28,
+              "115": 54,
+              "13": 36,
+              "140": 26,
+              "1522": 3,
+              "16": 26,
+              "171": 23,
+              "1857": 1,
+              "20": 37,
+              "209": 15,
+              "24": 28,
+              "255": 23,
+              "29": 25,
+              "311": 17,
+              "3370": 1,
+              "35": 50,
+              "379": 18,
+              "4111": 0,
+              "43": 51,
+              "462": 15,
+              "5": 0,
+              "52": 42,
+              "564": 7,
+              "6": 20,
+              "63": 50,
+              "688": 8,
+              "7": 23,
+              "77": 47,
+              "839": 9,
+              "9": 25,
+              "94": 32
+            }
+          },
+          "HTTP_SUB_OPEN_TO_FIRST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3251.081452727318,
+            "log_sum_squares": 15134.920769453049,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 112572,
+            "values": {
+              "1023": 2,
+              "11": 12,
+              "115": 60,
+              "13": 12,
+              "140": 37,
+              "1522": 3,
+              "16": 24,
+              "171": 31,
+              "1857": 2,
+              "20": 37,
+              "209": 22,
+              "24": 33,
+              "255": 26,
+              "29": 41,
+              "311": 24,
+              "3370": 1,
+              "35": 40,
+              "379": 22,
+              "4": 0,
+              "4111": 0,
+              "43": 47,
+              "462": 12,
+              "5": 1,
+              "52": 45,
+              "564": 8,
+              "6": 3,
+              "63": 69,
+              "688": 8,
+              "7": 13,
+              "77": 50,
+              "839": 10,
+              "9": 6,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_OPEN_TO_FIRST_SENT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 1550.930715084076,
+            "log_sum_squares": 5546.309858798981,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 27455,
+            "values": {
+              "0": 195,
+              "1": 48,
+              "11": 23,
+              "115": 18,
+              "1248": 1,
+              "13": 28,
+              "140": 4,
+              "1522": 0,
+              "16": 30,
+              "171": 9,
+              "2": 16,
+              "20": 27,
+              "209": 9,
+              "24": 16,
+              "255": 8,
+              "29": 15,
+              "3": 51,
+              "311": 6,
+              "35": 11,
+              "379": 3,
+              "4": 38,
+              "43": 18,
+              "462": 3,
+              "5": 24,
+              "52": 21,
+              "564": 2,
+              "6": 26,
+              "63": 21,
+              "7": 21,
+              "77": 17,
+              "9": 15,
+              "94": 18
+            }
+          },
+          "HTTP_SUB_TCP_CONNECTION": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 49.86611020565033,
+            "log_sum_squares": 178.6136667728424,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 638,
+            "values": {
+              "115": 0,
+              "29": 2,
+              "3": 0,
+              "35": 1,
+              "4": 2,
+              "5": 3,
+              "6": 1,
+              "63": 4,
+              "7": 1,
+              "77": 1,
+              "94": 1
+            }
+          },
+          "IMAGE_DECODE_CHUNKS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 1952,
+            "values": {
+              "0": 0,
+              "1": 1584,
+              "11": 1,
+              "111": 1,
+              "123": 0,
+              "2": 14,
+              "3": 5,
+              "4": 4,
+              "40": 1,
+              "5": 1,
+              "60": 1,
+              "66": 1,
+              "8": 1
+            }
+          },
+          "IMAGE_DECODE_COUNT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 1617,
+            "values": {
+              "0": 301,
+              "1": 623,
+              "12": 2,
+              "13": 1,
+              "14": 10,
+              "16": 3,
+              "18": 1,
+              "2": 88,
+              "20": 2,
+              "22": 1,
+              "27": 1,
+              "3": 15,
+              "30": 1,
+              "33": 1,
+              "4": 11,
+              "40": 1,
+              "44": 1,
+              "5": 5,
+              "6": 7,
+              "66": 1,
+              "7": 9,
+              "73": 0,
+              "8": 4
+            }
+          },
+          "IMAGE_DECODE_ON_DRAW_LATENCY": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              50,
+              50000000
+            ],
+            "sum": 411042409,
+            "values": {
+              "0": 2,
+              "101216": 3,
+              "102": 1,
+              "10610": 5,
+              "1112": 2,
+              "116539": 1,
+              "117": 1,
+              "12216": 10,
+              "1280": 14,
+              "134181": 3,
+              "135": 2,
+              "14065": 27,
+              "1473830": 1,
+              "1474": 5,
+              "155": 3,
+              "16194": 45,
+              "1697": 7,
+              "177882": 1,
+              "178": 1,
+              "18646": 15,
+              "1954": 1,
+              "21469": 15,
+              "2250": 3,
+              "236": 1,
+              "24719": 14,
+              "2591": 4,
+              "28461": 18,
+              "2983": 2,
+              "312620": 1,
+              "313": 2,
+              "32770": 22,
+              "3435": 4,
+              "359946": 1,
+              "360": 1,
+              "37731": 34,
+              "3953609": 1,
+              "3955": 4,
+              "414437": 1,
+              "43443": 46,
+              "4554": 6,
+              "50000000": 1,
+              "50020": 28,
+              "5243": 4,
+              "549415": 1,
+              "550": 1,
+              "57592": 36,
+              "6037": 3,
+              "632589": 1,
+              "633": 9,
+              "66311": 26,
+              "6951": 2,
+              "729": 6,
+              "76350": 17,
+              "77": 1,
+              "8003": 2,
+              "839": 1,
+              "87908": 9,
+              "9215": 3,
+              "965572": 1,
+              "966": 2
+            }
+          },
+          "IMAGE_DECODE_SPEED_GIF": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 2471648,
+            "values": {
+              "0": 0,
+              "1027": 11,
+              "11306": 1,
+              "1305": 14,
+              "14370": 3,
+              "1659": 9,
+              "18265": 8,
+              "2109": 13,
+              "23216": 4,
+              "2681": 45,
+              "29509": 7,
+              "3408": 20,
+              "37507": 7,
+              "4332": 4,
+              "47673": 9,
+              "500": 2,
+              "5506": 1,
+              "60595": 6,
+              "636": 3,
+              "6998": 6,
+              "77019": 4,
+              "808": 5,
+              "8895": 1,
+              "97895": 0
+            }
+          },
+          "IMAGE_DECODE_SPEED_JPEG": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 4775122,
+            "values": {
+              "1027": 2,
+              "11306": 62,
+              "1305": 2,
+              "14370": 48,
+              "1659": 1,
+              "18265": 23,
+              "201023": 3,
+              "2109": 4,
+              "23216": 14,
+              "255510": 0,
+              "2681": 3,
+              "29509": 6,
+              "3408": 12,
+              "37507": 1,
+              "4332": 19,
+              "5506": 41,
+              "6998": 51,
+              "808": 0,
+              "8895": 50,
+              "97895": 1
+            }
+          },
+          "IMAGE_DECODE_SPEED_PNG": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 8616699,
+            "values": {
+              "0": 5,
+              "1027": 20,
+              "11306": 80,
+              "1305": 17,
+              "14370": 58,
+              "1659": 38,
+              "18265": 36,
+              "2109": 59,
+              "23216": 19,
+              "2681": 80,
+              "29509": 12,
+              "3408": 82,
+              "37507": 4,
+              "4332": 100,
+              "47673": 0,
+              "500": 4,
+              "5506": 153,
+              "636": 5,
+              "6998": 200,
+              "808": 13,
+              "8895": 101
+            }
+          },
+          "IMAGE_DECODE_TIME": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              50,
+              50000000
+            ],
+            "sum": 1785143,
+            "values": {
+              "0": 581,
+              "102": 34,
+              "10610": 8,
+              "1112": 22,
+              "117": 27,
+              "12216": 6,
+              "1280": 16,
+              "134181": 1,
+              "135": 21,
+              "14065": 19,
+              "1474": 17,
+              "154494": 0,
+              "155": 33,
+              "16194": 3,
+              "1697": 17,
+              "178": 21,
+              "18646": 5,
+              "1954": 13,
+              "205": 17,
+              "21469": 3,
+              "2250": 9,
+              "236": 37,
+              "2591": 8,
+              "272": 30,
+              "28461": 4,
+              "2983": 4,
+              "313": 41,
+              "3435": 3,
+              "360": 48,
+              "3955": 4,
+              "415": 61,
+              "4554": 1,
+              "478": 51,
+              "50": 45,
+              "5243": 3,
+              "550": 72,
+              "58": 42,
+              "6037": 6,
+              "633": 44,
+              "67": 34,
+              "6951": 2,
+              "729": 50,
+              "77": 31,
+              "8003": 14,
+              "839": 33,
+              "89": 31,
+              "9215": 9,
+              "966": 33
+            }
+          },
+          "IMAGE_MAX_DECODE_COUNT": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 70,
+            "values": {
+              "63": 0,
+              "68": 1,
+              "74": 0
+            }
+          },
+          "INNERWINDOWS_WITH_MUTATION_LISTENERS": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 776,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "LINK_ICON_SIZES_ATTR_DIMENSION": {
+            "bucket_count": 64,
+            "histogram_type": 1,
+            "range": [
+              1,
+              513
+            ],
+            "sum": 1008,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 349440,
+            "values": {
+              "1": 0,
+              "125": 1,
+              "249": 1,
+              "26": 1,
+              "505": 1,
+              "513": 0,
+              "59": 1,
+              "9": 1
+            }
+          },
+          "LINK_ICON_SIZES_ATTR_USAGE": {
+            "bucket_count": 5,
+            "histogram_type": 1,
+            "range": [
+              1,
+              4
+            ],
+            "sum": 12,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24,
+            "values": {
+              "0": 71,
+              "2": 6,
+              "3": 0
+            }
+          },
+          "LOCALDOMSTORAGE_GETVALUE_BLOCKING_MS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 9,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 9,
+            "values": {
+              "0": 12,
+              "1": 9,
+              "2": 0
+            }
+          },
+          "MAC_INITFONTLIST_TOTAL": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 2.7725887298583984,
+            "log_sum_squares": 7.687248229980469,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 15,
+            "values": {
+              "14": 1,
+              "4": 0,
+              "50": 0
+            }
+          },
+          "MASTER_PASSWORD_ENABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "MEMORY_HEAP_ALLOCATED": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 8809.515153884888,
+            "log_sum_squares": 110612.54148864746,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 206044098,
+            "values": {
+              "137661": 0,
+              "144576": 5,
+              "151838": 10,
+              "159465": 15,
+              "167475": 19,
+              "175887": 39,
+              "184722": 33,
+              "194001": 16,
+              "203746": 20,
+              "213980": 51,
+              "224728": 37,
+              "236016": 21,
+              "247871": 4,
+              "260322": 2,
+              "273398": 4,
+              "287131": 16,
+              "301554": 26,
+              "316701": 83,
+              "332609": 110,
+              "349316": 53,
+              "366862": 64,
+              "385290": 51,
+              "404644": 13,
+              "424970": 8,
+              "446317": 1,
+              "468736": 1,
+              "492281": 0
+            }
+          },
+          "MEMORY_HEAP_COMMITTED_UNUSED_RATIO": {
+            "bucket_count": 25,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 1738,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4628,
+            "values": {
+              "0": 0,
+              "1": 700,
+              "10": 0,
+              "5": 2
+            }
+          },
+          "MEMORY_IMAGES_CONTENT_USED_UNCOMPRESSED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 4823.088839054108,
+            "log_sum_squares": 34751.68099427223,
+            "range": [
+              1024,
+              1048576
+            ],
+            "sum": 1657367,
+            "values": {
+              "0": 345,
+              "1024": 3,
+              "10317": 1,
+              "1183": 23,
+              "1367": 65,
+              "1579": 67,
+              "1824": 53,
+              "2107": 4,
+              "21240": 1,
+              "28353": 11,
+              "3249": 18,
+              "3754": 1,
+              "4337": 9,
+              "43728": 1,
+              "5011": 63,
+              "50522": 0,
+              "5790": 8,
+              "6690": 4,
+              "7729": 22,
+              "8930": 3
+            }
+          },
+          "MEMORY_JS_COMPARTMENTS_SYSTEM": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3860.0667686462402,
+            "log_sum_squares": 21225.674673080444,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 170897,
+            "values": {
+              "192": 0,
+              "216": 271,
+              "243": 431,
+              "273": 0
+            }
+          },
+          "MEMORY_JS_COMPARTMENTS_USER": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3392.333098888397,
+            "log_sum_squares": 16404.058506011963,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 88087,
+            "values": {
+              "107": 181,
+              "120": 267,
+              "135": 120,
+              "152": 43,
+              "171": 0,
+              "84": 0,
+              "95": 91
+            }
+          },
+          "MEMORY_JS_GC_HEAP": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 8520.874587059021,
+            "log_sum_squares": 103489.8610534668,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 136859648,
+            "values": {
+              "102590": 0,
+              "107743": 52,
+              "113155": 37,
+              "124808": 11,
+              "131077": 71,
+              "137661": 100,
+              "144576": 1,
+              "167475": 20,
+              "175887": 2,
+              "236016": 397,
+              "247871": 11,
+              "260322": 0
+            }
+          },
+          "MEMORY_JS_MAIN_RUNTIME_TEMPORARY_PEAK": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 6170.476452827454,
+            "log_sum_squares": 54237.576599121094,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 4609516,
+            "values": {
+              "5979": 0,
+              "6279": 702,
+              "6594": 0
+            }
+          },
+          "MEMORY_RESIDENT": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 9436.214457511902,
+            "log_sum_squares": 126885.07312011719,
+            "range": [
+              32768,
+              16777216
+            ],
+            "sum": 499028228,
+            "values": {
+              "1016084": 3,
+              "1048607": 5,
+              "1082171": 11,
+              "108501": 0,
+              "1116809": 21,
+              "111974": 1,
+              "1152556": 24,
+              "1189447": 1,
+              "1227519": 0,
+              "288141": 1,
+              "477020": 10,
+              "492288": 14,
+              "508045": 16,
+              "524306": 62,
+              "541088": 39,
+              "558407": 71,
+              "576280": 20,
+              "594726": 25,
+              "613762": 50,
+              "633407": 31,
+              "653681": 60,
+              "674604": 66,
+              "696197": 19,
+              "718481": 16,
+              "741478": 14,
+              "765211": 3,
+              "789704": 22,
+              "814981": 10,
+              "841067": 5,
+              "867988": 14,
+              "895771": 19,
+              "924443": 8,
+              "954033": 3,
+              "984570": 38
+            }
+          },
+          "MEMORY_VSIZE": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 10687.191714286804,
+            "log_sum_squares": 162706.16564941406,
+            "range": [
+              32768,
+              16777216
+            ],
+            "sum": 2881356800,
+            "values": {
+              "3205781": 0,
+              "3416485": 23,
+              "3641037": 254,
+              "3880348": 17,
+              "4135388": 153,
+              "4407191": 255,
+              "4696859": 0
+            }
+          },
+          "MIXED_CONTENT_PAGE_LOAD": {
+            "bucket_count": 5,
+            "histogram_type": 1,
+            "range": [
+              1,
+              4
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 54,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "MIXED_CONTENT_UNBLOCK_COUNTER": {
+            "bucket_count": 4,
+            "histogram_type": 1,
+            "range": [
+              1,
+              3
+            ],
+            "sum": 55,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 55,
+            "values": {
+              "0": 0,
+              "1": 55,
+              "2": 0
+            }
+          },
+          "PAGE_FAULTS_HARD": {
+            "bucket_count": 13,
+            "histogram_type": 0,
+            "log_sum": 112.41163563728333,
+            "log_sum_squares": 378.23194670677185,
+            "range": [
+              8,
+              65536
+            ],
+            "sum": 1605,
+            "values": {
+              "0": 677,
+              "18": 11,
+              "211": 2,
+              "41": 2,
+              "479": 0,
+              "8": 5,
+              "93": 4
+            }
+          },
+          "PAINT_BUILD_DISPLAYLIST_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 91347,
+            "values": {
+              "0": 24585,
+              "1": 43110,
+              "10": 1,
+              "12": 2,
+              "14": 1,
+              "16": 3,
+              "18": 2,
+              "2": 7010,
+              "20": 1,
+              "3": 4456,
+              "33": 1,
+              "4": 3409,
+              "5": 1157,
+              "6": 162,
+              "7": 15,
+              "75": 1,
+              "8": 5,
+              "84": 0,
+              "9": 4
+            }
+          },
+          "PAINT_RASTERIZE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 241605,
+            "values": {
+              "0": 2640,
+              "1": 31283,
+              "10": 302,
+              "107": 9,
+              "11": 309,
+              "12": 711,
+              "120": 6,
+              "135": 3,
+              "14": 634,
+              "152": 1,
+              "16": 687,
+              "171": 2,
+              "18": 537,
+              "192": 0,
+              "2": 29700,
+              "20": 226,
+              "23": 144,
+              "26": 84,
+              "29": 81,
+              "3": 9804,
+              "33": 75,
+              "37": 71,
+              "4": 2260,
+              "42": 83,
+              "47": 77,
+              "5": 1392,
+              "53": 45,
+              "6": 810,
+              "60": 32,
+              "67": 21,
+              "7": 756,
+              "75": 15,
+              "8": 644,
+              "84": 19,
+              "9": 428,
+              "95": 34
+            }
+          },
+          "PLUGIN_CALLED_DIRECTLY": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "PUSH_API_USED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "PWMGR_FORM_AUTOFILL_RESULT": {
+            "bucket_count": 21,
+            "histogram_type": 1,
+            "range": [
+              1,
+              20
+            ],
+            "sum": 8,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 32,
+            "values": {
+              "0": 2,
+              "4": 2,
+              "5": 0
+            }
+          },
+          "PWMGR_LOGIN_PAGE_SAFETY": {
+            "bucket_count": 9,
+            "histogram_type": 1,
+            "range": [
+              1,
+              8
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 8,
+            "values": {
+              "0": 2,
+              "2": 2,
+              "3": 0
+            }
+          },
+          "PWMGR_PASSWORD_INPUT_IN_FORM": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "REFRESH_DRIVER_TICK": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 425742,
+            "values": {
+              "0": 87151,
+              "1": 2709,
+              "10": 637,
+              "107": 16,
+              "11": 612,
+              "12": 1051,
+              "120": 6,
+              "135": 5,
+              "14": 725,
+              "152": 1,
+              "16": 651,
+              "171": 5,
+              "18": 655,
+              "2": 14226,
+              "20": 720,
+              "216": 1,
+              "23": 732,
+              "243": 1,
+              "26": 269,
+              "273": 3,
+              "29": 163,
+              "3": 26479,
+              "307": 2,
+              "33": 116,
+              "345": 0,
+              "37": 78,
+              "4": 16819,
+              "42": 59,
+              "47": 94,
+              "5": 6402,
+              "53": 63,
+              "6": 3829,
+              "60": 31,
+              "67": 24,
+              "7": 3544,
+              "75": 21,
+              "8": 2499,
+              "84": 26,
+              "9": 1005,
+              "95": 31
+            }
+          },
+          "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_TIMEZONE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SEARCH_SERVICE_US_TIMEZONE_MISMATCHED_COUNTRY": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SERVICE_WORKER_REQUEST_PASSTHROUGH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 2,
+              "1": 0
+            }
+          },
+          "SHOULD_AUTO_DETECT_LANGUAGE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SHOULD_TRANSLATION_UI_APPEAR": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SOCIAL_ENABLED_ON_SESSION": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_CACHE_INVALID": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_CRASH_DETECTED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_MEASUREMENT_ERRORS": {
+            "bucket_count": 17,
+            "histogram_type": 1,
+            "range": [
+              1,
+              16
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "1": 0,
+              "2": 1,
+              "3": 0
+            }
+          },
+          "STARTUP_STARTUP_CACHE_INVALID": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_XUL_CACHE_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STS_NUMBER_OF_ONSOCKETREADY_CALLS": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 42,
+              "1": 0
+            }
+          },
+          "STS_NUMBER_OF_PENDING_EVENTS": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 80,
+            "values": {
+              "1": 0,
+              "2": 13,
+              "4": 1,
+              "5": 10,
+              "6": 0
+            }
+          },
+          "STS_POLL_AND_EVENTS_CYCLE": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 175,
+            "values": {
+              "0": 14,
+              "10": 1,
+              "13": 2,
+              "16": 1,
+              "17": 1,
+              "19": 1,
+              "21": 1,
+              "29": 1,
+              "30": 1,
+              "31": 0,
+              "7": 1
+            }
+          },
+          "STS_POLL_BLOCK_TIME": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 33886288,
+            "values": {
+              "0": 25,
+              "125": 1,
+              "138": 1,
+              "18": 1,
+              "197": 1,
+              "3480": 1,
+              "35": 1,
+              "60000": 10,
+              "830": 1
+            }
+          },
+          "STS_POLL_CYCLE": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 42,
+              "1": 0
+            }
+          },
+          "SUBJECT_PRINCIPAL_ACCESSED_WITHOUT_SCRIPT_ON_STACK": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SYSTEM_FONT_FALLBACK": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 87.43857419490814,
+            "log_sum_squares": 198.41094660758972,
+            "range": [
+              1,
+              100000
+            ],
+            "sum": 4604,
+            "values": {
+              "0": 57,
+              "1": 27,
+              "1122": 1,
+              "13": 1,
+              "2": 36,
+              "2753": 1,
+              "3": 3,
+              "3446": 0,
+              "4": 1,
+              "5": 2,
+              "6": 1
+            }
+          },
+          "SYSTEM_FONT_FALLBACK_FIRST": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0.6931471824645996,
+            "log_sum_squares": 0.4804530143737793,
+            "range": [
+              1,
+              40000
+            ],
+            "sum": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "SYSTEM_FONT_FALLBACK_SCRIPT": {
+            "bucket_count": 111,
+            "histogram_type": 1,
+            "range": [
+              1,
+              110
+            ],
+            "sum": 2706,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 69656,
+            "values": {
+              "0": 0,
+              "1": 28,
+              "26": 103,
+              "27": 0
+            }
+          },
+          "TELEMETRY_MEMORY_REPORTER_MS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 843.2068462371826,
+            "log_sum_squares": 1059.1628289222717,
+            "range": [
+              1,
+              5000
+            ],
+            "sum": 1730,
+            "values": {
+              "0": 0,
+              "1": 417,
+              "26": 1,
+              "3": 283,
+              "74": 0,
+              "9": 1
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_LOAD": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_PARSE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_SAVE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_VALIDATION": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_RELEASE_OPTIN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_RELEASE_OPTOUT": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 55,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 55,
+            "values": {
+              "0": 55,
+              "1": 0
+            }
+          },
+          "TOTAL_CONTENT_PAGE_LOAD_TIME": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 1238.1626212596893,
+            "log_sum_squares": 7688.37299156189,
+            "range": [
+              100,
+              30000
+            ],
+            "sum": 163364,
+            "values": {
+              "0": 36,
+              "100": 1,
+              "1027": 6,
+              "106": 1,
+              "1089": 5,
+              "1154": 3,
+              "119": 2,
+              "1223": 2,
+              "126": 1,
+              "1296": 4,
+              "13285": 1,
+              "134": 2,
+              "1374": 2,
+              "14081": 0,
+              "142": 3,
+              "1456": 3,
+              "151": 4,
+              "160": 5,
+              "1635": 2,
+              "170": 4,
+              "1733": 2,
+              "180": 1,
+              "1837": 1,
+              "191": 3,
+              "1947": 1,
+              "202": 1,
+              "2064": 2,
+              "2188": 2,
+              "227": 5,
+              "2319": 1,
+              "241": 4,
+              "2458": 3,
+              "255": 4,
+              "2605": 1,
+              "270": 8,
+              "286": 3,
+              "303": 2,
+              "321": 1,
+              "340": 1,
+              "360": 2,
+              "3693": 1,
+              "382": 7,
+              "3914": 1,
+              "405": 3,
+              "4149": 1,
+              "455": 4,
+              "482": 4,
+              "511": 2,
+              "542": 2,
+              "574": 2,
+              "5883": 1,
+              "608": 8,
+              "644": 8,
+              "683": 3,
+              "724": 4,
+              "7425": 1,
+              "767": 4,
+              "813": 6,
+              "862": 3,
+              "914": 5,
+              "969": 4
+            }
+          },
+          "URL_PATH_CONTAINS_EXCLAMATION_DOUBLE_SLASH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 18484,
+              "1": 0
+            }
+          },
+          "URL_PATH_CONTAINS_EXCLAMATION_SLASH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4183,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4183,
+            "values": {
+              "0": 14301,
+              "1": 4183,
+              "2": 0
+            }
+          },
+          "URL_PATH_ENDS_IN_EXCLAMATION": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 18484,
+              "1": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetAttributeNode_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 11,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 11,
+            "values": {
+              "0": 0,
+              "1": 11,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetAttributeNode_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 6,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 6,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetPreventDefault_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 51,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 51,
+            "values": {
+              "0": 0,
+              "1": 51,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetPreventDefault_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 24,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24,
+            "values": {
+              "0": 0,
+              "1": 24,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_MutationEvent_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_MutationEvent_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_NodeValue_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 3,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 3,
+            "values": {
+              "0": 0,
+              "1": 3,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_NodeValue_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 3,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 3,
+            "values": {
+              "0": 0,
+              "1": 3,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_PrefixedVisibilityAPI_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 9,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 9,
+            "values": {
+              "0": 0,
+              "1": 9,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_PrefixedVisibilityAPI_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_SyncXMLHttpRequest_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 7,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 7,
+            "values": {
+              "0": 0,
+              "1": 7,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_SyncXMLHttpRequest_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILLOPACITY_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 6,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 6,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILLOPACITY_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILL_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 27,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 27,
+            "values": {
+              "0": 0,
+              "1": 27,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILL_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 12,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 12,
+            "values": {
+              "0": 0,
+              "1": 12,
+              "2": 0
+            }
+          },
+          "VIDEO_ADOBE_GMP_DISAPPEARED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_CONSTRAINT_SET_FLAG": {
+            "bucket_count": 129,
+            "histogram_type": 1,
+            "range": [
+              1,
+              128
+            ],
+            "sum": 1120,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 250880,
+            "values": {
+              "127": 0,
+              "128": 5
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_LEVEL": {
+            "bucket_count": 52,
+            "histogram_type": 1,
+            "range": [
+              1,
+              51
+            ],
+            "sum": 150,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4500,
+            "values": {
+              "29": 0,
+              "30": 5,
+              "31": 0
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_PROFILE": {
+            "bucket_count": 245,
+            "histogram_type": 1,
+            "range": [
+              1,
+              244
+            ],
+            "sum": 330,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 21780,
+            "values": {
+              "65": 0,
+              "66": 5,
+              "67": 0
+            }
+          },
+          "VIDEO_OPENH264_GMP_DISAPPEARED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "WEAVE_CAN_FETCH_KEYS": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "WORD_CACHE_HITS_CHROME": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 4514,
+            "values": {
+              "0": 0,
+              "1": 198,
+              "11": 0,
+              "2": 93,
+              "3": 91,
+              "4": 213,
+              "5": 101,
+              "6": 27,
+              "7": 26,
+              "8": 120,
+              "9": 122
+            }
+          },
+          "WORD_CACHE_HITS_CONTENT": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 2017098,
+            "values": {
+              "0": 0,
+              "1": 113127,
+              "11": 10287,
+              "13": 1782,
+              "15": 1929,
+              "18": 1014,
+              "2": 66473,
+              "21": 832,
+              "25": 399,
+              "3": 83407,
+              "30": 118,
+              "35": 0,
+              "4": 71929,
+              "5": 44779,
+              "6": 32537,
+              "7": 32348,
+              "8": 19981,
+              "9": 21989
+            }
+          },
+          "WORD_CACHE_MISSES_CHROME": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 2131,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "11": 0,
+              "2": 24,
+              "3": 64,
+              "4": 48,
+              "5": 69,
+              "6": 35,
+              "7": 35,
+              "8": 65,
+              "9": 40
+            }
+          },
+          "WORD_CACHE_MISSES_CONTENT": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 663507,
+            "values": {
+              "0": 0,
+              "1": 6501,
+              "11": 3924,
+              "13": 1602,
+              "15": 1190,
+              "18": 701,
+              "2": 9497,
+              "21": 651,
+              "25": 387,
+              "3": 15296,
+              "30": 105,
+              "35": 0,
+              "4": 18345,
+              "5": 17136,
+              "6": 10814,
+              "7": 11810,
+              "8": 8561,
+              "9": 9606
+            }
+          },
+          "XMLHTTPREQUEST_ASYNC_OR_SYNC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 23,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 23,
+            "values": {
+              "0": 6046,
+              "1": 23,
+              "2": 0
+            }
+          },
+          "XUL_CACHE_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "YOUTUBE_EMBED_SEEN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        },
+        "keyedHistograms": {
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_FAILURE_TIME_MS": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_RATE": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_TIME_MS": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOAD_STARTED_COUNT": {},
+          "ADDON_SHIM_USAGE": {},
+          "BLOCKED_ON_PLUGINASYNCSURROGATE_WAITFORINIT_MS": {},
+          "BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS": {},
+          "BLOCKED_ON_PLUGIN_INSTANCE_INIT_MS": {},
+          "BLOCKED_ON_PLUGIN_MODULE_INIT_MS": {},
+          "BLOCKED_ON_PLUGIN_STREAM_INIT_MS": {},
+          "DEVTOOLS_HUD_APP_MEMORY_CONTENTINTERACTIVE_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_FULLYLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_MEDIAENUMERATED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONINTERACTIVE_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_SCANEND_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_VISUALLYLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_CONTENTINTERACTIVE": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_FULLYLOADED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_MEDIAENUMERATED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONINTERACTIVE": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONLOADED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_SCANEND": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_VISUALLYLOADED": {},
+          "DEVTOOLS_HUD_ERRORS": {},
+          "DEVTOOLS_HUD_JANK": {},
+          "DEVTOOLS_HUD_REFLOWS": {},
+          "DEVTOOLS_HUD_REFLOW_DURATION": {},
+          "DEVTOOLS_HUD_SECURITY_CATEGORY": {},
+          "DEVTOOLS_HUD_WARNINGS": {},
+          "DEVTOOLS_PERFTOOLS_RECORDING_FEATURES_USED": {},
+          "DEVTOOLS_PERFTOOLS_SELECTED_VIEW_MS": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_APP_TYPE": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_ID": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_OS": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PLATFORM_VERSION": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PROCESSOR": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_TYPE": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_VERSION": {},
+          "FXA_HAWK_ERRORS": {},
+          "FXA_SERVER_ERRORS": {},
+          "FXA_UNVERIFIED_ACCOUNT_ERRORS": {},
+          "FX_MIGRATION_ERRORS": {},
+          "FX_MIGRATION_HOMEPAGE_IMPORTED": {},
+          "FX_MIGRATION_USAGE": {},
+          "FX_TABLETMODE_PAGE_LOAD": {},
+          "JS_TELEMETRY_ADDON_EXCEPTIONS": {},
+          "KEYGEN_GENERATED_KEY_TYPE": {},
+          "MISBEHAVING_ADDONS_CPOW_TIME_MS": {},
+          "MISBEHAVING_ADDONS_JANK_LEVEL": {},
+          "PLUGIN_ACTIVATION_COUNT": {},
+          "POPUP_NOTIFICATION_DISMISSAL_MS": {},
+          "POPUP_NOTIFICATION_MAIN_ACTION_MS": {},
+          "POPUP_NOTIFICATION_STATS": {},
+          "PROCESS_CRASH_SUBMIT_ATTEMPT": {},
+          "PROCESS_CRASH_SUBMIT_SUCCESS": {},
+          "PWMGR_MANAGE_SORTED": {},
+          "SEARCH_COUNTS": {},
+          "SUBPROCESS_ABNORMAL_ABORT": {},
+          "SUBPROCESS_CRASHES_WITH_DUMP": {},
+          "TELEMETRY_INVALID_PING_TYPE_SUBMITTED": {},
+          "TELEMETRY_TEST_KEYED_COUNT": {},
+          "TELEMETRY_TEST_KEYED_FLAG": {},
+          "TELEMETRY_TEST_KEYED_RELEASE_OPTIN": {},
+          "TELEMETRY_TEST_KEYED_RELEASE_OPTOUT": {},
+          "TOKENSERVER_AUTH_ERRORS": {},
+          "TRANSLATED_PAGES_BY_LANGUAGE": {},
+          "TRANSLATION_OPPORTUNITIES_BY_LANGUAGE": {},
+          "UPDATE_CHECK_EXTENDED_ERROR_EXTERNAL": {},
+          "UPDATE_CHECK_EXTENDED_ERROR_NOTIFY": {},
+          "WEAVE_ENGINE_APPLY_FAILURES": {},
+          "WEAVE_ENGINE_APPLY_NEW_FAILURES": {},
+          "WEAVE_ENGINE_SYNC_ERRORS": {},
+          "WEAVE_STORAGE_AUTH_ERRORS": {}
+        }
+      },
+      "gpu": {
+        "histograms": {
+          "A11Y_INSTANTIATED_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        },
+        "keyedHistograms": {
+          "ADDON_SHIM_USAGE": {}
+        }
+      }
+    },
+    "info": {
+      "addons": "masspasswordreset%40johnathan.nightingale:1.05.1-signed,foxyproxy%40eric.h.jung:4.5.5,eliteproxyswitcher%40my-proxy.com:1.2.0.2.1-signed,%7B972ce4c6-7e08-4474-a285-3208198ce6fd%7D:45.0,fxos_2_1_simulator%40mozilla.org:2.1.20141223.1-signed,fxos_1_4_simulator%40mozilla.org:1.4.20140506.1-signed,adbhelper%40mozilla.org:0.8.5,fxdevtools-adapters%40mozilla.org:0.3.3",
+      "asyncPluginInit": false,
+      "flashVersion": "19.0.0.226",
+      "previousBuildId": "20151102030241",
+      "previousSessionId": "3f4b8574-44f5-4173-a2fe-fbf1939ec516",
+      "previousSubsessionId": "f2af8461-80c2-4560-8131-bfc313f3d0fa",
+      "profileSubsessionCounter": 197,
+      "reason": "shutdown",
+      "revision": "https://hg.mozilla.org/mozilla-central/rev/bb4d614a0b09",
+      "sessionId": "a472b0c5-1498-4cd0-a953-954bbd474317",
+      "sessionLength": 44180,
+      "sessionStartDate": "2015-11-03T00:00:00.0-08:00",
+      "subsessionCounter": 2,
+      "subsessionId": "6e52dd1f-408a-483a-9406-d43d8c39e3a4",
+      "subsessionLength": 38376,
+      "subsessionStartDate": "2015-11-04T00:00:00.0-08:00",
+      "timezoneOffset": -480
+    },
+    "keyedHistograms": {
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_FAILURE_TIME_MS": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_RATE": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_TIME_MS": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOAD_STARTED_COUNT": {},
+      "ADDON_SHIM_USAGE": {
+        "foxyproxy@eric.h.jung": {
+          "bucket_count": 16,
+          "histogram_type": 1,
+          "range": [
+            1,
+            15
+          ],
+          "sum": 258,
+          "sum_squares_hi": 0,
+          "sum_squares_lo": 378,
+          "values": {
+            "0": 0,
+            "1": 234,
+            "6": 4,
+            "7": 0
+          }
+        }
+      },
+      "BLOCKED_ON_PLUGINASYNCSURROGATE_WAITFORINIT_MS": {},
+      "BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS": {},
+      "BLOCKED_ON_PLUGIN_INSTANCE_INIT_MS": {},
+      "BLOCKED_ON_PLUGIN_MODULE_INIT_MS": {},
+      "BLOCKED_ON_PLUGIN_STREAM_INIT_MS": {},
+      "DEVTOOLS_HUD_APP_MEMORY_CONTENTINTERACTIVE_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_FULLYLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_MEDIAENUMERATED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONINTERACTIVE_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_SCANEND_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_VISUALLYLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_CONTENTINTERACTIVE": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_FULLYLOADED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_MEDIAENUMERATED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONINTERACTIVE": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONLOADED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_SCANEND": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_VISUALLYLOADED": {},
+      "DEVTOOLS_HUD_ERRORS": {},
+      "DEVTOOLS_HUD_JANK": {},
+      "DEVTOOLS_HUD_REFLOWS": {},
+      "DEVTOOLS_HUD_REFLOW_DURATION": {},
+      "DEVTOOLS_HUD_SECURITY_CATEGORY": {},
+      "DEVTOOLS_HUD_WARNINGS": {},
+      "DEVTOOLS_PERFTOOLS_RECORDING_FEATURES_USED": {},
+      "DEVTOOLS_PERFTOOLS_SELECTED_VIEW_MS": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_APP_TYPE": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_ID": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_OS": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PLATFORM_VERSION": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PROCESSOR": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_TYPE": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_VERSION": {},
+      "FXA_HAWK_ERRORS": {},
+      "FXA_SERVER_ERRORS": {},
+      "FXA_UNVERIFIED_ACCOUNT_ERRORS": {},
+      "FX_MIGRATION_ERRORS": {},
+      "FX_MIGRATION_HOMEPAGE_IMPORTED": {},
+      "FX_MIGRATION_USAGE": {},
+      "FX_TABLETMODE_PAGE_LOAD": {
+        "desktop": {
+          "bucket_count": 30,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            100000
+          ],
+          "sum": 0,
+          "values": {
+            "0": 6,
+            "1": 0
+          }
+        },
+        "tablet": {
+          "bucket_count": 30,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            100000
+          ],
+          "sum": 0,
+          "values": {
+            "0": 6,
+            "1": 0
+          }
+        }
+      },
+      "JS_TELEMETRY_ADDON_EXCEPTIONS": {},
+      "KEYGEN_GENERATED_KEY_TYPE": {},
+      "MISBEHAVING_ADDONS_CPOW_TIME_MS": {
+        "foxyproxy@eric.h.jung": {
+          "bucket_count": 20,
+          "histogram_type": 0,
+          "log_sum": 17.722850799560547,
+          "log_sum_squares": 19.94512128829956,
+          "range": [
+            1,
+            10000
+          ],
+          "sum": 34,
+          "values": {
+            "0": 36,
+            "1": 10,
+            "2": 4,
+            "3": 3,
+            "5": 1,
+            "8": 0
+          }
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "bucket_count": 20,
+          "histogram_type": 0,
+          "log_sum": 33.526108741760254,
+          "log_sum_squares": 49.915854930877686,
+          "range": [
+            1,
+            10000
+          ],
+          "sum": 83,
+          "values": {
+            "0": 28,
+            "1": 11,
+            "13": 0,
+            "2": 4,
+            "3": 5,
+            "5": 5,
+            "8": 2
+          }
+        }
+      },
+      "MISBEHAVING_ADDONS_JANK_LEVEL": {},
+      "PLUGIN_ACTIVATION_COUNT": {},
+      "POPUP_NOTIFICATION_DISMISSAL_MS": {},
+      "POPUP_NOTIFICATION_MAIN_ACTION_MS": {},
+      "POPUP_NOTIFICATION_STATS": {},
+      "PROCESS_CRASH_SUBMIT_ATTEMPT": {},
+      "PROCESS_CRASH_SUBMIT_SUCCESS": {},
+      "PWMGR_MANAGE_SORTED": {},
+      "SEARCH_COUNTS": {
+        "google.urlbar": {
+          "bucket_count": 3,
+          "histogram_type": 4,
+          "range": [
+            1,
+            2
+          ],
+          "sum": 5,
+          "sum_squares_hi": 0,
+          "sum_squares_lo": 5,
+          "values": {
+            "0": 5,
+            "1": 0
+          }
+        }
+      },
+      "SUBPROCESS_ABNORMAL_ABORT": {},
+      "SUBPROCESS_CRASHES_WITH_DUMP": {},
+      "TELEMETRY_INVALID_PING_TYPE_SUBMITTED": {},
+      "TELEMETRY_TEST_KEYED_COUNT": {},
+      "TELEMETRY_TEST_KEYED_FLAG": {},
+      "TELEMETRY_TEST_KEYED_RELEASE_OPTIN": {},
+      "TELEMETRY_TEST_KEYED_RELEASE_OPTOUT": {},
+      "TOKENSERVER_AUTH_ERRORS": {},
+      "TRANSLATED_PAGES_BY_LANGUAGE": {},
+      "TRANSLATION_OPPORTUNITIES_BY_LANGUAGE": {},
+      "UPDATE_CHECK_EXTENDED_ERROR_EXTERNAL": {},
+      "UPDATE_CHECK_EXTENDED_ERROR_NOTIFY": {},
+      "WEAVE_ENGINE_APPLY_FAILURES": {},
+      "WEAVE_ENGINE_APPLY_NEW_FAILURES": {},
+      "WEAVE_ENGINE_SYNC_ERRORS": {},
+      "WEAVE_STORAGE_AUTH_ERRORS": {}
+    },
+    "lateWrites": {
+      "memoryMap": [
+        ["foo", "bar"],
+        ["baz", "foo", "error: too many items in this entry"]
+      ],
+      "stacks": [
+        [
+          [0, 0],
+          [0, 1],
+          [10, 10]
+        ],
+        [
+          [100, 0],
+          [200, -1],
+          [300, 10],
+          [400, 20]
+        ]
+      ]
+    },
+    "log": [
+      [
+        "EXPERIMENT_ACTIVATION",
+        1430,
+        "REJECTED",
+        "e10s-enabled-aurora-20151020@experiments.mozilla.org",
+        "endTime"
+      ],
+      [
+        "EXPERIMENT_ACTIVATION",
+        16393806,
+        "REJECTED",
+        "e10s-enabled-aurora-20151020@experiments.mozilla.org",
+        "endTime"
+      ]
+    ],
+    "simpleMeasurements": {
+      "AMI_startup_begin": 544,
+      "AMI_startup_end": 895,
+      "UITelemetry": {
+        "UITour": {
+          "seenPageIDs": [
+            "australis-29-release-no-tour"
+          ]
+        },
+        "contextmenu": {},
+        "toolbars": {
+          "addonToolbars": 1,
+          "bookmarksBarEnabled": true,
+          "countableEvents": {
+            "__DEFAULT__": {
+              "click-bookmarks-bar": {
+                "chevron": {
+                  "left": 1
+                }
+              },
+              "click-builtin-item": {
+                "alltabs-button": {
+                  "left": 2
+                },
+                "new-tab-button": {
+                  "left": 1
+                },
+                "tabbrowser-tabs": {
+                  "left": 25
+                }
+              },
+              "search": {
+                "urlbar": 6
+              }
+            }
+          },
+          "currentSearchEngine": "Google",
+          "defaultKept": [
+            "edit-controls",
+            "zoom-controls",
+            "new-window-button",
+            "privatebrowsing-button",
+            "save-page-button",
+            "print-button",
+            "history-panelmenu",
+            "fullscreen-button",
+            "find-button",
+            "preferences-button",
+            "add-ons-button",
+            "developer-button",
+            "urlbar-container",
+            "search-container",
+            "bookmarks-menu-button",
+            "pocket-button",
+            "downloads-button",
+            "home-button",
+            "social-share-button",
+            "tabbrowser-tabs",
+            "new-tab-button",
+            "alltabs-button",
+            "personal-bookmarks"
+          ],
+          "defaultMoved": [],
+          "defaultRemoved": [],
+          "durations": {
+            "customization": []
+          },
+          "hiddenTabs": [
+            0,
+            0
+          ],
+          "menuBarEnabled": false,
+          "nondefaultAdded": [
+            "tabview-button"
+          ],
+          "sizemode": "normal",
+          "titleBarEnabled": false,
+          "visibleTabs": [
+            46,
+            21
+          ]
+        }
+      },
+      "XPI_bootstrap_addons_begin": 749,
+      "XPI_bootstrap_addons_end": 889,
+      "XPI_finalUIStartup": 1156,
+      "XPI_startup_begin": 557,
+      "XPI_startup_end": 889,
+      "activeTicks": 1034,
+      "addonManager": {
+        "XPIDB_parseDB_MS": 2,
+        "XPIDB_saves_late": 0,
+        "XPIDB_saves_overlapped": 0,
+        "XPIDB_saves_total": 2,
+        "XPIDB_startup_load_reasons": [
+          "directoryState"
+        ],
+        "XPIDB_syncRead_MS": 1,
+        "default_providers": true
+      },
+      "createTopLevelWindow": 1244,
+      "debuggerAttached": 0,
+      "delayedStartupFinished": 1959,
+      "delayedStartupStarted": 1927,
+      "firstLoadURI": 2223,
+      "firstPaint": 1881,
+      "js": {
+        "customIter": 23,
+        "setProto": 0
+      },
+      "main": 133,
+      "maximalNumberOfConcurrentThreads": 45,
+      "pingsOverdue": 0,
+      "profileBeforeChange": 44180512,
+      "quitApplication": 44179631,
+      "savedPings": 0,
+      "selectProfile": 447,
+      "sessionRestoreInit": 1157,
+      "sessionRestoreInitialized": 1197,
+      "sessionRestoreRestoring": 1966,
+      "sessionRestored": 2481,
+      "shutdownDuration": 1476,
+      "start": 0,
+      "startupCrashDetectionBegin": 540,
+      "startupCrashDetectionEnd": 31951,
+      "startupInterrupted": 0,
+      "totalTime": 79083,
+      "uptime": 1318
+    },
+    "slowSQL": {
+      "mainThread": {},
+      "otherThreads": {
+        "COMMIT TRANSACTION /* cookies.sqlite */": [
+          1,
+          1137
+        ],
+        "SELECT :query_type, h.url, h.title, f.url, EXISTS(SELECT 1 FROM moz_bookmarks WHERE fk = h.id) AS bookmarked,\n   ( SELECT title FROM moz_bookmarks WHERE fk = h.id AND title NOTNULL\n     ORDER BY lastModified DESC LIMIT 1\n   ) AS btitle,\n   ( SELECT GROUP_CONCAT(t.title, :private)\n     FROM moz_bookmarks b\n     JOIN moz_bookmarks t ON t.id = +b.parent AND t.parent = :parent\n     WHERE b.fk = h.id\n   ) AS tags,\n            h.visit_count, h.typed, h.id, t.open_count, h.frecency\n     FROM moz_places h\n     LEFT JOIN moz_favicons f ON f.id = h.favicon_id\n     LEFT JOIN moz_openpages_temp t ON t.url = h.url\n     WHERE h.frecency <> 0\n       AND AUTOCOMPLETE_MATCH(:searchString, h.url,\n                              IFNULL(btitle, h.title), tags,\n                              h.visit_count, h.typed,\n                              bookmarked, t.open_count,\n                              :matchBehavior, :searchBehavior)\n       \n     ORDER BY h.frecency DESC, h.id DESC\n     LIMIT :maxResults /* places.sqlite */": [
+          80,
+          9995
+        ],
+        "UPDATE moz_cookies SET lastAccessed = :lastAccessed WHERE name = :name AND host = :host AND path = :path /* cookies.sqlite */": [
+          3,
+          1551
+        ],
+        "UPDATE moz_places SET frecency = CALCULATE_FRECENCY(id) WHERE frecency < 0 /* places.sqlite */": [
+          1,
+          102
+        ]
+      }
+    },
+    "threadHangStats": [
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 2285595,
+            "1023": 1,
+            "127": 334,
+            "15": 82830,
+            "2047": 0,
+            "255": 200,
+            "3": 68207,
+            "31": 19816,
+            "511": 19,
+            "63": 4295,
+            "7": 74255
+          }
+        },
+        "hangs": [
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "(chrome script)"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "nsBrowserGlue.js:282",
+              "gre/modules/XPCOMUtils.jsm:197",
+              "gre/modules/XPCOMUtils.jsm:271",
+              "/modules/RemotePrompt.jsm:8"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 3,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "ChildView::drawUsingOpenGL"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "gre/modules/Promise-backend.js:747",
+              "gre/modules/Promise-backend.js:805",
+              "/modules/sessionstore/SessionStore.jsm:1137",
+              "(chrome script)"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 5,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "Timer::Fire",
+              "nsJSContext::RunCycleCollectorSlice",
+              "nsCycleCollector::collectSlice"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 1,
+                "127": 0,
+                "2047": 0,
+                "255": 184,
+                "511": 14
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 1,
+                "2047": 0,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "IPDL::PBrowser::RecvAsyncMessage",
+              "gre/modules/RemoteWebProgress.jsm:183"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "nsRefreshDriver::Tick",
+              "EventDispatcher::Dispatch",
+              "global/content/bindings/scrollbox.xml:572",
+              "global/content/bindings/scrollbox.xml:172",
+              "PresShell::Flush",
+              "PresShell::Paint",
+              "nsLayoutUtils::PaintFrame",
+              "nsDisplayList::PaintRoot",
+              "BasicLayerManager::EndTransactionInternal",
+              "FrameLayerBuilder::DrawPaintedLayer",
+              "DisplayList::Draw"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "EventDispatcher::Dispatch",
+              "browser/content/places/browserPlacesViews.js:1812",
+              "browser/content/places/browserPlacesViews.js:674",
+              "gre/components/nsLivemarkService.js:290",
+              "gre/modules/Task.jsm:164",
+              "gre/modules/Task.jsm:226"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 4
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "gre/components/nsLoginManagerPrompter.js:105",
+              "gre/components/nsPrompter.js:107"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "ChildView::drawUsingOpenGL",
+              "IPDL::PCompositor::SendFlushRendering"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "EventDispatcher::Dispatch",
+              "browser/content/hiddenWindow.xul:1",
+              "nsBrowserGlue.js:282",
+              "gre/modules/XPCOMUtils.jsm:197",
+              "gre/modules/XPCOMUtils.jsm:271",
+              "/modules/CustomizationTabPreloader.jsm:9"
+            ]
+          }
+        ],
+        "name": "Gecko"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 5058912,
+            "127": 37,
+            "15": 33710,
+            "2047": 2,
+            "255": 6,
+            "3": 42286,
+            "31": 17226,
+            "4095": 0,
+            "63": 1035,
+            "7": 38624
+          }
+        },
+        "hangs": [
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "2047": 1,
+                "255": 0,
+                "4095": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render",
+              "LayerManagerComposite::EndFrame",
+              "CompositorOGL::EndFrame",
+              "GLContextCGL::SwapBuffers"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "2047": 1,
+                "4095": 0
+              }
+            },
+            "stack": [
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 4,
+                "511": 0
+              }
+            },
+            "stack": [
+              "IPDL::PLayerTransaction::RecvUpdateNoSwap",
+              "LayerTransactionParent::RecvUpdate"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "IPDL::PCompositor::RecvFlushRendering",
+              "CompositorParent::ForceComposeToTarget",
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render",
+              "LayerManagerComposite::EndFrame",
+              "CompositorOGL::EndFrame",
+              "GLContextCGL::SwapBuffers"
+            ]
+          }
+        ],
+        "name": "Compositor"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 13,
+            "3": 0
+          }
+        },
+        "hangs": [],
+        "name": "ImageBridgeChild"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 20,
+            "15": 1,
+            "3": 1,
+            "31": 0
+          }
+        },
+        "hangs": [],
+        "name": "ProcessHangMonitor"
+      }
+    ],
+    "ver": 4,
+    "webrtc": {
+      "IceCandidatesStats": {
+        "loop": {},
+        "webrtc": {}
+      }
+    }
+  },
+  "type": "main",
+  "version": 4
+}

--- a/validation/telemetry/main.4.latewrites.pass.json
+++ b/validation/telemetry/main.4.latewrites.pass.json
@@ -1,0 +1,16909 @@
+{
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20151103030248",
+    "channel": "beta",
+    "name": "Firefox",
+    "platformVersion": "45.0",
+    "vendor": "Mozilla",
+    "version": "45.0",
+    "displayVersion": "45.0b6",
+    "xpcomAbi": "x86_64-gcc3"
+  },
+  "clientId": "6fd3eb50-8bec-4b9c-8778-59406171312a",
+  "creationDate": "2015-11-05T01:25:43.312Z",
+  "environment": {
+    "addons": {
+      "activeAddons": {
+        "adbhelper@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "An addon to ease connecting to Firefox OS devices.",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16232,
+          "name": "ADB Helper",
+          "scope": 1,
+          "signedState": 1,
+          "type": "extension",
+          "updateDay": 16729,
+          "userDisabled": false,
+          "version": "0.8.5"
+        },
+        "eliteproxyswitcher@my-proxy.com": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Automatically change the proxy for Firefox.",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16644,
+          "name": "Elite Proxy Switcher",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16644,
+          "userDisabled": false,
+          "version": "1.2.0.2.1-signed"
+        },
+        "foxyproxy@eric.h.jung": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "FoxyProxy - Premier proxy management for Firefox",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16637,
+          "name": "FoxyProxy Standard",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16637,
+          "userDisabled": false,
+          "version": "4.5.5"
+        },
+        "fxdevtools-adapters@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Protocol Adapters for Firefox Developer Tools. User documentation is available on MDN: https://devel",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16548,
+          "name": "Valence",
+          "scope": 1,
+          "signedState": 1,
+          "type": "extension",
+          "updateDay": 16729,
+          "userDisabled": false,
+          "version": "0.3.3"
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "a Firefox OS 1.4 simulator",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16232,
+          "name": "Firefox OS 1.4 Simulator",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16673,
+          "userDisabled": false,
+          "version": "1.4.20140506.1-signed"
+        },
+        "fxos_2_1_simulator@mozilla.org": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "a Firefox OS 2.1 simulator",
+          "foreignInstall": false,
+          "hasBinaryComponents": false,
+          "installDay": 16330,
+          "name": "Firefox OS 2.1 Simulator",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16673,
+          "userDisabled": false,
+          "version": "2.1.20141223.1-signed"
+        },
+        "masspasswordreset@johnathan.nightingale": {
+          "appDisabled": false,
+          "blocklisted": false,
+          "description": "Sometimes you change a central password that ends up changing 12 others.  This add on helps you rese",
+          "foreignInstall": 0,
+          "hasBinaryComponents": false,
+          "installDay": 15988,
+          "name": "Mass Password Reset",
+          "scope": 1,
+          "signedState": 2,
+          "type": "extension",
+          "updateDay": 16565,
+          "userDisabled": false,
+          "version": "1.05.1-signed"
+        }
+      },
+      "activeExperiment": {},
+      "activeGMPlugins": {
+        "gmp-gmpopenh264": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": "1.4"
+        }
+      },
+      "activePlugins": [
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Version 5.41.0.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/googletalk"
+          ],
+          "name": "Google Talk Plugin",
+          "updateDay": 16520,
+          "version": "5.41.0.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Version 5.41.0.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/o1d"
+          ],
+          "name": "Google Talk Plugin Video Renderer",
+          "updateDay": 16520,
+          "version": "5.41.0.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Provides information about the default web browser",
+          "disabled": false,
+          "mimeTypes": [
+            "application/apple-default-browser"
+          ],
+          "name": "Default Browser Helper",
+          "updateDay": 16633,
+          "version": "600"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in web pages. For more ",
+          "disabled": false,
+          "mimeTypes": [
+            "video/x-msvideo",
+            "audio/mp3",
+            "audio/mpeg3",
+            "video/3gpp2",
+            "audio/x-caf",
+            "audio/mpeg",
+            "video/quicktime",
+            "audio/x-mpeg3",
+            "video/mp4",
+            "application/x-sdp",
+            "audio/wav",
+            "video/avi",
+            "audio/x-ac3",
+            "audio/mp4",
+            "video/x-m4v",
+            "application/sdp",
+            "audio/x-wav",
+            "audio/x-aiff",
+            "video/x-mpeg",
+            "video/3gpp",
+            "video/msvideo",
+            "audio/x-mpeg",
+            "audio/vnd.qcelp",
+            "audio/x-mp3",
+            "application/x-rtsp",
+            "audio/amr",
+            "video/sd-video",
+            "audio/aiff",
+            "video/mpeg",
+            "audio/3gpp2",
+            "audio/aac",
+            "audio/ac3",
+            "audio/x-m4b",
+            "audio/x-m4p",
+            "audio/x-gsm",
+            "application/x-mpeg",
+            "audio/x-aac",
+            "audio/basic",
+            "audio/x-m4a",
+            "audio/3gpp"
+          ],
+          "name": "QuickTime Plug-in 7.7.3",
+          "updateDay": 16638,
+          "version": "7.7.3"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "5.1.40728.0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-silverlight",
+            "application/x-silverlight-2"
+          ],
+          "name": "Silverlight Plug-In",
+          "updateDay": 16644,
+          "version": "5.1.40728.0"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Displays Java applet content, or a placeholder if Java is not installed.",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-java-applet;version=1.4",
+            "application/x-java-applet;version=1.2.1",
+            "application/x-java-applet;jpi-version=1.8.0_60",
+            "application/x-java-applet;version=1.2.2",
+            "application/x-java-applet;version=1.3",
+            "application/x-java-applet;version=1.8",
+            "application/x-java-vm",
+            "application/x-java-applet;version=1.1.1",
+            "application/x-java-applet;version=1.2",
+            "application/x-java-applet;version=1.7",
+            "application/x-java-applet;version=1.4.1",
+            "application/x-java-applet;version=1.1.2",
+            "application/x-java-applet",
+            "application/x-java-applet;deploy=11.60.2",
+            "application/x-java-applet;version=1.1",
+            "application/x-java-applet;version=1.1.3",
+            "application/x-java-applet;version=1.6",
+            "application/x-java-applet;javafx=8.0.60",
+            "application/x-java-applet;version=1.4.2",
+            "application/x-java-applet;version=1.3.1",
+            "application/x-java-applet;version=1.5"
+          ],
+          "name": "Java Applet Plug-in",
+          "updateDay": 16651,
+          "version": "Java 8 Update 60 build 27"
+        },
+        {
+          "blocklisted": false,
+          "clicktoplay": true,
+          "description": "Shockwave Flash 19.0 r0",
+          "disabled": false,
+          "mimeTypes": [
+            "application/x-shockwave-flash",
+            "application/futuresplash"
+          ],
+          "name": "Shockwave Flash",
+          "updateDay": 16725,
+          "version": "19.0.0.226"
+        }
+      ],
+      "persona": null,
+      "theme": {
+        "appDisabled": false,
+        "blocklisted": false,
+        "description": "The default theme.",
+        "foreignInstall": false,
+        "hasBinaryComponents": false,
+        "id": "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+        "installDay": 15937,
+        "name": "Default",
+        "scope": 4,
+        "updateDay": 16742,
+        "userDisabled": false,
+        "version": "45.0"
+      }
+    },
+    "build": {
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "applicationName": "Firefox",
+      "architecture": "x86-64",
+      "architecturesInBinary": "i386-x86_64",
+      "buildId": "20151103030248",
+      "hotfixVersion": "20150225.01",
+      "displayVersion": "45.0b1",
+      "platformVersion": "45.0",
+      "vendor": "Mozilla",
+      "version": "45.0",
+      "xpcomAbi": "x86_64-gcc3"
+    },
+    "experiments": {
+      "test_id123": {
+        "branch": "brunch"
+      }
+    },
+    "partner": {
+      "distributionId": null,
+      "distributionVersion": null,
+      "distributor": null,
+      "distributorChannel": null,
+      "partnerId": null,
+      "partnerNames": []
+    },
+    "profile": {
+      "creationDate": 15987
+    },
+    "settings": {
+      "addonCompatibilityCheckEnabled": true,
+      "attribution": {
+        "source": "google.com",
+        "medium": "organic",
+        "campaign": "(not set)",
+        "content": "(not set)"
+      },
+      "blocklistEnabled": true,
+      "defaultSearchEngine": "google",
+      "defaultSearchEngineData": {
+        "loadPath": "jar:[app]/omni.ja!browser/google.xml",
+        "name": "Google",
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8",
+        "origin": "default"
+      },
+      "defaultPrivateSearchEngine": "random",
+      "defaultPrivateSearchEngineData": {
+        "loadPath": "[other]addEngineWithDetails:random@example.com",
+        "name": "Random",
+        "submissionURL": "https://www.example.com/search?q=",
+        "origin": "default"
+      },
+      "e10sEnabled": true,
+      "e10sCohort": "unknown",
+      "isDefaultBrowser": true,
+      "isInOptoutSample": false,
+      "locale": "en-US",
+      "telemetryEnabled": true,
+      "update": {
+        "autoDownload": true,
+        "channel": "beta",
+        "enabled": true
+      },
+      "userPrefs": {
+        "browser.cache.disk.capacity": 358400,
+        "browser.newtabpage.enhanced": true,
+        "browser.startup.page": 3,
+        "browser.urlbar.suggest.searches": true,
+        "browser.urlbar.userMadeSearchSuggestionsChoice": true,
+        "devtools.chrome.enabled": true
+      }
+    },
+    "system": {
+      "cpu": {
+        "cores": 4,
+        "count": 8,
+        "extensions": [
+          "hasMMX",
+          "hasSSE",
+          "hasSSE2",
+          "hasSSE3",
+          "hasSSSE3",
+          "hasSSE4_1",
+          "hasSSE4_2"
+        ],
+        "family": 6,
+        "l2cacheKB": 256,
+        "l3cacheKB": 6144,
+        "model": 70,
+        "speedMHz": 2800,
+        "stepping": 1,
+        "vendor": "GenuineIntel"
+      },
+      "gfx": {
+        "D2DEnabled": null,
+        "LowEndMachine": false,
+        "DWriteEnabled": null,
+        "adapters": [
+          {
+            "GPUActive": true,
+            "RAM": null,
+            "description": null,
+            "deviceID": "0x6821",
+            "driver": null,
+            "driverDate": null,
+            "driverVersion": null,
+            "subsysID": null,
+            "vendorID": "0x1002"
+          }
+        ],
+        "features": {
+          "compositor": "none"
+        },
+        "monitors": [
+          {
+            "scale": 2,
+            "screenHeight": 900,
+            "screenWidth": 1440
+          }
+        ]
+      },
+      "hdd": {
+        "binary": {
+          "model": null,
+          "revision": null
+        },
+        "profile": {
+          "model": null,
+          "revision": null
+        },
+        "system": {
+          "model": null,
+          "revision": null
+        }
+      },
+      "memoryMB": 16384,
+      "os": {
+        "locale": "en-US",
+        "name": "Darwin",
+        "version": "14.5.0"
+      },
+      "virtualMaxMB": null
+    }
+  },
+  "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",
+  "payload": {
+    "UIMeasurements": [],
+    "addonDetails": {
+      "GMP": {
+        "gmp-eme-adobe": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": null
+        },
+        "gmp-gmpopenh264": {
+          "applyBackgroundUpdates": 1,
+          "userDisabled": false,
+          "version": "1.4"
+        }
+      },
+      "XPI": {
+        "adbhelper@mozilla.org": {
+          "creator": "Mozilla & Android Open Source Project",
+          "location": "app-profile",
+          "name": "ADB Helper",
+          "scan_MS": 3,
+          "scan_items": 23,
+          "shutdown_MS": 6,
+          "startup_MS": 44
+        },
+        "eliteproxyswitcher@my-proxy.com": {
+          "creator": "My-Proxy",
+          "location": "app-profile",
+          "name": "Elite Proxy Switcher",
+          "scan_MS": 0,
+          "scan_items": 1
+        },
+        "firefox-hotfix@mozilla.org": {
+          "creator": "Mozilla",
+          "location": "app-profile",
+          "name": "Firefox Certificate Store Hotfix",
+          "scan_MS": 0
+        },
+        "foxyproxy@eric.h.jung": {
+          "creator": "FoxyProxy, Inc.",
+          "location": "app-profile",
+          "name": "FoxyProxy Standard",
+          "scan_MS": 12,
+          "scan_items": 324
+        },
+        "fxdevtools-adapters@mozilla.org": {
+          "creator": "Mozilla",
+          "location": "app-profile",
+          "name": "Valence",
+          "scan_MS": 6,
+          "scan_items": 48,
+          "shutdown_MS": 13,
+          "startup_MS": 33
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 1.4 Simulator",
+          "scan_MS": 52,
+          "scan_items": 1094,
+          "shutdown_MS": 17,
+          "startup_MS": 33
+        },
+        "fxos_2_0_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 2.0 Simulator",
+          "scan_MS": 0
+        },
+        "fxos_2_1_simulator@mozilla.org": {
+          "creator": "Myk Melez (https://github.com/mykmelez)",
+          "location": "app-profile",
+          "name": "Firefox OS 2.1 Simulator",
+          "scan_MS": 38,
+          "scan_items": 1248,
+          "shutdown_MS": 2,
+          "startup_MS": 30
+        },
+        "hotdish@mozilla.com": {
+          "creator": "Mozilla Hotdish Team",
+          "location": "app-profile",
+          "name": "Hotdish",
+          "scan_MS": 0
+        },
+        "jid0-NgMDcEu2B88AbzZ6ulHodW9sJzA@jetpack": {
+          "creator": "Gregory Koberger",
+          "location": "app-profile",
+          "name": "BugzillaJS",
+          "scan_MS": 0
+        },
+        "masspasswordreset@johnathan.nightingale": {
+          "creator": "Johnathan Nightingale",
+          "location": "app-profile",
+          "name": "Mass Password Reset",
+          "scan_MS": 0,
+          "scan_items": 1
+        },
+        "testpilot@labs.mozilla.com": {
+          "creator": "Mozilla Corporation",
+          "location": "app-profile",
+          "name": "Test Pilot",
+          "scan_MS": 0
+        },
+        "{4d5b56bf-1df3-8cee-2177-2389a677b9a1}": {
+          "creator": "Dave Garrett",
+          "location": "app-profile",
+          "name": "JSM EXPORTED_SYMBOLS Test",
+          "scan_MS": 0
+        },
+        "{972ce4c6-7e08-4474-a285-3208198ce6fd}": {
+          "creator": "Mozilla",
+          "location": "app-global",
+          "modifiedFile": "{972ce4c6-7e08-4474-a285-3208198ce6fd}",
+          "name": "Default",
+          "scan_MS": 0,
+          "scan_items": 4
+        }
+      }
+    },
+    "childPayloads": [
+      {
+        "chromeHangs": {
+          "annotations": [],
+          "durations": [],
+          "firefoxUptime": [],
+          "memoryMap": [],
+          "stacks": [],
+          "systemUptime": []
+        },
+        "log": [],
+        "simpleMeasurements": {
+          "firstLoadURI": 2028,
+          "js": {
+            "customIter": 0,
+            "setProto": 19
+          },
+          "main": 0,
+          "maximalNumberOfConcurrentThreads": 36,
+          "startupInterrupted": 0,
+          "totalTime": 44178,
+          "uptime": 736
+        },
+        "threadHangStats": [
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {}
+            },
+            "hangs": [],
+            "name": ""
+          },
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "0": 0,
+                "1": 15,
+                "3": 0
+              }
+            },
+            "hangs": [],
+            "name": "ImageBridgeChild"
+          },
+          {
+            "activity": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "0": 0,
+                "1": 13,
+                "3": 0
+              }
+            },
+            "hangs": [],
+            "name": "ProcessHangMonitor"
+          }
+        ],
+        "ver": 4,
+        "webrtc": {
+          "IceCandidatesStats": {
+            "loop": {},
+            "webrtc": {}
+          }
+        }
+      }
+    ],
+    "chromeHangs": {
+      "annotations": [],
+      "durations": [],
+      "firefoxUptime": [],
+      "memoryMap": [],
+      "stacks": [],
+      "systemUptime": []
+    },
+    "fileIOReports": {},
+    "histograms": {
+      "A11Y_IATABLE_USAGE_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "A11Y_INSTANTIATED_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "A11Y_ISIMPLEDOM_USAGE_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "BROWSER_IS_USER_DEFAULT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_IS_USER_DEFAULT_ERROR": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_SET_DEFAULT_ALWAYS_CHECK": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "BROWSER_SET_DEFAULT_DIALOG_PROMPT_RAWCOUNT": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          250
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "BR_9_2_1_SUBJECT_ALT_NAMES": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 302,
+          "1": 0
+        }
+      },
+      "BR_9_2_2_SUBJECT_COMMON_NAME": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 301,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 3,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_CLOSEALLSTREAMS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSCACHESERVICE_ONPROFILESHUTDOWN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 2,
+          "1": 0
+        }
+      },
+      "CANVAS_2D_USED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 200,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 200,
+        "values": {
+          "0": 0,
+          "1": 200,
+          "2": 0
+        }
+      },
+      "CERT_CHAIN_KEY_SIZE_STATUS": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 288,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 288,
+        "values": {
+          "0": 0,
+          "1": 288,
+          "2": 0
+        }
+      },
+      "CERT_CHAIN_SIGNATURE_DIGEST_STATUS": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 380,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 692,
+        "values": {
+          "0": 0,
+          "1": 276,
+          "4": 26,
+          "5": 0
+        }
+      },
+      "CERT_OCSP_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "CERT_OCSP_REQUIRED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "CERT_PINNING_MOZ_RESULTS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 23,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 23,
+        "values": {
+          "0": 0,
+          "1": 23,
+          "2": 0
+        }
+      },
+      "CERT_PINNING_MOZ_RESULTS_BY_HOST": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 341,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4403,
+        "values": {
+          "13": 26,
+          "14": 0,
+          "2": 0,
+          "3": 1
+        }
+      },
+      "CERT_PINNING_MOZ_TEST_RESULTS_BY_HOST": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 30,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 450,
+        "values": {
+          "14": 0,
+          "15": 2,
+          "16": 0
+        }
+      },
+      "CERT_PINNING_RESULTS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 153,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 153,
+        "values": {
+          "0": 0,
+          "1": 153,
+          "2": 0
+        }
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_CANCELED_TIME": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_RESULT": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 29,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29,
+        "values": {
+          "0": 0,
+          "1": 29,
+          "2": 0
+        }
+      },
+      "CERT_VALIDATION_HTTP_REQUEST_SUCCEEDED_TIME": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 3438,
+        "values": {
+          "1092": 1,
+          "110": 1,
+          "1142": 0,
+          "12": 1,
+          "15": 1,
+          "16": 1,
+          "17": 2,
+          "18": 1,
+          "189": 1,
+          "27": 1,
+          "29": 1,
+          "41": 2,
+          "425": 1,
+          "445": 1,
+          "5": 0,
+          "55": 1,
+          "6": 2,
+          "61": 3,
+          "64": 1,
+          "67": 1,
+          "70": 2,
+          "73": 2,
+          "84": 1,
+          "96": 1
+        }
+      },
+      "CERT_VALIDATION_SUCCESS_BY_CA": {
+        "bucket_count": 257,
+        "histogram_type": 1,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 11834,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 692790,
+        "values": {
+          "106": 8,
+          "123": 1,
+          "154": 2,
+          "155": 4,
+          "163": 2,
+          "164": 0,
+          "20": 155,
+          "49": 67,
+          "5": 0,
+          "50": 50,
+          "6": 1,
+          "60": 12
+        }
+      },
+      "CHARSET_OVERRIDE_USED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CHECK_ADDONS_MODIFIED_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "COMPONENTS_SHIM_ACCESSED_BY_CONTENT": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "COMPOSITE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 106036,
+        "values": {
+          "0": 15572,
+          "1": 48180,
+          "10": 84,
+          "11": 116,
+          "12": 133,
+          "14": 323,
+          "152": 1,
+          "16": 712,
+          "171": 0,
+          "18": 57,
+          "2": 8211,
+          "20": 43,
+          "23": 20,
+          "26": 19,
+          "29": 13,
+          "3": 913,
+          "33": 15,
+          "37": 24,
+          "4": 547,
+          "42": 7,
+          "47": 3,
+          "5": 816,
+          "53": 6,
+          "6": 428,
+          "60": 2,
+          "67": 3,
+          "7": 238,
+          "75": 1,
+          "8": 118,
+          "84": 2,
+          "9": 81,
+          "95": 1
+        }
+      },
+      "CONTENT_DOCUMENTS_DESTROYED": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "COOKIE_SCHEME_SECURITY": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 2055,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5919,
+        "values": {
+          "0": 21,
+          "1": 123,
+          "3": 644,
+          "4": 0
+        }
+      },
+      "CRASH_STORE_COMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "CYCLE_COLLECTOR": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 90970,
+        "values": {
+          "114": 87,
+          "135": 126,
+          "160": 63,
+          "1782": 3,
+          "190": 88,
+          "2117": 1,
+          "226": 3,
+          "24": 0,
+          "268": 8,
+          "29": 1,
+          "318": 2,
+          "34": 8,
+          "378": 1,
+          "40": 4,
+          "4222": 1,
+          "449": 3,
+          "48": 1,
+          "5017": 0,
+          "533": 1,
+          "68": 18,
+          "752": 3,
+          "894": 4,
+          "96": 57
+        }
+      },
+      "CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 217,
+        "values": {
+          "0": 15669,
+          "1": 77,
+          "10": 1,
+          "12": 1,
+          "14": 0,
+          "2": 30,
+          "3": 9,
+          "4": 5,
+          "5": 2
+        }
+      },
+      "CYCLE_COLLECTOR_COLLECTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 517386,
+        "values": {
+          "0": 116,
+          "10": 17,
+          "10589": 6,
+          "1122": 7,
+          "119": 12,
+          "13": 10,
+          "13255": 2,
+          "1404": 13,
+          "149": 16,
+          "16": 13,
+          "16592": 2,
+          "1757": 6,
+          "186": 10,
+          "2": 11,
+          "20": 8,
+          "2199": 10,
+          "233": 13,
+          "25": 9,
+          "2753": 6,
+          "292": 4,
+          "31": 14,
+          "32541": 1,
+          "3446": 11,
+          "365": 11,
+          "39": 5,
+          "4": 9,
+          "40733": 0,
+          "4313": 7,
+          "457": 6,
+          "49": 4,
+          "5399": 8,
+          "572": 26,
+          "6": 5,
+          "61": 25,
+          "6758": 5,
+          "716": 7,
+          "76": 19,
+          "8": 5,
+          "8459": 4,
+          "896": 8,
+          "95": 12
+        }
+      },
+      "CYCLE_COLLECTOR_FINISH_IGC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_FULL": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 90975,
+        "values": {
+          "114": 87,
+          "135": 126,
+          "160": 63,
+          "1782": 3,
+          "190": 88,
+          "2117": 1,
+          "226": 3,
+          "24": 0,
+          "268": 8,
+          "29": 1,
+          "318": 2,
+          "34": 8,
+          "378": 1,
+          "40": 4,
+          "4222": 1,
+          "449": 3,
+          "48": 1,
+          "5017": 0,
+          "533": 1,
+          "68": 18,
+          "752": 3,
+          "894": 4,
+          "96": 57
+        }
+      },
+      "CYCLE_COLLECTOR_MAX_PAUSE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 2611,
+        "values": {
+          "10": 6,
+          "12": 1,
+          "14": 5,
+          "17": 2,
+          "24": 1,
+          "29": 0,
+          "3": 0,
+          "4": 4,
+          "5": 419,
+          "6": 35,
+          "7": 4,
+          "8": 6
+        }
+      },
+      "CYCLE_COLLECTOR_NEED_GC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_OOM": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_SYNC_SKIPPABLE": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 483,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_TIME_BETWEEN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          120
+        ],
+        "sum": 38150,
+        "values": {
+          "1": 0,
+          "10": 23,
+          "100": 1,
+          "106": 3,
+          "11": 11,
+          "113": 4,
+          "12": 8,
+          "120": 86,
+          "13": 5,
+          "14": 4,
+          "15": 1,
+          "16": 3,
+          "17": 2,
+          "18": 8,
+          "19": 2,
+          "2": 1,
+          "20": 4,
+          "21": 5,
+          "22": 4,
+          "23": 13,
+          "25": 28,
+          "27": 14,
+          "29": 10,
+          "3": 1,
+          "31": 5,
+          "33": 5,
+          "35": 5,
+          "37": 5,
+          "39": 2,
+          "42": 7,
+          "45": 4,
+          "48": 3,
+          "5": 4,
+          "51": 4,
+          "54": 5,
+          "57": 2,
+          "6": 161,
+          "61": 1,
+          "65": 5,
+          "69": 3,
+          "7": 5,
+          "73": 2,
+          "78": 4,
+          "8": 3,
+          "83": 1,
+          "88": 1,
+          "9": 3,
+          "94": 2
+        }
+      },
+      "CYCLE_COLLECTOR_VISITED_GCED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 6378709,
+        "values": {
+          "11508": 58,
+          "14789": 227,
+          "19005": 3,
+          "1988": 0,
+          "24423": 9,
+          "2555": 3,
+          "3283": 5,
+          "40334": 1,
+          "4219": 10,
+          "51833": 0,
+          "5422": 18,
+          "6968": 99,
+          "8955": 50
+        }
+      },
+      "CYCLE_COLLECTOR_VISITED_REF_COUNTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 1407559,
+        "values": {
+          "11508": 1,
+          "1204": 8,
+          "14789": 0,
+          "1547": 86,
+          "1988": 127,
+          "2555": 155,
+          "3283": 56,
+          "4219": 20,
+          "5422": 18,
+          "567": 0,
+          "6968": 8,
+          "729": 1,
+          "8955": 2,
+          "937": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 808,
+        "values": {
+          "0": 19628,
+          "1": 241,
+          "14": 1,
+          "2": 16,
+          "20": 1,
+          "24": 3,
+          "29": 4,
+          "3": 3,
+          "34": 8,
+          "40": 0,
+          "7": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_COLLECTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 255052,
+        "values": {
+          "0": 19434,
+          "10": 24,
+          "1122": 0,
+          "13": 111,
+          "16": 3,
+          "20": 5,
+          "25": 1,
+          "292": 1,
+          "31": 1,
+          "49": 5,
+          "5": 11,
+          "6": 10,
+          "61": 4,
+          "716": 136,
+          "76": 2,
+          "8": 18,
+          "896": 139,
+          "95": 1
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_OOM": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_VISITED_GCED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 1476345,
+        "values": {
+          "10": 24,
+          "1204": 0,
+          "126": 1,
+          "162": 6610,
+          "17": 4,
+          "2": 0,
+          "28": 5,
+          "3": 12969,
+          "36": 6,
+          "46": 1,
+          "6": 11,
+          "729": 187,
+          "937": 88
+        }
+      },
+      "CYCLE_COLLECTOR_WORKER_VISITED_REF_COUNTED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 22170,
+        "values": {
+          "0": 0,
+          "1": 19426,
+          "10": 5,
+          "126": 1,
+          "13": 1,
+          "162": 0,
+          "2": 8,
+          "28": 5,
+          "36": 6,
+          "4": 314,
+          "46": 1,
+          "6": 137,
+          "8": 2
+        }
+      },
+      "DATA_STORAGE_ENTRIES": {
+        "bucket_count": 16,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1024
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "DECODER_INSTANTIATED_IBM866": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_ISO2022JP": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_ISO_8859_5": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_KOI8R": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_KOI8U": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACARABIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCROATIAN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACCYRILLIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACDEVANAGARI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACFARSI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGREEK": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGUJARATI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACGURMUKHI": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACHEBREW": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACICELANDIC": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACROMANIAN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DECODER_INSTANTIATED_MACTURKISH": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEFERRED_FINALIZE_ASYNC": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 272,
+        "values": {
+          "0": 191,
+          "1": 37,
+          "2": 23,
+          "3": 15,
+          "4": 11,
+          "5": 20,
+          "6": 0
+        }
+      },
+      "DEVTOOLS_ABOUTDEBUGGING_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_ANIMATIONINSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_BROWSERCONSOLE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_CANVASDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_COMPUTEDVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_CUSTOM_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_DEVELOPERTOOLBAR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_FONTINSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_INSPECTOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSBROWSERDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSDEBUGGER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_JSPROFILER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_LAYOUTVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_MENU_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_NETMONITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_OPTIONS_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PAINTFLASHING_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PERFTOOLS_RECORDING_EXPORT_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PERFTOOLS_RECORDING_IMPORT_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_PICKER_EYEDROPPER_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_RESPONSIVE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_RULEVIEW_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_SCRATCHPAD_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_SHADEREDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_STORAGE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_STYLEEDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TABS_OPEN_AVERAGE_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 46,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2116,
+        "values": {
+          "45": 0,
+          "46": 1,
+          "47": 0
+        }
+      },
+      "DEVTOOLS_TABS_OPEN_PEAK_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 72,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5184,
+        "values": {
+          "71": 0,
+          "72": 1,
+          "73": 0
+        }
+      },
+      "DEVTOOLS_TABS_PINNED_AVERAGE_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TABS_PINNED_PEAK_LINEAR": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TILT_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_TOOLBOX_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBAUDIOEDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBCONSOLE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_IMPORT_PROJECT_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_NEW_PROJECT_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_PROJECT_EDITOR_OPENED_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DEVTOOLS_WEBIDE_PROJECT_EDITOR_SAVE_PER_USER_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "DISPLAY_SCALING_OSX": {
+        "bucket_count": 100,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "DNS_BLACKLIST_COUNT": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          21
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 64,
+        "values": {
+          "0": 353,
+          "1": 4,
+          "2": 2,
+          "3": 4,
+          "4": 1,
+          "5": 0
+        }
+      },
+      "DNS_FAILED_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 434,
+        "values": {
+          "0": 2677,
+          "1": 95,
+          "118": 1,
+          "14": 1,
+          "146": 0,
+          "17": 2,
+          "2": 17,
+          "21": 1,
+          "3": 12,
+          "32": 1,
+          "4": 6,
+          "6": 1,
+          "7": 1
+        }
+      },
+      "DNS_LOOKUP_METHOD2": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 36255,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 166313,
+        "values": {
+          "0": 0,
+          "1": 7521,
+          "2": 1735,
+          "4": 12,
+          "6": 4142,
+          "7": 52,
+          "8": 0
+        }
+      },
+      "DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 23527,
+        "values": {
+          "0": 22,
+          "1": 1,
+          "11": 8,
+          "118": 2,
+          "14": 2,
+          "17": 4,
+          "1929": 1,
+          "2": 3,
+          "21": 33,
+          "2391": 0,
+          "26": 4,
+          "278": 4,
+          "3": 18,
+          "32": 9,
+          "345": 27,
+          "4": 9,
+          "40": 8,
+          "428": 2,
+          "5": 4,
+          "50": 6,
+          "531": 6,
+          "6": 4,
+          "62": 9,
+          "658": 2,
+          "7": 10,
+          "77": 1,
+          "9": 20,
+          "95": 3
+        }
+      },
+      "DNS_RENEWAL_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 178252,
+        "values": {
+          "0": 1110,
+          "1": 225,
+          "1012": 2,
+          "11": 18,
+          "118": 2,
+          "1255": 0,
+          "14": 16,
+          "146": 2,
+          "17": 62,
+          "181": 2,
+          "2": 85,
+          "21": 38,
+          "224": 8,
+          "26": 19,
+          "278": 114,
+          "3": 286,
+          "32": 110,
+          "345": 279,
+          "4": 194,
+          "40": 30,
+          "428": 9,
+          "5": 41,
+          "50": 23,
+          "531": 3,
+          "6": 71,
+          "62": 21,
+          "658": 1,
+          "7": 38,
+          "77": 12,
+          "816": 2,
+          "9": 14,
+          "95": 3
+        }
+      },
+      "DNT_USAGE": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 2,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "3": 0
+        }
+      },
+      "E10S_AUTOSTART": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_AUTOSTART_STATUS": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_BLOCKED_FROM_RUNNING": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_STILL_ACCEPTED_FROM_PROMPT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "E10S_WINDOW": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 4,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4,
+        "values": {
+          "0": 0,
+          "1": 4,
+          "2": 0
+        }
+      },
+      "ENABLE_PRIVILEGE_EVER_CALLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "FIND_PLUGINS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FONT_CACHE_HIT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 156,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 156,
+        "values": {
+          "0": 26,
+          "1": 156,
+          "2": 0
+        }
+      },
+      "FORGET_SKIPPABLE_MAX": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1028,
+        "values": {
+          "0": 50,
+          "1": 110,
+          "10": 1,
+          "12": 0,
+          "2": 102,
+          "3": 192,
+          "4": 21,
+          "5": 2,
+          "6": 2,
+          "7": 2,
+          "8": 1
+        }
+      },
+      "FXA_CONFIGURED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "FX_BOOKMARKS_TOOLBAR_INIT_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 34,
+        "values": {
+          "0": 4,
+          "50": 0
+        }
+      },
+      "FX_NEW_WINDOW_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1156,
+        "values": {
+          "103": 0,
+          "171": 1,
+          "284": 3,
+          "472": 0
+        }
+      },
+      "FX_PAGE_LOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 71344,
+        "values": {
+          "1": 0,
+          "10000": 1,
+          "103": 2,
+          "13": 1,
+          "1306": 10,
+          "171": 3,
+          "2": 10,
+          "2172": 4,
+          "22": 5,
+          "284": 4,
+          "3613": 3,
+          "472": 9,
+          "62": 1,
+          "785": 11
+        }
+      },
+      "FX_REFRESH_DRIVER_CHROME_FRAME_DELAY_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 117293,
+        "values": {
+          "0": 42239,
+          "1": 34401,
+          "10": 541,
+          "114": 1,
+          "12": 552,
+          "135": 2,
+          "14": 915,
+          "160": 4,
+          "17": 398,
+          "190": 4,
+          "2": 426,
+          "20": 122,
+          "24": 97,
+          "268": 1,
+          "29": 64,
+          "3": 323,
+          "318": 4,
+          "34": 59,
+          "378": 0,
+          "4": 313,
+          "40": 67,
+          "48": 72,
+          "5": 327,
+          "57": 94,
+          "6": 325,
+          "68": 60,
+          "7": 243,
+          "8": 544,
+          "81": 55,
+          "96": 21
+        }
+      },
+      "FX_SESSION_RESTORE_ALL_FILES_CORRUPT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_COLLECT_ALL_WINDOWS_DATA_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1260,
+        "values": {
+          "0": 2,
+          "1": 82,
+          "14": 1,
+          "4": 192,
+          "50": 0
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_COOKIES_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 4359,
+        "values": {
+          "1": 0,
+          "14": 235,
+          "180": 0,
+          "4": 41,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_DATA_LONGEST_OP_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 5836,
+        "values": {
+          "14": 276,
+          "180": 0,
+          "4": 0,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_COLLECT_DATA_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 5845,
+        "values": {
+          "14": 276,
+          "180": 0,
+          "4": 0,
+          "50": 1
+        }
+      },
+      "FX_SESSION_RESTORE_CONTENT_COLLECT_DATA_LONGEST_OP_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 3232,
+        "values": {
+          "0": 197,
+          "1": 386,
+          "14": 0,
+          "4": 471
+        }
+      },
+      "FX_SESSION_RESTORE_CORRUPT_FILE": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_FILE_SIZE_BYTES": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          50000000
+        ],
+        "sum": 110907314,
+        "values": {
+          "168359": 0,
+          "316945": 277,
+          "596667": 0
+        }
+      },
+      "FX_SESSION_RESTORE_READ_FILE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_RESTORE_WINDOW_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_STARTUP_INIT_SESSION_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_STARTUP_ONLOAD_INITIAL_WINDOW_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "FX_SESSION_RESTORE_WRITE_FILE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 962,
+        "values": {
+          "0": 4,
+          "1": 171,
+          "21": 9,
+          "3": 83,
+          "57": 0,
+          "8": 10
+        }
+      },
+      "FX_TAB_ANIM_ANY_FRAME_INTERVAL_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          7,
+          500
+        ],
+        "sum": 379,
+        "values": {
+          "15": 0,
+          "16": 6,
+          "17": 6,
+          "19": 1,
+          "23": 1,
+          "29": 3,
+          "42": 1,
+          "46": 0
+        }
+      },
+      "FX_TAB_CLICK_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 153,
+        "values": {
+          "13": 0,
+          "4": 0,
+          "6": 9,
+          "9": 9
+        }
+      },
+      "FX_TAB_SWITCH_SPINNER_VISIBLE_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 296,
+        "values": {
+          "165": 0,
+          "237": 1,
+          "340": 0
+        }
+      },
+      "FX_TAB_SWITCH_TOTAL_E10S_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 8085,
+        "values": {
+          "1000": 0,
+          "115": 8,
+          "165": 3,
+          "19": 5,
+          "27": 9,
+          "39": 13,
+          "4": 0,
+          "56": 23,
+          "6": 1,
+          "698": 1,
+          "80": 34,
+          "9": 3
+        }
+      },
+      "FX_TAB_SWITCH_UPDATE_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 733,
+        "values": {
+          "13": 1,
+          "19": 0,
+          "3": 0,
+          "4": 3,
+          "6": 81,
+          "9": 15
+        }
+      },
+      "FX_THUMBNAILS_CAPTURE_TIME_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 5350,
+        "values": {
+          "129": 1,
+          "13": 0,
+          "203": 1,
+          "21": 8,
+          "319": 2,
+          "33": 53,
+          "500": 1,
+          "52": 9,
+          "82": 5
+        }
+      },
+      "FX_THUMBNAILS_STORE_TIME_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 144,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 10,
+          "3": 11,
+          "5": 16,
+          "8": 0
+        }
+      },
+      "FX_TOTAL_TOP_VISITS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 67,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 67,
+        "values": {
+          "0": 0,
+          "1": 67,
+          "2": 0
+        }
+      },
+      "GC_ANIMATION_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 4980,
+        "values": {
+          "0": 2,
+          "10": 131,
+          "12": 109,
+          "14": 98,
+          "17": 23,
+          "2": 2,
+          "20": 8,
+          "24": 5,
+          "29": 1,
+          "3": 3,
+          "34": 1,
+          "4": 1,
+          "40": 0,
+          "5": 2,
+          "7": 2,
+          "8": 1
+        }
+      },
+      "GC_BUDGET_MS": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 43030,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1604100,
+        "values": {
+          "0": 0,
+          "1": 389,
+          "13": 1,
+          "38": 978,
+          "51": 0
+        }
+      },
+      "GC_INCREMENTAL_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 278,
+          "1": 0
+        }
+      },
+      "GC_IS_COMPARTMENTAL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6,
+        "values": {
+          "0": 272,
+          "1": 6,
+          "2": 0
+        }
+      },
+      "GC_MARK_GRAY_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 1309,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6535,
+        "values": {
+          "0": 0,
+          "1": 121,
+          "13": 0,
+          "5": 154,
+          "9": 3
+        }
+      },
+      "GC_MARK_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 21834,
+        "values": {
+          "114": 2,
+          "135": 1,
+          "160": 0,
+          "40": 0,
+          "48": 4,
+          "57": 30,
+          "68": 147,
+          "81": 85,
+          "96": 9
+        }
+      },
+      "GC_MARK_ROOTS_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 1728,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14746,
+        "values": {
+          "0": 0,
+          "1": 150,
+          "13": 24,
+          "18": 5,
+          "22": 0,
+          "5": 70,
+          "9": 29
+        }
+      },
+      "GC_MAX_PAUSE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 11687,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 514373,
+        "values": {
+          "0": 0,
+          "1": 5,
+          "105": 1,
+          "126": 1,
+          "147": 0,
+          "22": 218,
+          "43": 50,
+          "63": 3
+        }
+      },
+      "GC_MINOR_REASON": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 30538,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1106536,
+        "values": {
+          "0": 1,
+          "1": 6,
+          "10": 13,
+          "11": 25,
+          "12": 665,
+          "14": 5,
+          "36": 159,
+          "42": 2,
+          "47": 141,
+          "48": 87,
+          "52": 105,
+          "53": 0,
+          "6": 1
+        }
+      },
+      "GC_MINOR_REASON_LONG": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 15622,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 492458,
+        "values": {
+          "0": 1,
+          "1": 2,
+          "10": 2,
+          "11": 10,
+          "12": 541,
+          "14": 4,
+          "36": 76,
+          "42": 2,
+          "47": 30,
+          "48": 5,
+          "52": 86,
+          "53": 0
+        }
+      },
+      "GC_MINOR_US": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1731016,
+        "values": {
+          "1026": 126,
+          "114": 0,
+          "1168": 110,
+          "12092": 1,
+          "130": 1,
+          "1330": 108,
+          "148": 1,
+          "1514": 85,
+          "168": 9,
+          "1724": 75,
+          "191": 4,
+          "1963": 61,
+          "217": 17,
+          "2235": 55,
+          "247": 11,
+          "2545": 41,
+          "26357": 1,
+          "281": 10,
+          "2898": 32,
+          "320": 16,
+          "3300": 13,
+          "34174": 1,
+          "364": 16,
+          "3758": 8,
+          "38913": 0,
+          "414": 25,
+          "4279": 5,
+          "471": 37,
+          "4872": 6,
+          "536": 34,
+          "5548": 4,
+          "610": 62,
+          "6317": 1,
+          "695": 62,
+          "7193": 1,
+          "791": 78,
+          "901": 93
+        }
+      },
+      "GC_MMU_50": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 4532,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 87730,
+        "values": {
+          "0": 29,
+          "1": 7,
+          "12": 11,
+          "18": 207,
+          "23": 3,
+          "29": 3,
+          "34": 2,
+          "45": 1,
+          "51": 0,
+          "7": 15
+        }
+      },
+      "GC_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 36722,
+        "values": {
+          "114": 113,
+          "135": 34,
+          "160": 36,
+          "190": 11,
+          "226": 4,
+          "268": 1,
+          "318": 0,
+          "68": 0,
+          "81": 4,
+          "96": 75
+        }
+      },
+      "GC_NON_INCREMENTAL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 2,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2,
+        "values": {
+          "0": 276,
+          "1": 2,
+          "2": 0
+        }
+      },
+      "GC_REASON_2": {
+        "bucket_count": 101,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 62692,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2912984,
+        "values": {
+          "0": 1,
+          "1": 6,
+          "14": 5,
+          "36": 159,
+          "42": 2,
+          "47": 978,
+          "48": 112,
+          "52": 105,
+          "53": 0,
+          "6": 1
+        }
+      },
+      "GC_RESET": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1369,
+          "1": 0
+        }
+      },
+      "GC_SCC_SWEEP_MAX_PAUSE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 1206,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 10800,
+        "values": {
+          "0": 0,
+          "1": 252,
+          "11": 22,
+          "22": 3,
+          "32": 1,
+          "43": 0
+        }
+      },
+      "GC_SCC_SWEEP_TOTAL_MS": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 1548,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14010,
+        "values": {
+          "0": 0,
+          "1": 246,
+          "11": 28,
+          "22": 3,
+          "32": 1,
+          "43": 0
+        }
+      },
+      "GC_SLICE_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 36329,
+        "values": {
+          "0": 5,
+          "1": 27,
+          "10": 140,
+          "114": 1,
+          "12": 122,
+          "135": 0,
+          "14": 109,
+          "17": 36,
+          "2": 20,
+          "20": 67,
+          "24": 120,
+          "29": 178,
+          "3": 9,
+          "34": 111,
+          "4": 4,
+          "40": 366,
+          "48": 25,
+          "5": 4,
+          "57": 4,
+          "6": 3,
+          "68": 3,
+          "7": 5,
+          "8": 9,
+          "96": 1
+        }
+      },
+      "GC_SLOW_PHASE": {
+        "bucket_count": 76,
+        "histogram_type": 1,
+        "range": [
+          1,
+          75
+        ],
+        "sum": 120,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 936,
+        "values": {
+          "10": 0,
+          "5": 0,
+          "6": 8,
+          "9": 8
+        }
+      },
+      "GC_SWEEP_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 8788,
+        "values": {
+          "14": 0,
+          "17": 1,
+          "20": 29,
+          "24": 83,
+          "29": 93,
+          "34": 35,
+          "40": 17,
+          "48": 14,
+          "57": 6,
+          "68": 0
+        }
+      },
+      "GEOLOCATION_ERROR": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "GHOST_WINDOWS": {
+        "bucket_count": 32,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 0,
+        "values": {
+          "0": 166,
+          "1": 0
+        }
+      },
+      "GRADIENT_DURATION": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          50000000
+        ],
+        "sum": 1153732,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "1056": 5,
+          "149": 737,
+          "21": 6871,
+          "2810": 0,
+          "3": 310,
+          "397": 852,
+          "56": 1454,
+          "8": 7602
+        }
+      },
+      "GRADIENT_RETENTION_TIME": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_COLLECT_CONSTANT_DATA_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 85,
+        "values": {
+          "19": 3,
+          "41": 0,
+          "9": 0
+        }
+      },
+      "HEALTHREPORT_COLLECT_DAILY_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 102,
+        "values": {
+          "193": 0,
+          "41": 0,
+          "89": 1
+        }
+      },
+      "HEALTHREPORT_DB_OPEN_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_GENERATE_JSON_PAYLOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 134,
+        "values": {
+          "114": 1,
+          "199": 0,
+          "65": 0
+        }
+      },
+      "HEALTHREPORT_INIT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "HEALTHREPORT_JSON_PAYLOAD_SERIALIZE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 2,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "HEALTHREPORT_PAYLOAD_COMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 1,
+        "range": [
+          1,
+          2000000
+        ],
+        "sum": 8013,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 64208169,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "10001": 0
+        }
+      },
+      "HEALTHREPORT_PAYLOAD_UNCOMPRESSED_BYTES": {
+        "bucket_count": 202,
+        "histogram_type": 1,
+        "range": [
+          1,
+          2000000
+        ],
+        "sum": 138621,
+        "sum_squares_hi": 4,
+        "sum_squares_lo": 2035912457,
+        "values": {
+          "120001": 0,
+          "130001": 1,
+          "140001": 0
+        }
+      },
+      "HEALTHREPORT_POST_COLLECT_CHECKPOINT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 13,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "19": 0,
+          "2": 1,
+          "9": 1
+        }
+      },
+      "HEALTHREPORT_SHUTDOWN_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          20000
+        ],
+        "sum": 161,
+        "values": {
+          "193": 0,
+          "41": 0,
+          "89": 1
+        }
+      },
+      "HEALTHREPORT_UPLOAD_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 60,
+        "values": {
+          "24": 0,
+          "44": 1,
+          "80": 0
+        }
+      },
+      "HTML_FOREGROUND_REFLOW_MS_2": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 65,
+        "values": {
+          "0": 91,
+          "1": 1,
+          "2": 1,
+          "37": 1,
+          "62": 0,
+          "8": 1
+        }
+      },
+      "HTTPCONNMGR_TOTAL_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1244,
+        "values": {
+          "0": 0,
+          "1": 1244,
+          "2": 0
+        }
+      },
+      "HTTPCONNMGR_UNUSED_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 174,
+        "values": {
+          "0": 0,
+          "1": 174,
+          "2": 0
+        }
+      },
+      "HTTPCONNMGR_USED_SPECULATIVE_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1070,
+        "values": {
+          "0": 0,
+          "1": 1070,
+          "2": 0
+        }
+      },
+      "HTTP_AUTH_DIALOG_STATS": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 2,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "HTTP_CACHE_DISPOSITION_2_V2": {
+        "bucket_count": 6,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5
+        ],
+        "sum": 25613,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 97767,
+        "values": {
+          "0": 0,
+          "1": 1309,
+          "2": 41,
+          "3": 198,
+          "4": 5907,
+          "5": 0
+        }
+      },
+      "HTTP_CACHE_ENTRY_ALIVE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          7200000
+        ],
+        "sum": 46151811302,
+        "values": {
+          "1066088": 118,
+          "114814": 24,
+          "12365": 40,
+          "1332": 10,
+          "1465715": 26,
+          "157853": 35,
+          "17000": 64,
+          "1831": 45,
+          "2015144": 135,
+          "217025": 63,
+          "23373": 51,
+          "2517": 21,
+          "271": 0,
+          "2770529": 105,
+          "298378": 13,
+          "32134": 18,
+          "3461": 22,
+          "373": 4,
+          "3809073": 177,
+          "410226": 27,
+          "44180": 51,
+          "4758": 50,
+          "513": 22,
+          "5236919": 72,
+          "564001": 150,
+          "60741": 106,
+          "6542": 6,
+          "705": 67,
+          "7200000": 1502,
+          "775419": 37,
+          "83510": 75,
+          "8994": 14,
+          "969": 57
+        }
+      },
+      "HTTP_CACHE_ENTRY_RELOAD_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          900000
+        ],
+        "sum": 35104963,
+        "values": {
+          "101437": 14,
+          "110": 1,
+          "11433": 6,
+          "133261": 8,
+          "15020": 12,
+          "1693": 4,
+          "175069": 6,
+          "191": 1,
+          "19732": 5,
+          "2224": 8,
+          "229993": 15,
+          "25922": 4,
+          "2922": 8,
+          "302148": 3,
+          "330": 3,
+          "34054": 2,
+          "3839": 11,
+          "396941": 5,
+          "44738": 9,
+          "5043": 7,
+          "521473": 5,
+          "569": 1,
+          "58774": 7,
+          "64": 0,
+          "6625": 2,
+          "685073": 22,
+          "747": 2,
+          "77213": 6,
+          "84": 2,
+          "8703": 20,
+          "900000": 2,
+          "981": 3
+        }
+      },
+      "HTTP_CACHE_ENTRY_REUSE_COUNT": {
+        "bucket_count": 19,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 3830,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 13966,
+        "values": {
+          "0": 119,
+          "1": 2875,
+          "10": 3,
+          "11": 1,
+          "13": 1,
+          "18": 2,
+          "2": 116,
+          "20": 11,
+          "3": 32,
+          "4": 14,
+          "5": 27,
+          "7": 2,
+          "8": 2,
+          "9": 2
+        }
+      },
+      "HTTP_CACHE_MISS_HALFLIFE_EXPERIMENT_2": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 5907,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5907,
+        "values": {
+          "0": 0,
+          "1": 5907,
+          "2": 0
+        }
+      },
+      "HTTP_CONTENT_ENCODING": {
+        "bucket_count": 7,
+        "histogram_type": 1,
+        "range": [
+          1,
+          6
+        ],
+        "sum": 97,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 97,
+        "values": {
+          "0": 0,
+          "1": 97,
+          "2": 0
+        }
+      },
+      "HTTP_KBREAD_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 109871,
+        "values": {
+          "0": 90,
+          "1": 14,
+          "10": 5,
+          "106": 6,
+          "12": 6,
+          "123": 1,
+          "14": 4,
+          "142": 4,
+          "16": 7,
+          "164": 3,
+          "19": 4,
+          "190": 1,
+          "2": 11,
+          "22": 10,
+          "220": 1,
+          "25": 5,
+          "29": 5,
+          "3": 5,
+          "3000": 1,
+          "34": 1,
+          "340": 2,
+          "39": 1,
+          "4": 2,
+          "45": 2,
+          "5": 3,
+          "52": 4,
+          "525": 1,
+          "6": 2,
+          "60": 3,
+          "607": 1,
+          "69": 4,
+          "7": 2,
+          "8": 2,
+          "80": 6,
+          "9": 2,
+          "92": 3
+        }
+      },
+      "HTTP_OFFLINE_CACHE_DOCUMENT_LOAD": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 99,
+          "1": 0
+        }
+      },
+      "HTTP_PAGELOAD_IS_SSL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 76,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 76,
+        "values": {
+          "0": 14,
+          "1": 76,
+          "2": 0
+        }
+      },
+      "HTTP_PAGE_COMPLETE_LOAD_NET_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 68,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_COMPLETE_LOAD_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 68,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_DNS_ISSUE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 35,
+        "values": {
+          "29": 0,
+          "35": 1,
+          "43": 0
+        }
+      },
+      "HTTP_PAGE_DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 3,
+        "values": {
+          "2": 0,
+          "3": 1,
+          "4": 0
+        }
+      },
+      "HTTP_PAGE_FIRST_SENT_TO_LAST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 6,
+        "values": {
+          "5": 0,
+          "6": 1,
+          "7": 0
+        }
+      },
+      "HTTP_PAGE_OPEN_TO_FIRST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 66,
+        "values": {
+          "52": 0,
+          "63": 1,
+          "77": 0
+        }
+      },
+      "HTTP_PAGE_OPEN_TO_FIRST_SENT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 61,
+        "values": {
+          "43": 0,
+          "52": 1,
+          "63": 0
+        }
+      },
+      "HTTP_PROXY_TYPE": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 6808,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6808,
+        "values": {
+          "0": 0,
+          "1": 6808,
+          "2": 0
+        }
+      },
+      "HTTP_REQUEST_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 1319,
+        "values": {
+          "0": 728,
+          "1": 740,
+          "10": 2,
+          "11": 1,
+          "12": 2,
+          "14": 1,
+          "16": 1,
+          "18": 1,
+          "2": 32,
+          "20": 3,
+          "23": 3,
+          "29": 1,
+          "3": 31,
+          "33": 0,
+          "4": 9,
+          "5": 6,
+          "6": 4,
+          "7": 3,
+          "8": 2,
+          "9": 3
+        }
+      },
+      "HTTP_REQUEST_PER_PAGE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 15,
+        "values": {
+          "12": 0,
+          "14": 1,
+          "16": 0
+        }
+      },
+      "HTTP_REQUEST_PER_PAGE_FROM_CACHE": {
+        "bucket_count": 102,
+        "histogram_type": 1,
+        "range": [
+          1,
+          101
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "HTTP_RESPONSE_VERSION": {
+        "bucket_count": 49,
+        "histogram_type": 1,
+        "range": [
+          1,
+          48
+        ],
+        "sum": 116386,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2255846,
+        "values": {
+          "10": 0,
+          "11": 726,
+          "20": 5420,
+          "21": 0
+        }
+      },
+      "HTTP_SAW_QUIC_ALT_PROTOCOL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 5415,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5415,
+        "values": {
+          "0": 731,
+          "1": 5415,
+          "2": 0
+        }
+      },
+      "HTTP_SCHEME_UPGRADE": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 187,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 205,
+        "values": {
+          "0": 7942,
+          "1": 178,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "HTTP_SUBITEM_FIRST_BYTE_LATENCY_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1313,
+        "values": {
+          "115": 3,
+          "140": 3,
+          "209": 1,
+          "255": 0,
+          "52": 0,
+          "63": 1,
+          "77": 1,
+          "94": 1
+        }
+      },
+      "HTTP_SUBITEM_OPEN_LATENCY_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 1185,
+        "values": {
+          "0": 1,
+          "115": 1,
+          "140": 1,
+          "171": 0,
+          "63": 12
+        }
+      },
+      "HTTP_SUB_COMPLETE_LOAD_NET_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 509,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "29": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_COMPLETE_LOAD_V2": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 509,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "29": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_DNS_ISSUE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 112,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "29": 1,
+          "35": 1,
+          "43": 0,
+          "7": 4,
+          "9": 2
+        }
+      },
+      "HTTP_SUB_DNS_LOOKUP_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 15,
+        "values": {
+          "0": 3,
+          "2": 3,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "HTTP_SUB_FIRST_SENT_TO_LAST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 127,
+        "values": {
+          "11": 5,
+          "13": 2,
+          "24": 1,
+          "29": 0,
+          "5": 0,
+          "6": 1,
+          "9": 1
+        }
+      },
+      "HTTP_SUB_OPEN_TO_FIRST_RECEIVED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 495,
+        "values": {
+          "13": 0,
+          "16": 1,
+          "20": 1,
+          "35": 4,
+          "63": 2,
+          "77": 2,
+          "94": 0
+        }
+      },
+      "HTTP_SUB_OPEN_TO_FIRST_SENT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 375,
+        "values": {
+          "16": 1,
+          "24": 1,
+          "29": 3,
+          "52": 3,
+          "6": 0,
+          "63": 1,
+          "7": 1,
+          "77": 0
+        }
+      },
+      "HTTP_TRANSACTION_IS_SSL": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6026,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6026,
+        "values": {
+          "0": 120,
+          "1": 6026,
+          "2": 0
+        }
+      },
+      "HTTP_TRANSACTION_USE_ALTSVC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 8151,
+          "1": 0
+        }
+      },
+      "IDLE_NOTIFY_IDLE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 5,
+        "values": {
+          "0": 10,
+          "1": 5,
+          "3": 0
+        }
+      },
+      "IMAGE_DECODE_CHUNKS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 768,
+        "values": {
+          "0": 0,
+          "1": 731,
+          "2": 9,
+          "6": 2,
+          "7": 1,
+          "8": 0
+        }
+      },
+      "IMAGE_DECODE_COUNT": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "IMAGE_DECODE_ON_DRAW_LATENCY": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          50000000
+        ],
+        "sum": 12610301,
+        "values": {
+          "0": 11,
+          "101216": 33,
+          "116539": 12,
+          "12216": 1,
+          "134181": 11,
+          "14065": 3,
+          "154494": 1,
+          "16194": 5,
+          "177882": 0,
+          "18646": 4,
+          "66311": 7,
+          "6951": 1,
+          "76350": 19,
+          "8003": 2,
+          "87908": 37
+        }
+      },
+      "IMAGE_DECODE_SPEED_PNG": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          500,
+          50000000
+        ],
+        "sum": 8766850,
+        "values": {
+          "0": 1,
+          "1027": 2,
+          "11306": 102,
+          "1305": 3,
+          "14370": 90,
+          "1659": 1,
+          "18265": 64,
+          "2109": 2,
+          "23216": 35,
+          "2681": 19,
+          "29509": 16,
+          "3408": 32,
+          "37507": 25,
+          "4332": 37,
+          "47673": 0,
+          "500": 4,
+          "5506": 60,
+          "636": 3,
+          "6998": 69,
+          "808": 3,
+          "8895": 91
+        }
+      },
+      "IMAGE_DECODE_TIME": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          50000000
+        ],
+        "sum": 692307,
+        "values": {
+          "0": 332,
+          "102": 10,
+          "1112": 1,
+          "117": 7,
+          "1280": 2,
+          "135": 4,
+          "1474": 1,
+          "155": 3,
+          "1697": 37,
+          "178": 3,
+          "1954": 45,
+          "205": 1,
+          "2250": 38,
+          "236": 1,
+          "2591": 48,
+          "2983": 25,
+          "313": 1,
+          "3435": 23,
+          "360": 2,
+          "3955": 9,
+          "415": 2,
+          "478": 3,
+          "50": 53,
+          "5243": 1,
+          "550": 1,
+          "58": 24,
+          "6037": 6,
+          "67": 28,
+          "6951": 2,
+          "77": 18,
+          "8003": 1,
+          "89": 10,
+          "9215": 0,
+          "966": 1
+        }
+      },
+      "IMAGE_MAX_DECODE_COUNT": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "INNERWINDOWS_WITH_MUTATION_LISTENERS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 102,
+          "1": 0
+        }
+      },
+      "IPV4_AND_IPV6_ADDRESS_CONNECTIVITY": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 119,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 219,
+        "values": {
+          "0": 717,
+          "1": 28,
+          "2": 41,
+          "3": 3,
+          "4": 0
+        }
+      },
+      "LINK_ICON_SIZES_ATTR_USAGE": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "LOCALDOMSTORAGE_SHUTDOWN_DATABASE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 5,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "MAC_INITFONTLIST_TOTAL": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          30000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "MASTER_PASSWORD_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "MEMORY_HEAP_ALLOCATED": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 55816789,
+        "values": {
+          "184722": 0,
+          "194001": 2,
+          "203746": 2,
+          "213980": 7,
+          "224728": 11,
+          "236016": 6,
+          "247871": 5,
+          "260322": 11,
+          "273398": 7,
+          "287131": 3,
+          "301554": 6,
+          "316701": 10,
+          "332609": 1,
+          "349316": 25,
+          "366862": 35,
+          "385290": 20,
+          "404644": 7,
+          "424970": 3,
+          "446317": 2,
+          "542979": 1,
+          "628980": 2,
+          "660574": 0
+        }
+      },
+      "MEMORY_HEAP_COMMITTED_UNUSED_RATIO": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 232,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 368,
+        "values": {
+          "0": 0,
+          "1": 166,
+          "5": 0
+        }
+      },
+      "MEMORY_IMAGES_CONTENT_USED_UNCOMPRESSED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          1048576
+        ],
+        "sum": 178932,
+        "values": {
+          "0": 112,
+          "1024": 11,
+          "10317": 2,
+          "1183": 1,
+          "11920": 0,
+          "1579": 19,
+          "1824": 8,
+          "2434": 6,
+          "3249": 2,
+          "8930": 5
+        }
+      },
+      "MEMORY_JS_COMPARTMENTS_SYSTEM": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 102689,
+        "values": {
+          "492": 0,
+          "554": 91,
+          "623": 75,
+          "701": 0
+        }
+      },
+      "MEMORY_JS_COMPARTMENTS_USER": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 889,
+        "values": {
+          "10": 0,
+          "4": 0,
+          "5": 115,
+          "6": 47,
+          "7": 2,
+          "9": 2
+        }
+      },
+      "MEMORY_JS_GC_HEAP": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 12229632,
+        "values": {
+          "59836": 0,
+          "62842": 40,
+          "65999": 3,
+          "69314": 64,
+          "80293": 59,
+          "84326": 0
+        }
+      },
+      "MEMORY_JS_MAIN_RUNTIME_TEMPORARY_PEAK": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          16777216
+        ],
+        "sum": 217792,
+        "values": {
+          "1246": 0,
+          "1309": 166,
+          "1375": 0
+        }
+      },
+      "MEMORY_RESIDENT": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          32768,
+          16777216
+        ],
+        "sum": 122195140,
+        "values": {
+          "1016084": 1,
+          "1048607": 12,
+          "1082171": 6,
+          "1116809": 4,
+          "1152556": 1,
+          "1189447": 3,
+          "1227519": 0,
+          "420537": 0,
+          "433998": 1,
+          "447889": 3,
+          "462225": 2,
+          "477020": 1,
+          "492288": 5,
+          "508045": 6,
+          "524306": 8,
+          "541088": 7,
+          "558407": 3,
+          "576280": 5,
+          "594726": 4,
+          "613762": 18,
+          "633407": 11,
+          "653681": 13,
+          "674604": 7,
+          "696197": 1,
+          "718481": 9,
+          "741478": 7,
+          "765211": 1,
+          "789704": 10,
+          "814981": 2,
+          "841067": 3,
+          "867988": 2,
+          "895771": 5,
+          "924443": 2,
+          "954033": 3
+        }
+      },
+      "MEMORY_STORAGE_SQLITE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          524288
+        ],
+        "sum": 2850088,
+        "values": {
+          "13777": 0,
+          "15689": 138,
+          "17866": 28,
+          "20346": 0
+        }
+      },
+      "MEMORY_VSIZE": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          32768,
+          16777216
+        ],
+        "sum": 723760328,
+        "values": {
+          "3416485": 0,
+          "3641037": 16,
+          "3880348": 21,
+          "4135388": 31,
+          "4407191": 85,
+          "4696859": 13,
+          "5005565": 0
+        }
+      },
+      "MIXED_CONTENT_HSTS": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 8,
+          "1": 0
+        }
+      },
+      "MOZ_SQLITE_COOKIES_OPEN_READAHEAD_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "MOZ_SQLITE_OPEN_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 980,
+        "values": {
+          "0": 2792,
+          "1": 176,
+          "154": 2,
+          "21": 2,
+          "3": 14,
+          "414": 0
+        }
+      },
+      "MOZ_SQLITE_OTHER_READ_B": {
+        "bucket_count": 3,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32768
+        ],
+        "sum": 3976276,
+        "sum_squares_hi": 29,
+        "sum_squares_lo": 2583783760,
+        "values": {
+          "0": 0,
+          "1": 197,
+          "32768": 118
+        }
+      },
+      "MOZ_SQLITE_OTHER_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 2,
+        "values": {
+          "0": 40,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "MOZ_SQLITE_OTHER_WRITE_B": {
+        "bucket_count": 3,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32768
+        ],
+        "sum": 150749056,
+        "sum_squares_hi": 1149,
+        "sum_squares_lo": 504556576,
+        "values": {
+          "0": 0,
+          "1": 4594,
+          "32768": 4596
+        }
+      },
+      "MOZ_SQLITE_PLACES_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 234,
+        "values": {
+          "0": 316,
+          "1": 130,
+          "3": 15,
+          "8": 0
+        }
+      },
+      "MOZ_SQLITE_PLACES_WRITE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 30,
+        "values": {
+          "0": 9016,
+          "1": 21,
+          "3": 2,
+          "8": 0
+        }
+      },
+      "MOZ_SQLITE_WEBAPPS_SYNC_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 36,
+        "values": {
+          "0": 23,
+          "1": 19,
+          "3": 2,
+          "8": 0
+        }
+      },
+      "NETWORK_CACHE_HASH_STATS": {
+        "bucket_count": 161,
+        "histogram_type": 1,
+        "range": [
+          1,
+          160
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NETWORK_CACHE_HIT_MISS_STAT_PER_CACHE_SIZE": {
+        "bucket_count": 41,
+        "histogram_type": 1,
+        "range": [
+          1,
+          40
+        ],
+        "sum": 47000,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 322796,
+        "values": {
+          "5": 0,
+          "6": 1034,
+          "7": 5828,
+          "8": 0
+        }
+      },
+      "NETWORK_CACHE_HIT_RATE_PER_CACHE_SIZE": {
+        "bucket_count": 401,
+        "histogram_type": 1,
+        "range": [
+          1,
+          400
+        ],
+        "sum": 338,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 28374,
+        "values": {
+          "123": 1,
+          "124": 0,
+          "2": 0,
+          "23": 1,
+          "3": 1,
+          "43": 1,
+          "63": 1,
+          "83": 1
+        }
+      },
+      "NETWORK_CACHE_METADATA_FIRST_READ_SIZE": {
+        "bucket_count": 256,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5119
+        ],
+        "sum": 3007666,
+        "sum_squares_hi": 2,
+        "sum_squares_lo": 1604968888,
+        "values": {
+          "1008": 3,
+          "102": 3,
+          "1029": 1,
+          "1049": 6,
+          "1069": 3,
+          "1089": 3,
+          "1109": 1,
+          "1129": 8,
+          "1150": 4,
+          "1170": 3,
+          "1190": 6,
+          "1210": 1,
+          "122": 1,
+          "1230": 1,
+          "1250": 7,
+          "1270": 6,
+          "1291": 5,
+          "1311": 1,
+          "1331": 6,
+          "1351": 2,
+          "1391": 1,
+          "1411": 1,
+          "1452": 3,
+          "1472": 4,
+          "1492": 5,
+          "1512": 1,
+          "1532": 2,
+          "1553": 2,
+          "1573": 4,
+          "1593": 2,
+          "1613": 4,
+          "1633": 1,
+          "1653": 1,
+          "1673": 2,
+          "1694": 44,
+          "1714": 2,
+          "1754": 3,
+          "1774": 2,
+          "1794": 2,
+          "1814": 5,
+          "182": 10,
+          "1855": 3,
+          "1875": 3,
+          "1895": 2,
+          "1915": 1,
+          "1935": 2,
+          "1956": 4,
+          "1976": 9,
+          "1996": 4,
+          "2016": 2,
+          "202": 3,
+          "2036": 4,
+          "2076": 7,
+          "2097": 3,
+          "2117": 7,
+          "2137": 6,
+          "2157": 2,
+          "2177": 4,
+          "2197": 4,
+          "2217": 4,
+          "2238": 2,
+          "2258": 1,
+          "2278": 8,
+          "2298": 8,
+          "2318": 2,
+          "2359": 1,
+          "2379": 3,
+          "2399": 9,
+          "2419": 4,
+          "243": 8,
+          "2439": 2,
+          "2459": 17,
+          "2479": 21,
+          "2500": 3,
+          "2520": 5,
+          "2540": 5,
+          "2560": 6,
+          "2580": 6,
+          "2600": 7,
+          "2620": 7,
+          "263": 1,
+          "2641": 2,
+          "2661": 4,
+          "2681": 1,
+          "2701": 7,
+          "2721": 8,
+          "2741": 10,
+          "2761": 7,
+          "2782": 10,
+          "2802": 6,
+          "2822": 1,
+          "283": 6,
+          "2842": 11,
+          "2862": 4,
+          "2882": 3,
+          "2903": 3,
+          "2923": 5,
+          "2943": 10,
+          "2963": 9,
+          "2983": 10,
+          "3003": 3,
+          "3023": 14,
+          "303": 5,
+          "3044": 8,
+          "3064": 4,
+          "3084": 1,
+          "3124": 9,
+          "3144": 3,
+          "3185": 6,
+          "3205": 21,
+          "3225": 9,
+          "3245": 3,
+          "3265": 21,
+          "3285": 10,
+          "3306": 3,
+          "3326": 6,
+          "3346": 14,
+          "3366": 17,
+          "3386": 7,
+          "3406": 14,
+          "3426": 8,
+          "344": 7,
+          "3447": 8,
+          "3467": 4,
+          "3487": 9,
+          "3507": 7,
+          "3527": 1,
+          "3547": 6,
+          "3567": 10,
+          "3588": 3,
+          "3608": 6,
+          "3628": 3,
+          "364": 6,
+          "3648": 3,
+          "3668": 9,
+          "3688": 3,
+          "3709": 6,
+          "3729": 10,
+          "3749": 8,
+          "3769": 7,
+          "3789": 6,
+          "3809": 4,
+          "3829": 3,
+          "3850": 6,
+          "3870": 1,
+          "3890": 2,
+          "3910": 5,
+          "3930": 3,
+          "3950": 4,
+          "3970": 7,
+          "3991": 2,
+          "4011": 1,
+          "4031": 5,
+          "404": 1,
+          "4091": 4,
+          "41": 0,
+          "4112": 1,
+          "4132": 4,
+          "4152": 5,
+          "4172": 16,
+          "4192": 1,
+          "4212": 5,
+          "4232": 3,
+          "4253": 2,
+          "4273": 5,
+          "4293": 6,
+          "4313": 3,
+          "4333": 2,
+          "4353": 2,
+          "4373": 4,
+          "4414": 10,
+          "4434": 4,
+          "444": 1,
+          "4454": 3,
+          "4474": 6,
+          "4494": 3,
+          "4515": 2,
+          "4535": 4,
+          "4555": 2,
+          "4575": 6,
+          "4595": 10,
+          "4615": 6,
+          "4635": 5,
+          "464": 1,
+          "4656": 3,
+          "4676": 2,
+          "4716": 7,
+          "4736": 4,
+          "4756": 7,
+          "4797": 3,
+          "4857": 1,
+          "4897": 9,
+          "4918": 4,
+          "4938": 3,
+          "4958": 6,
+          "4978": 5,
+          "4998": 3,
+          "5018": 2,
+          "5059": 3,
+          "5079": 1,
+          "5099": 1,
+          "5119": 0,
+          "61": 4,
+          "686": 1,
+          "747": 2,
+          "82": 2
+        }
+      },
+      "NETWORK_CACHE_METADATA_FIRST_READ_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 1021,
+        "values": {
+          "0": 712,
+          "1": 147,
+          "10": 9,
+          "12": 14,
+          "2": 57,
+          "29": 1,
+          "3": 44,
+          "34": 0,
+          "4": 8,
+          "5": 13,
+          "6": 21,
+          "7": 9,
+          "8": 5
+        }
+      },
+      "NETWORK_CACHE_METADATA_SECOND_READ_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 298,
+        "values": {
+          "0": 252,
+          "1": 41,
+          "10": 4,
+          "12": 2,
+          "14": 0,
+          "2": 10,
+          "3": 6,
+          "4": 13,
+          "5": 1,
+          "6": 2,
+          "7": 10,
+          "8": 2
+        }
+      },
+      "NETWORK_CACHE_METADATA_SIZE": {
+        "bucket_count": 256,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5119
+        ],
+        "sum": 3209747,
+        "sum_squares_hi": 3,
+        "sum_squares_lo": 1737291685,
+        "values": {
+          "1008": 2,
+          "102": 3,
+          "122": 1,
+          "1472": 1,
+          "1613": 1,
+          "1694": 40,
+          "182": 10,
+          "202": 3,
+          "2076": 1,
+          "2137": 4,
+          "2238": 1,
+          "2278": 1,
+          "2298": 2,
+          "2318": 1,
+          "2338": 3,
+          "2359": 28,
+          "2379": 5,
+          "2399": 3,
+          "2419": 27,
+          "243": 8,
+          "2439": 64,
+          "2459": 26,
+          "2479": 20,
+          "2500": 5,
+          "2520": 2,
+          "2540": 6,
+          "2560": 21,
+          "2580": 10,
+          "2600": 10,
+          "2620": 40,
+          "263": 1,
+          "2641": 8,
+          "2661": 15,
+          "2681": 4,
+          "2701": 4,
+          "2741": 4,
+          "2761": 3,
+          "2782": 13,
+          "2802": 1,
+          "2822": 1,
+          "283": 6,
+          "2842": 1,
+          "2862": 2,
+          "2882": 2,
+          "2943": 1,
+          "2963": 1,
+          "2983": 1,
+          "3023": 11,
+          "303": 6,
+          "3044": 3,
+          "3064": 4,
+          "3084": 7,
+          "3104": 17,
+          "3124": 35,
+          "3144": 19,
+          "3164": 59,
+          "3185": 30,
+          "3205": 38,
+          "3225": 31,
+          "323": 1,
+          "3245": 26,
+          "3265": 76,
+          "3285": 2,
+          "3306": 5,
+          "3326": 13,
+          "3346": 5,
+          "3366": 29,
+          "3386": 19,
+          "3406": 10,
+          "3426": 8,
+          "344": 7,
+          "3447": 8,
+          "3547": 4,
+          "3567": 9,
+          "3588": 5,
+          "3608": 2,
+          "3628": 1,
+          "364": 6,
+          "3648": 4,
+          "3668": 2,
+          "3688": 4,
+          "3729": 4,
+          "3809": 1,
+          "3829": 1,
+          "3890": 1,
+          "3991": 1,
+          "4031": 1,
+          "404": 1,
+          "4051": 4,
+          "4071": 9,
+          "41": 0,
+          "4152": 1,
+          "4172": 1,
+          "4192": 1,
+          "424": 1,
+          "4293": 1,
+          "4313": 1,
+          "444": 1,
+          "4454": 1,
+          "4494": 1,
+          "4555": 1,
+          "464": 4,
+          "4716": 1,
+          "4756": 1,
+          "4978": 1,
+          "505": 3,
+          "5079": 1,
+          "5119": 43,
+          "525": 1,
+          "545": 4,
+          "565": 4,
+          "585": 2,
+          "605": 2,
+          "61": 4,
+          "626": 1,
+          "646": 1,
+          "666": 1,
+          "747": 3,
+          "767": 1,
+          "787": 1,
+          "82": 2,
+          "908": 1,
+          "928": 2
+        }
+      },
+      "NETWORK_CACHE_V2_HIT_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 2967,
+        "values": {
+          "0": 399,
+          "1": 158,
+          "10": 17,
+          "12": 20,
+          "14": 19,
+          "17": 9,
+          "2": 174,
+          "20": 7,
+          "24": 9,
+          "29": 3,
+          "3": 88,
+          "34": 5,
+          "4": 53,
+          "40": 0,
+          "5": 32,
+          "6": 5,
+          "7": 20,
+          "8": 16
+        }
+      },
+      "NETWORK_CACHE_V2_INPUT_STREAM_STATUS": {
+        "bucket_count": 8,
+        "histogram_type": 1,
+        "range": [
+          1,
+          7
+        ],
+        "sum": 54,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 324,
+        "values": {
+          "0": 1555,
+          "6": 9,
+          "7": 0
+        }
+      },
+      "NETWORK_CACHE_V2_MISS_TIME_MS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 8,
+        "values": {
+          "0": 5824,
+          "2": 4,
+          "3": 0
+        }
+      },
+      "NETWORK_CACHE_V2_OUTPUT_STREAM_STATUS": {
+        "bucket_count": 8,
+        "histogram_type": 1,
+        "range": [
+          1,
+          7
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 5969,
+          "1": 0
+        }
+      },
+      "NETWORK_DISK_CACHE_TRASHRENAME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_BLOCKED_SITES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_ENHANCED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "NEWTAB_PAGE_LIFE_SPAN": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1200
+        ],
+        "sum": 187,
+        "values": {
+          "0": 2,
+          "12": 1,
+          "138": 1,
+          "145": 0,
+          "3": 2,
+          "4": 1,
+          "6": 1,
+          "7": 1,
+          "8": 1
+        }
+      },
+      "NEWTAB_PAGE_LIFE_SPAN_SUGGESTED": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1200
+        ],
+        "sum": 81,
+        "values": {
+          "12": 1,
+          "20": 1,
+          "42": 1,
+          "44": 0,
+          "6": 0,
+          "7": 1
+        }
+      },
+      "NEWTAB_PAGE_PINNED_SITES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          9
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "OSFILE_WORKER_LAUNCH_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "OSFILE_WORKER_READY_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "OSFILE_WRITEATOMIC_JANK_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 4,
+        "values": {
+          "0": 157,
+          "1": 4,
+          "3": 0
+        }
+      },
+      "PAGE_FAULTS_HARD": {
+        "bucket_count": 13,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          8,
+          65536
+        ],
+        "sum": 453,
+        "values": {
+          "0": 160,
+          "18": 3,
+          "211": 1,
+          "479": 0,
+          "8": 1,
+          "93": 1
+        }
+      },
+      "PAINT_BUILD_DISPLAYLIST_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 5384,
+        "values": {
+          "0": 6469,
+          "1": 4697,
+          "10": 2,
+          "2": 297,
+          "29": 2,
+          "3": 1,
+          "33": 0,
+          "8": 1
+        }
+      },
+      "PAINT_RASTERIZE_TIME": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 23492,
+        "values": {
+          "0": 1335,
+          "1": 4667,
+          "10": 93,
+          "11": 42,
+          "12": 42,
+          "14": 10,
+          "16": 8,
+          "18": 3,
+          "192": 1,
+          "2": 3799,
+          "20": 2,
+          "216": 0,
+          "23": 5,
+          "26": 2,
+          "29": 3,
+          "3": 622,
+          "33": 10,
+          "37": 3,
+          "4": 157,
+          "42": 9,
+          "47": 5,
+          "5": 130,
+          "6": 125,
+          "60": 1,
+          "7": 81,
+          "75": 1,
+          "8": 137,
+          "84": 1,
+          "9": 175
+        }
+      },
+      "PLACES_ANNOS_BOOKMARKS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_ANNOS_PAGES_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_AUTOCOMPLETE_1ST_RESULT_TIME_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          500
+        ],
+        "sum": 6752,
+        "values": {
+          "0": 51,
+          "119": 1,
+          "159": 11,
+          "212": 8,
+          "282": 1,
+          "375": 0,
+          "50": 4,
+          "67": 21,
+          "89": 2
+        }
+      },
+      "PLACES_AUTOCOMPLETE_6_FIRST_RESULTS_TIME_MS": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          1000
+        ],
+        "sum": 8561,
+        "values": {
+          "107": 2,
+          "132": 7,
+          "147": 4,
+          "164": 1,
+          "182": 2,
+          "202": 2,
+          "225": 1,
+          "250": 0,
+          "50": 0,
+          "56": 1,
+          "62": 7,
+          "69": 19,
+          "77": 24,
+          "86": 13,
+          "96": 5
+        }
+      },
+      "PLACES_BACKUPS_BOOKMARKSTREE_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          2000
+        ],
+        "sum": 64,
+        "values": {
+          "0": 0,
+          "50": 1,
+          "79": 0
+        }
+      },
+      "PLACES_BACKUPS_TOJSON_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          2000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 1,
+          "50": 0
+        }
+      },
+      "PLACES_BOOKMARKS_COUNT": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          100,
+          8000
+        ],
+        "sum": 90,
+        "values": {
+          "0": 1,
+          "100": 0
+        }
+      },
+      "PLACES_DATABASE_FILESIZE_MB": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          5,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_DATABASE_PAGESIZE_B": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1024,
+          32768
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_DATABASE_SIZE_PER_PAGE_B": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          500,
+          10240
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_FAVICON_ICO_SIZES": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          524288
+        ],
+        "sum": 897712,
+        "values": {
+          "1008": 0,
+          "1140": 3,
+          "1289": 6,
+          "16925": 1,
+          "21629": 1,
+          "362923": 1,
+          "3886": 2,
+          "410267": 1,
+          "463787": 0,
+          "4966": 1
+        }
+      },
+      "PLACES_FAVICON_PNG_SIZES": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          524288
+        ],
+        "sum": 10247,
+        "values": {
+          "141": 0,
+          "159": 1,
+          "2380": 1,
+          "3438": 1,
+          "3886": 0,
+          "427": 1,
+          "789": 4
+        }
+      },
+      "PLACES_IDLE_FRECENCY_DECAY_TIME_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          50,
+          10000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_KEYWORDS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_MAINTENANCE_DAYSFROMLAST": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          7,
+          60
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLACES_PAGES_COUNT": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1000,
+          150000
+        ],
+        "sum": 30798,
+        "values": {
+          "21371": 0,
+          "28231": 1,
+          "37292": 0
+        }
+      },
+      "PLACES_SORTED_BOOKMARKS_PERC": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PLACES_TAGGED_BOOKMARKS_PERC": {
+        "bucket_count": 10,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PLACES_TAGS_COUNT": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PLUGIN_CALLED_DIRECTLY": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 20,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCLOSE_TCP_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 25,
+        "values": {
+          "0": 757,
+          "1": 25,
+          "2": 0
+        }
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 15,
+          "1": 0
+        }
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCONNECTCONTINUE_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 5,
+        "values": {
+          "0": 760,
+          "1": 5,
+          "2": 0
+        }
+      },
+      "PRCONNECT_BLOCKING_TIME_CONNECTIVITY_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 23,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "PRCONNECT_BLOCKING_TIME_LINK_CHANGE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PRCONNECT_BLOCKING_TIME_NORMAL": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 35,
+        "values": {
+          "0": 740,
+          "1": 35,
+          "2": 0
+        }
+      },
+      "PREDICTOR_BASE_CONFIDENCE": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 46520,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4041014,
+        "values": {
+          "0": 626,
+          "1": 30,
+          "100": 125,
+          "11": 16,
+          "13": 17,
+          "15": 6,
+          "18": 6,
+          "20": 4,
+          "22": 2,
+          "24": 17,
+          "26": 16,
+          "32": 6,
+          "36": 1,
+          "38": 16,
+          "40": 24,
+          "42": 6,
+          "44": 2,
+          "46": 1,
+          "48": 14,
+          "5": 52,
+          "51": 3,
+          "53": 3,
+          "57": 2,
+          "59": 6,
+          "61": 1,
+          "65": 10,
+          "69": 4,
+          "7": 33,
+          "71": 1,
+          "73": 3,
+          "75": 14,
+          "77": 1,
+          "79": 11,
+          "81": 9,
+          "84": 6,
+          "86": 6,
+          "88": 6,
+          "9": 35,
+          "90": 9,
+          "92": 16,
+          "94": 51,
+          "96": 52,
+          "98": 102
+        }
+      },
+      "PREDICTOR_CONFIDENCE": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 42687,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3553705,
+        "values": {
+          "0": 701,
+          "1": 19,
+          "100": 60,
+          "11": 21,
+          "13": 16,
+          "15": 13,
+          "22": 3,
+          "24": 12,
+          "26": 1,
+          "28": 2,
+          "3": 1,
+          "30": 4,
+          "32": 4,
+          "36": 1,
+          "38": 28,
+          "40": 8,
+          "42": 1,
+          "44": 1,
+          "46": 6,
+          "48": 8,
+          "5": 56,
+          "51": 6,
+          "55": 2,
+          "59": 9,
+          "63": 1,
+          "65": 11,
+          "69": 6,
+          "7": 5,
+          "73": 10,
+          "75": 5,
+          "77": 1,
+          "79": 10,
+          "81": 10,
+          "84": 13,
+          "86": 10,
+          "88": 210,
+          "9": 21,
+          "90": 31,
+          "92": 2,
+          "94": 39,
+          "96": 2,
+          "98": 1
+        }
+      },
+      "PREDICTOR_GLOBAL_DEGRADATION": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 980,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 47700,
+        "values": {
+          "0": 165,
+          "48": 19,
+          "5": 4,
+          "51": 0,
+          "9": 1
+        }
+      },
+      "PREDICTOR_LEARN_ATTEMPTS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1915,
+        "values": {
+          "0": 0,
+          "1": 1915,
+          "2": 0
+        }
+      },
+      "PREDICTOR_LEARN_WORK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 682,
+        "values": {
+          "0": 3390,
+          "1": 63,
+          "154": 0,
+          "21": 1,
+          "3": 39,
+          "57": 2,
+          "8": 23
+        }
+      },
+      "PREDICTOR_PREDICTIONS_CALCULATED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 1528,
+        "values": {
+          "0": 0,
+          "1": 1528,
+          "2": 0
+        }
+      },
+      "PREDICTOR_PREDICT_TIME_TO_ACTION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 231,
+        "values": {
+          "0": 100,
+          "1": 17,
+          "154": 0,
+          "3": 14,
+          "57": 1,
+          "8": 7
+        }
+      },
+      "PREDICTOR_PREDICT_TIME_TO_INACTION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 119,
+        "values": {
+          "0": 36,
+          "1": 9,
+          "154": 0,
+          "3": 1,
+          "57": 1,
+          "8": 3
+        }
+      },
+      "PREDICTOR_PREDICT_WORK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 350,
+        "values": {
+          "0": 136,
+          "1": 26,
+          "154": 0,
+          "3": 15,
+          "57": 2,
+          "8": 10
+        }
+      },
+      "PREDICTOR_SUBRESOURCE_DEGRADATION": {
+        "bucket_count": 50,
+        "histogram_type": 1,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 18400,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 591060,
+        "values": {
+          "0": 141,
+          "1": 535,
+          "24": 357,
+          "48": 139,
+          "51": 0,
+          "9": 199
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 135,
+        "values": {
+          "0": 167,
+          "1": 10,
+          "12": 1,
+          "16": 1,
+          "28": 2,
+          "3": 5,
+          "37": 0,
+          "5": 1,
+          "7": 1,
+          "9": 1
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_CREATED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 38,
+        "values": {
+          "0": 0,
+          "1": 38,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_UNUSED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 35,
+        "values": {
+          "0": 0,
+          "1": 35,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PRECONNECTS_USED": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "PREDICTOR_TOTAL_PREDICTIONS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 424,
+        "values": {
+          "0": 50,
+          "1": 68,
+          "12": 2,
+          "16": 1,
+          "2": 16,
+          "28": 2,
+          "3": 28,
+          "37": 0,
+          "5": 19,
+          "7": 2,
+          "9": 1
+        }
+      },
+      "PREDICTOR_TOTAL_PRERESOLVES": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000000
+        ],
+        "sum": 289,
+        "values": {
+          "0": 71,
+          "1": 58,
+          "12": 1,
+          "16": 0,
+          "2": 17,
+          "3": 23,
+          "5": 18,
+          "7": 1
+        }
+      },
+      "PREDICTOR_WAIT_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 1004,
+        "values": {
+          "0": 3540,
+          "1": 79,
+          "154": 0,
+          "21": 1,
+          "3": 51,
+          "57": 4,
+          "8": 32
+        }
+      },
+      "PUSH_API_USED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "PWMGR_BLOCKLIST_NUM_SITES": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_FORM_ACTION_EFFECT": {
+        "bucket_count": 6,
+        "histogram_type": 1,
+        "range": [
+          1,
+          5
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 2,
+          "1": 0
+        }
+      },
+      "PWMGR_LOGIN_LAST_USED_DAYS": {
+        "bucket_count": 40,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_HTTPAUTH_PASSWORDS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_PASSWORDS_PER_HOSTNAME": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          21
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PWMGR_NUM_SAVED_PASSWORDS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          750
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "PWMGR_SAVING_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "PWMGR_USERNAME_PRESENT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "REFRESH_DRIVER_TICK": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 40006,
+        "values": {
+          "0": 61092,
+          "1": 908,
+          "10": 80,
+          "11": 49,
+          "12": 127,
+          "14": 60,
+          "16": 22,
+          "18": 17,
+          "2": 2698,
+          "20": 9,
+          "23": 13,
+          "243": 1,
+          "26": 6,
+          "273": 0,
+          "29": 10,
+          "3": 2888,
+          "33": 9,
+          "37": 12,
+          "4": 2160,
+          "42": 8,
+          "47": 8,
+          "5": 784,
+          "53": 4,
+          "6": 271,
+          "7": 153,
+          "75": 3,
+          "8": 126,
+          "84": 1,
+          "9": 114
+        }
+      },
+      "SAFE_MODE_USAGE": {
+        "bucket_count": 4,
+        "histogram_type": 1,
+        "range": [
+          1,
+          3
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_INIT_MS": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_INIT_SYNC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_TIMEZONE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SEARCH_SERVICE_US_TIMEZONE_MISMATCHED_COUNTRY": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SERVICE_WORKER_REGISTRATION_LOADING": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SHOULD_AUTO_DETECT_LANGUAGE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SHOULD_TRANSLATION_UI_APPEAR": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SHUTDOWN_OK": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "SHUTDOWN_PHASE_DURATION_TICKS_PROFILE_CHANGE_TEARDOWN": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          65
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SOCIAL_ENABLED_ON_SESSION": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SOCIAL_SIDEBAR_OPEN_DURATION": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          10000000
+        ],
+        "sum": 8680007019,
+        "values": {
+          "10000000": 6,
+          "1320121": 0
+        }
+      },
+      "SPDY_CHUNK_RECVD": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 13602,
+        "values": {
+          "0": 21613,
+          "1": 496,
+          "10": 25,
+          "11": 6,
+          "12": 26,
+          "13": 11,
+          "14": 10,
+          "15": 58,
+          "16": 318,
+          "17": 0,
+          "2": 165,
+          "3": 148,
+          "4": 1023,
+          "5": 73,
+          "6": 44,
+          "7": 23,
+          "8": 58,
+          "9": 13
+        }
+      },
+      "SPDY_GOAWAY_LOCAL": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 48,
+        "values": {
+          "0": 328,
+          "2": 12,
+          "3": 0
+        }
+      },
+      "SPDY_GOAWAY_PEER": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 1343,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 32963,
+        "values": {
+          "0": 17,
+          "1": 289,
+          "31": 34,
+          "32": 0
+        }
+      },
+      "SPDY_KBREAD_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 16555,
+        "values": {
+          "0": 229,
+          "1": 31,
+          "10": 1,
+          "106": 5,
+          "1086": 1,
+          "12": 2,
+          "123": 2,
+          "14": 2,
+          "142": 2,
+          "16": 3,
+          "164": 1,
+          "190": 1,
+          "2": 4,
+          "22": 3,
+          "220": 4,
+          "2244": 1,
+          "254": 2,
+          "29": 1,
+          "294": 2,
+          "3": 4,
+          "3000": 1,
+          "39": 3,
+          "4": 4,
+          "45": 7,
+          "5": 2,
+          "525": 2,
+          "6": 4,
+          "60": 2,
+          "607": 3,
+          "69": 4,
+          "7": 1,
+          "702": 1,
+          "8": 2,
+          "80": 2,
+          "9": 1,
+          "92": 1,
+          "939": 1
+        }
+      },
+      "SPDY_NPN_CONNECT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 338,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 338,
+        "values": {
+          "0": 266,
+          "1": 338,
+          "2": 0
+        }
+      },
+      "SPDY_NPN_JOIN": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 58335,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 58335,
+        "values": {
+          "0": 844,
+          "1": 58335,
+          "2": 0
+        }
+      },
+      "SPDY_PARALLEL_STREAMS": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 487,
+        "values": {
+          "0": 46,
+          "1": 233,
+          "14": 2,
+          "2": 27,
+          "3": 16,
+          "4": 13,
+          "47": 1,
+          "5": 2,
+          "53": 0,
+          "6": 2
+        }
+      },
+      "SPDY_REQUEST_PER_CONN": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 7582,
+        "values": {
+          "0": 0,
+          "1": 2,
+          "10": 6,
+          "107": 1,
+          "11": 6,
+          "12": 8,
+          "120": 2,
+          "135": 2,
+          "14": 5,
+          "152": 3,
+          "16": 5,
+          "171": 1,
+          "18": 2,
+          "20": 2,
+          "216": 4,
+          "23": 3,
+          "26": 1,
+          "273": 1,
+          "29": 5,
+          "33": 1,
+          "37": 1,
+          "42": 2,
+          "437": 1,
+          "492": 1,
+          "6": 46,
+          "60": 2,
+          "7": 153,
+          "789": 1,
+          "8": 54,
+          "84": 1,
+          "888": 0,
+          "9": 18,
+          "95": 2
+        }
+      },
+      "SPDY_SERVER_INITIATED_STREAMS": {
+        "bucket_count": 250,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 342,
+          "1": 0
+        }
+      },
+      "SPDY_SETTINGS_IW": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 6632445,
+        "values": {
+          "1000": 336,
+          "888": 0
+        }
+      },
+      "SPDY_SETTINGS_MAX_STREAMS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 32844,
+        "values": {
+          "100": 321,
+          "123": 3,
+          "132": 0,
+          "27": 0,
+          "29": 12
+        }
+      },
+      "SPDY_SYN_RATIO": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          99
+        ],
+        "sum": 235213,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 13977361,
+        "values": {
+          "0": 0,
+          "1": 298,
+          "12": 453,
+          "17": 93,
+          "23": 132,
+          "28": 422,
+          "34": 574,
+          "39": 123,
+          "45": 119,
+          "50": 23,
+          "55": 219,
+          "6": 756,
+          "61": 306,
+          "66": 711,
+          "72": 1240,
+          "99": 2
+        }
+      },
+      "SPDY_SYN_REPLY_RATIO": {
+        "bucket_count": 20,
+        "histogram_type": 1,
+        "range": [
+          1,
+          99
+        ],
+        "sum": 75685,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2101841,
+        "values": {
+          "0": 0,
+          "1": 454,
+          "12": 198,
+          "17": 216,
+          "23": 307,
+          "28": 92,
+          "34": 33,
+          "39": 49,
+          "45": 19,
+          "50": 45,
+          "55": 138,
+          "6": 3698,
+          "61": 157,
+          "66": 13,
+          "88": 2,
+          "99": 1
+        }
+      },
+      "SPDY_SYN_REPLY_SIZE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          16,
+          20000
+        ],
+        "sum": 330321,
+        "values": {
+          "0": 313,
+          "101": 104,
+          "117": 59,
+          "136": 68,
+          "158": 96,
+          "16": 110,
+          "183": 41,
+          "19": 23,
+          "212": 128,
+          "22": 7,
+          "245": 83,
+          "26": 37,
+          "284": 88,
+          "30": 1501,
+          "329": 10,
+          "35": 2025,
+          "381": 12,
+          "41": 173,
+          "441": 3,
+          "48": 43,
+          "511": 5,
+          "56": 83,
+          "592": 12,
+          "65": 31,
+          "686": 0,
+          "75": 111,
+          "87": 256
+        }
+      },
+      "SPDY_SYN_SIZE": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          20,
+          20000
+        ],
+        "sum": 8201935,
+        "values": {
+          "1126": 276,
+          "113": 34,
+          "130": 37,
+          "1300": 281,
+          "150": 56,
+          "1501": 108,
+          "173": 216,
+          "1733": 215,
+          "20": 0,
+          "200": 135,
+          "2001": 494,
+          "23": 1,
+          "231": 215,
+          "2311": 117,
+          "2669": 963,
+          "267": 142,
+          "27": 4,
+          "308": 57,
+          "3082": 394,
+          "31": 21,
+          "3559": 78,
+          "356": 181,
+          "36": 5,
+          "411": 38,
+          "4110": 0,
+          "42": 33,
+          "475": 14,
+          "48": 37,
+          "548": 35,
+          "55": 55,
+          "633": 21,
+          "64": 244,
+          "731": 242,
+          "74": 30,
+          "844": 263,
+          "85": 68,
+          "975": 328,
+          "98": 33
+        }
+      },
+      "SPDY_VERSION2": {
+        "bucket_count": 49,
+        "histogram_type": 1,
+        "range": [
+          1,
+          48
+        ],
+        "sum": 1688,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 8432,
+        "values": {
+          "3": 0,
+          "4": 2,
+          "5": 336,
+          "6": 0
+        }
+      },
+      "SSL_AUTH_ALGORITHM_FULL": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 647,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 2039,
+        "values": {
+          "0": 0,
+          "1": 183,
+          "4": 116,
+          "5": 0
+        }
+      },
+      "SSL_AUTH_ECDSA_CURVE_FULL": {
+        "bucket_count": 37,
+        "histogram_type": 1,
+        "range": [
+          1,
+          36
+        ],
+        "sum": 2668,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 61364,
+        "values": {
+          "22": 0,
+          "23": 116,
+          "24": 0
+        }
+      },
+      "SSL_AUTH_RSA_KEY_SIZE_FULL": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 2136,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 25632,
+        "values": {
+          "11": 0,
+          "12": 178,
+          "13": 0
+        }
+      },
+      "SSL_BYTES_BEFORE_CERT_CALLBACK": {
+        "bucket_count": 64,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          32000
+        ],
+        "sum": 1176341,
+        "values": {
+          "2105": 0,
+          "2449": 3,
+          "2849": 50,
+          "3314": 83,
+          "3855": 140,
+          "4484": 5,
+          "5216": 8,
+          "6067": 13,
+          "7057": 0
+        }
+      },
+      "SSL_CERT_ERROR_OVERRIDES": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 302,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 302,
+        "values": {
+          "0": 0,
+          "1": 302,
+          "2": 0
+        }
+      },
+      "SSL_CIPHER_SUITE_FULL": {
+        "bucket_count": 129,
+        "histogram_type": 1,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 735,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 19367,
+        "values": {
+          "0": 0,
+          "1": 173,
+          "2": 116,
+          "5": 5,
+          "61": 5,
+          "62": 0
+        }
+      },
+      "SSL_CIPHER_SUITE_RESUMED": {
+        "bucket_count": 129,
+        "histogram_type": 1,
+        "range": [
+          1,
+          128
+        ],
+        "sum": 2459,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 123615,
+        "values": {
+          "0": 0,
+          "1": 115,
+          "2": 158,
+          "5": 3,
+          "61": 33,
+          "62": 0
+        }
+      },
+      "SSL_HANDSHAKE_TYPE": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 959,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1811,
+        "values": {
+          "0": 0,
+          "1": 309,
+          "2": 270,
+          "3": 6,
+          "4": 23,
+          "5": 0
+        }
+      },
+      "SSL_HANDSHAKE_VERSION": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1810,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 5416,
+        "values": {
+          "0": 0,
+          "1": 7,
+          "3": 601,
+          "4": 0
+        }
+      },
+      "SSL_KEA_ECDHE_CURVE_FULL": {
+        "bucket_count": 37,
+        "histogram_type": 1,
+        "range": [
+          1,
+          36
+        ],
+        "sum": 6762,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 155526,
+        "values": {
+          "22": 0,
+          "23": 294,
+          "24": 0
+        }
+      },
+      "SSL_KEA_RSA_KEY_SIZE_FULL": {
+        "bucket_count": 25,
+        "histogram_type": 1,
+        "range": [
+          1,
+          24
+        ],
+        "sum": 60,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 720,
+        "values": {
+          "11": 0,
+          "12": 5,
+          "13": 0
+        }
+      },
+      "SSL_KEY_EXCHANGE_ALGORITHM_FULL": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1181,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4709,
+        "values": {
+          "0": 0,
+          "1": 5,
+          "4": 294,
+          "5": 0
+        }
+      },
+      "SSL_KEY_EXCHANGE_ALGORITHM_RESUMED": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1137,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 4449,
+        "values": {
+          "0": 0,
+          "1": 33,
+          "4": 276,
+          "5": 0
+        }
+      },
+      "SSL_NPN_TYPE": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 1212,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3552,
+        "values": {
+          "0": 177,
+          "1": 42,
+          "3": 390,
+          "4": 0
+        }
+      },
+      "SSL_OBSERVED_END_ENTITY_CERTIFICATE_LIFETIME": {
+        "bucket_count": 126,
+        "histogram_type": 1,
+        "range": [
+          1,
+          125
+        ],
+        "sum": 14777,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1276745,
+        "values": {
+          "104": 7,
+          "105": 98,
+          "106": 0,
+          "11": 0,
+          "12": 153,
+          "15": 1,
+          "16": 11,
+          "45": 2,
+          "52": 17,
+          "53": 8,
+          "54": 1,
+          "56": 1,
+          "64": 1,
+          "74": 1,
+          "86": 1
+        }
+      },
+      "SSL_OCSP_STAPLING": {
+        "bucket_count": 9,
+        "histogram_type": 1,
+        "range": [
+          1,
+          8
+        ],
+        "sum": 518,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 950,
+        "values": {
+          "0": 0,
+          "1": 86,
+          "2": 216,
+          "3": 0
+        }
+      },
+      "SSL_PERMANENT_CERT_ERROR_OVERRIDES": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1024
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "SSL_REASONS_FOR_NOT_FALSE_STARTING": {
+        "bucket_count": 513,
+        "histogram_type": 1,
+        "range": [
+          1,
+          512
+        ],
+        "sum": 24,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 124,
+        "values": {
+          "0": 271,
+          "2": 2,
+          "3": 2,
+          "7": 2,
+          "8": 0
+        }
+      },
+      "SSL_RESUMED_SESSION": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 309,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 309,
+        "values": {
+          "0": 299,
+          "1": 309,
+          "2": 0
+        }
+      },
+      "SSL_SERVER_AUTH_EKU": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 604,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1208,
+        "values": {
+          "1": 0,
+          "2": 302,
+          "3": 0
+        }
+      },
+      "SSL_SUCCESFUL_CERT_VALIDATION_TIME_MOZILLAPKIX": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 4087,
+        "values": {
+          "0": 8,
+          "1": 153,
+          "1012": 1,
+          "11": 1,
+          "1255": 0,
+          "14": 1,
+          "17": 4,
+          "181": 1,
+          "2": 72,
+          "26": 2,
+          "3": 26,
+          "4": 6,
+          "40": 4,
+          "428": 2,
+          "5": 5,
+          "50": 1,
+          "62": 8,
+          "7": 1,
+          "77": 3,
+          "9": 1,
+          "95": 2
+        }
+      },
+      "SSL_SYMMETRIC_CIPHER_FULL": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 2960,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29390,
+        "values": {
+          "10": 289,
+          "11": 0,
+          "6": 0,
+          "7": 10
+        }
+      },
+      "SSL_SYMMETRIC_CIPHER_RESUMED": {
+        "bucket_count": 33,
+        "histogram_type": 1,
+        "range": [
+          1,
+          32
+        ],
+        "sum": 2982,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 29064,
+        "values": {
+          "10": 273,
+          "11": 0,
+          "6": 0,
+          "7": 36
+        }
+      },
+      "SSL_TIME_UNTIL_HANDSHAKE_FINISHED": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 44537,
+        "values": {
+          "10": 1,
+          "100": 4,
+          "105": 13,
+          "11": 3,
+          "110": 5,
+          "115": 5,
+          "12": 7,
+          "120": 4,
+          "126": 11,
+          "13": 22,
+          "132": 7,
+          "138": 6,
+          "14": 34,
+          "144": 7,
+          "15": 29,
+          "151": 6,
+          "158": 1,
+          "16": 23,
+          "165": 1,
+          "17": 20,
+          "173": 1,
+          "18": 17,
+          "181": 3,
+          "189": 2,
+          "19": 12,
+          "198": 2,
+          "20": 7,
+          "207": 1,
+          "21": 13,
+          "217": 1,
+          "22": 11,
+          "227": 5,
+          "23": 13,
+          "237": 12,
+          "24": 16,
+          "248": 6,
+          "25": 17,
+          "259": 2,
+          "26": 12,
+          "27": 13,
+          "28": 8,
+          "283": 2,
+          "29": 8,
+          "296": 1,
+          "30": 4,
+          "31": 5,
+          "310": 1,
+          "32": 5,
+          "324": 3,
+          "33": 10,
+          "339": 8,
+          "35": 7,
+          "355": 5,
+          "37": 10,
+          "371": 3,
+          "39": 7,
+          "41": 6,
+          "43": 2,
+          "445": 1,
+          "45": 3,
+          "47": 1,
+          "486": 1,
+          "49": 7,
+          "51": 3,
+          "53": 7,
+          "55": 10,
+          "555": 2,
+          "58": 15,
+          "608": 1,
+          "61": 6,
+          "636": 0,
+          "64": 8,
+          "67": 2,
+          "70": 6,
+          "73": 3,
+          "76": 5,
+          "8": 0,
+          "80": 10,
+          "84": 17,
+          "88": 15,
+          "9": 1,
+          "92": 9,
+          "96": 5
+        }
+      },
+      "SSL_TIME_UNTIL_READY": {
+        "bucket_count": 200,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 35761,
+        "values": {
+          "10": 1,
+          "100": 4,
+          "105": 12,
+          "11": 3,
+          "110": 4,
+          "115": 4,
+          "12": 7,
+          "120": 10,
+          "126": 3,
+          "13": 22,
+          "132": 3,
+          "138": 1,
+          "14": 37,
+          "144": 1,
+          "15": 34,
+          "151": 4,
+          "158": 3,
+          "16": 28,
+          "165": 2,
+          "17": 28,
+          "173": 3,
+          "18": 26,
+          "181": 5,
+          "189": 5,
+          "19": 15,
+          "20": 13,
+          "207": 1,
+          "21": 24,
+          "217": 2,
+          "22": 13,
+          "227": 10,
+          "23": 12,
+          "237": 11,
+          "24": 16,
+          "248": 5,
+          "25": 17,
+          "259": 2,
+          "26": 12,
+          "27": 6,
+          "28": 5,
+          "283": 1,
+          "29": 4,
+          "296": 1,
+          "30": 1,
+          "31": 1,
+          "310": 1,
+          "32": 3,
+          "33": 10,
+          "35": 6,
+          "355": 1,
+          "37": 3,
+          "388": 1,
+          "39": 14,
+          "41": 11,
+          "43": 7,
+          "45": 6,
+          "47": 4,
+          "486": 1,
+          "49": 7,
+          "51": 2,
+          "53": 6,
+          "55": 12,
+          "58": 12,
+          "608": 1,
+          "61": 12,
+          "636": 0,
+          "64": 13,
+          "67": 4,
+          "70": 4,
+          "73": 4,
+          "76": 4,
+          "8": 0,
+          "80": 5,
+          "84": 11,
+          "88": 14,
+          "9": 1,
+          "92": 5,
+          "96": 2
+        }
+      },
+      "STARTUP_CACHE_INVALID": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "STARTUP_CRASH_DETECTED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "STS_NUMBER_OF_ONSOCKETREADY_CALLS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 58775,
+        "values": {
+          "0": 46630,
+          "1": 56822,
+          "2": 604,
+          "3": 121,
+          "4": 51,
+          "5": 22,
+          "6": 9,
+          "7": 2,
+          "8": 0
+        }
+      },
+      "STS_NUMBER_OF_PENDING_EVENTS": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 78594,
+        "values": {
+          "1": 0,
+          "10": 10,
+          "11": 7,
+          "12": 8,
+          "13": 8,
+          "14": 4,
+          "15": 3,
+          "16": 3,
+          "17": 1,
+          "18": 2,
+          "19": 2,
+          "2": 31581,
+          "20": 1,
+          "22": 2,
+          "25": 3,
+          "27": 2,
+          "3": 3147,
+          "31": 3,
+          "33": 3,
+          "35": 1,
+          "37": 2,
+          "39": 1,
+          "4": 650,
+          "5": 184,
+          "52": 1,
+          "55": 1,
+          "58": 1,
+          "6": 72,
+          "62": 0,
+          "7": 48,
+          "8": 26,
+          "9": 19
+        }
+      },
+      "STS_NUMBER_OF_PENDING_EVENTS_IN_THE_LAST_CYCLE": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          2000
+        ],
+        "sum": 2,
+        "values": {
+          "1": 0,
+          "2": 1,
+          "3": 0
+        }
+      },
+      "STS_POLL_AND_EVENTS_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 77521,
+        "values": {
+          "0": 27522,
+          "1": 774,
+          "10": 380,
+          "11": 173,
+          "110": 1,
+          "115": 1,
+          "118": 1,
+          "12": 181,
+          "13": 229,
+          "14": 215,
+          "148": 1,
+          "15": 177,
+          "153": 1,
+          "155": 2,
+          "16": 134,
+          "164": 1,
+          "166": 1,
+          "17": 143,
+          "18": 129,
+          "19": 107,
+          "2": 1040,
+          "20": 91,
+          "205": 1,
+          "206": 0,
+          "21": 66,
+          "22": 57,
+          "23": 55,
+          "24": 31,
+          "25": 54,
+          "26": 47,
+          "27": 39,
+          "28": 33,
+          "29": 33,
+          "3": 934,
+          "30": 29,
+          "31": 14,
+          "32": 18,
+          "33": 19,
+          "34": 11,
+          "35": 13,
+          "36": 16,
+          "37": 9,
+          "38": 6,
+          "39": 15,
+          "4": 529,
+          "40": 8,
+          "41": 12,
+          "42": 13,
+          "43": 4,
+          "44": 12,
+          "45": 9,
+          "46": 9,
+          "47": 10,
+          "48": 8,
+          "49": 8,
+          "5": 307,
+          "50": 8,
+          "51": 8,
+          "52": 4,
+          "54": 4,
+          "55": 4,
+          "56": 4,
+          "57": 5,
+          "58": 2,
+          "59": 3,
+          "6": 347,
+          "61": 1,
+          "62": 3,
+          "63": 1,
+          "64": 4,
+          "65": 2,
+          "67": 1,
+          "68": 1,
+          "69": 2,
+          "7": 581,
+          "70": 3,
+          "71": 1,
+          "74": 1,
+          "75": 2,
+          "78": 2,
+          "8": 484,
+          "81": 1,
+          "82": 1,
+          "83": 2,
+          "84": 1,
+          "85": 1,
+          "87": 2,
+          "9": 573,
+          "96": 2,
+          "97": 1,
+          "99": 1
+        }
+      },
+      "STS_POLL_AND_EVENT_THE_LAST_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "STS_POLL_BLOCK_TIME": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 38277641,
+        "values": {
+          "0": 65851,
+          "1": 4074,
+          "10": 164,
+          "100": 37,
+          "10005": 56,
+          "1006": 63,
+          "10077": 8,
+          "101": 32,
+          "1013": 27,
+          "10149": 10,
+          "102": 34,
+          "1020": 85,
+          "10222": 9,
+          "1027": 25,
+          "10295": 12,
+          "103": 32,
+          "1034": 23,
+          "10369": 8,
+          "104": 37,
+          "1041": 14,
+          "10443": 17,
+          "1048": 23,
+          "105": 27,
+          "10518": 9,
+          "1056": 18,
+          "10593": 6,
+          "106": 22,
+          "1064": 18,
+          "10669": 5,
+          "107": 30,
+          "1072": 23,
+          "10745": 13,
+          "108": 27,
+          "1080": 22,
+          "10822": 9,
+          "1088": 19,
+          "109": 26,
+          "10900": 6,
+          "1096": 22,
+          "10978": 7,
+          "11": 169,
+          "110": 36,
+          "1104": 36,
+          "11057": 7,
+          "111": 34,
+          "1112": 22,
+          "11136": 5,
+          "112": 42,
+          "1120": 78,
+          "11216": 9,
+          "1128": 32,
+          "11296": 7,
+          "113": 53,
+          "1136": 18,
+          "11377": 7,
+          "114": 46,
+          "1144": 29,
+          "11458": 10,
+          "115": 35,
+          "1152": 17,
+          "11540": 3,
+          "116": 41,
+          "1160": 22,
+          "11623": 15,
+          "1168": 24,
+          "117": 38,
+          "11706": 10,
+          "1176": 21,
+          "11790": 8,
+          "118": 40,
+          "1184": 23,
+          "11874": 6,
+          "119": 29,
+          "1192": 24,
+          "11959": 7,
+          "12": 153,
+          "120": 29,
+          "1201": 33,
+          "12045": 11,
+          "121": 21,
+          "1210": 27,
+          "12131": 14,
+          "1219": 37,
+          "122": 34,
+          "12218": 11,
+          "1228": 65,
+          "123": 34,
+          "12306": 5,
+          "1237": 27,
+          "12394": 2,
+          "124": 35,
+          "1246": 28,
+          "12483": 7,
+          "125": 28,
+          "1255": 26,
+          "12572": 5,
+          "126": 27,
+          "1264": 18,
+          "12662": 7,
+          "127": 29,
+          "1273": 20,
+          "12753": 6,
+          "128": 31,
+          "1282": 17,
+          "12844": 7,
+          "129": 28,
+          "1291": 28,
+          "12936": 8,
+          "13": 142,
+          "130": 32,
+          "1300": 27,
+          "13029": 2,
+          "1309": 26,
+          "131": 38,
+          "13122": 3,
+          "1318": 36,
+          "132": 26,
+          "13216": 2,
+          "1327": 88,
+          "133": 36,
+          "13311": 4,
+          "1337": 24,
+          "134": 32,
+          "13406": 4,
+          "1347": 27,
+          "135": 32,
+          "13502": 9,
+          "1357": 11,
+          "13599": 3,
+          "136": 32,
+          "1367": 24,
+          "13696": 3,
+          "137": 31,
+          "1377": 19,
+          "13794": 11,
+          "138": 29,
+          "1387": 21,
+          "13893": 3,
+          "139": 25,
+          "1397": 25,
+          "13993": 7,
+          "14": 173,
+          "140": 26,
+          "1407": 25,
+          "14093": 12,
+          "141": 25,
+          "1417": 24,
+          "14194": 5,
+          "142": 29,
+          "1427": 43,
+          "14296": 5,
+          "143": 22,
+          "1437": 21,
+          "14398": 10,
+          "144": 27,
+          "1447": 22,
+          "145": 30,
+          "14501": 5,
+          "1457": 17,
+          "146": 29,
+          "14605": 3,
+          "1467": 18,
+          "147": 31,
+          "14710": 6,
+          "1478": 19,
+          "148": 27,
+          "14815": 1,
+          "1489": 22,
+          "149": 48,
+          "14921": 19,
+          "15": 281,
+          "150": 26,
+          "1500": 25,
+          "15028": 2,
+          "151": 21,
+          "1511": 22,
+          "15136": 4,
+          "152": 29,
+          "1522": 37,
+          "15244": 4,
+          "153": 32,
+          "1533": 59,
+          "15353": 4,
+          "154": 27,
+          "1544": 28,
+          "15463": 8,
+          "155": 24,
+          "1555": 23,
+          "156": 21,
+          "1566": 20,
+          "15686": 4,
+          "157": 30,
+          "1577": 27,
+          "15798": 2,
+          "158": 19,
+          "1588": 14,
+          "159": 34,
+          "15911": 3,
+          "1599": 33,
+          "16": 800,
+          "160": 39,
+          "16025": 3,
+          "161": 25,
+          "1610": 17,
+          "16140": 3,
+          "162": 32,
+          "1622": 24,
+          "163": 30,
+          "1634": 43,
+          "16372": 3,
+          "164": 36,
+          "1646": 24,
+          "16489": 6,
+          "165": 27,
+          "1658": 20,
+          "166": 21,
+          "16607": 3,
+          "167": 22,
+          "1670": 16,
+          "16726": 5,
+          "168": 32,
+          "1682": 18,
+          "16846": 6,
+          "169": 22,
+          "1694": 30,
+          "16967": 3,
+          "17": 577,
+          "170": 23,
+          "1706": 15,
+          "17089": 1,
+          "171": 19,
+          "1718": 26,
+          "172": 28,
+          "17211": 2,
+          "173": 26,
+          "1730": 51,
+          "17334": 1,
+          "174": 24,
+          "1742": 36,
+          "17458": 4,
+          "175": 28,
+          "1754": 22,
+          "17583": 3,
+          "176": 22,
+          "1767": 20,
+          "177": 24,
+          "17709": 4,
+          "178": 24,
+          "1780": 12,
+          "17836": 1,
+          "179": 24,
+          "1793": 17,
+          "17964": 1,
+          "18": 464,
+          "180": 25,
+          "1806": 18,
+          "18093": 3,
+          "181": 16,
+          "1819": 22,
+          "182": 26,
+          "18223": 3,
+          "183": 18,
+          "1832": 83,
+          "18353": 1,
+          "184": 23,
+          "1845": 49,
+          "18484": 2,
+          "185": 27,
+          "1858": 28,
+          "186": 18,
+          "18616": 3,
+          "187": 17,
+          "1871": 26,
+          "18749": 1,
+          "188": 16,
+          "1884": 16,
+          "18883": 1,
+          "189": 25,
+          "1897": 23,
+          "19": 452,
+          "190": 19,
+          "19018": 1,
+          "191": 19,
+          "1911": 16,
+          "192": 9,
+          "1925": 38,
+          "19291": 1,
+          "193": 19,
+          "1939": 38,
+          "194": 17,
+          "19429": 1,
+          "195": 15,
+          "1953": 16,
+          "19568": 1,
+          "196": 20,
+          "1967": 14,
+          "197": 16,
+          "19708": 2,
+          "198": 18,
+          "1981": 17,
+          "199": 57,
+          "1995": 45,
+          "2": 1614,
+          "20": 550,
+          "200": 14,
+          "2009": 19,
+          "201": 21,
+          "20134": 1,
+          "202": 22,
+          "2023": 22,
+          "203": 15,
+          "2037": 49,
+          "204": 20,
+          "205": 15,
+          "2052": 19,
+          "20569": 1,
+          "206": 21,
+          "2067": 25,
+          "207": 14,
+          "20716": 1,
+          "208": 21,
+          "2082": 21,
+          "20864": 2,
+          "209": 29,
+          "2097": 22,
+          "21": 331,
+          "21013": 1,
+          "211": 30,
+          "2112": 18,
+          "2127": 29,
+          "213": 27,
+          "2142": 63,
+          "215": 21,
+          "2157": 27,
+          "217": 19,
+          "2172": 21,
+          "2188": 26,
+          "219": 26,
+          "22": 89,
+          "2204": 17,
+          "221": 15,
+          "2220": 17,
+          "223": 15,
+          "2236": 23,
+          "225": 21,
+          "2252": 41,
+          "2268": 18,
+          "227": 13,
+          "22731": 1,
+          "2284": 19,
+          "229": 20,
+          "23": 80,
+          "2300": 16,
+          "231": 26,
+          "2316": 15,
+          "233": 30,
+          "2333": 36,
+          "23389": 2,
+          "235": 24,
+          "2350": 42,
+          "2367": 17,
+          "237": 17,
+          "2384": 23,
+          "239": 33,
+          "24": 62,
+          "2401": 13,
+          "241": 27,
+          "2418": 32,
+          "24239": 1,
+          "243": 21,
+          "2435": 22,
+          "245": 16,
+          "2452": 46,
+          "247": 24,
+          "2470": 25,
+          "24764": 1,
+          "2488": 22,
+          "249": 58,
+          "25": 77,
+          "2506": 21,
+          "251": 16,
+          "2524": 22,
+          "253": 20,
+          "25300": 1,
+          "2542": 39,
+          "255": 15,
+          "2560": 19,
+          "257": 22,
+          "2578": 14,
+          "25848": 1,
+          "259": 26,
+          "2596": 24,
+          "26": 90,
+          "261": 26,
+          "2615": 19,
+          "263": 22,
+          "2634": 27,
+          "26407": 1,
+          "265": 19,
+          "2653": 52,
+          "267": 20,
+          "2672": 25,
+          "269": 25,
+          "2691": 20,
+          "27": 113,
+          "271": 21,
+          "2710": 13,
+          "2729": 34,
+          "273": 13,
+          "2749": 71,
+          "275": 18,
+          "2769": 23,
+          "277": 11,
+          "2789": 21,
+          "279": 21,
+          "28": 104,
+          "2809": 20,
+          "281": 15,
+          "2829": 21,
+          "283": 16,
+          "2849": 42,
+          "285": 27,
+          "2869": 27,
+          "287": 20,
+          "28768": 1,
+          "289": 21,
+          "2890": 25,
+          "29": 82,
+          "291": 27,
+          "2911": 20,
+          "293": 24,
+          "2932": 20,
+          "295": 19,
+          "2953": 43,
+          "297": 22,
+          "2974": 21,
+          "299": 48,
+          "2995": 39,
+          "3": 1089,
+          "30": 97,
+          "301": 9,
+          "3016": 37,
+          "303": 25,
+          "3038": 30,
+          "305": 34,
+          "3060": 57,
+          "307": 30,
+          "3082": 25,
+          "309": 18,
+          "31": 72,
+          "3104": 18,
+          "311": 18,
+          "3126": 15,
+          "313": 16,
+          "3148": 25,
+          "315": 11,
+          "317": 15,
+          "3171": 36,
+          "319": 18,
+          "3194": 21,
+          "32": 80,
+          "321": 24,
+          "3217": 26,
+          "323": 21,
+          "3240": 28,
+          "325": 16,
+          "3263": 47,
+          "327": 9,
+          "3286": 22,
+          "329": 15,
+          "33": 70,
+          "331": 19,
+          "3310": 26,
+          "333": 13,
+          "3334": 19,
+          "335": 16,
+          "3358": 36,
+          "337": 13,
+          "3382": 24,
+          "339": 18,
+          "33901": 1,
+          "34": 109,
+          "3406": 18,
+          "341": 20,
+          "34144": 0,
+          "343": 24,
+          "3430": 23,
+          "345": 18,
+          "3455": 26,
+          "347": 18,
+          "3480": 31,
+          "349": 33,
+          "35": 96,
+          "3505": 21,
+          "352": 20,
+          "3530": 19,
+          "355": 25,
+          "3555": 24,
+          "358": 23,
+          "3580": 35,
+          "36": 94,
+          "3606": 17,
+          "361": 28,
+          "3632": 27,
+          "364": 31,
+          "3658": 18,
+          "367": 24,
+          "3684": 51,
+          "37": 120,
+          "370": 24,
+          "3710": 26,
+          "373": 24,
+          "3737": 21,
+          "376": 20,
+          "3764": 34,
+          "379": 22,
+          "3791": 26,
+          "38": 155,
+          "3818": 23,
+          "382": 29,
+          "3845": 23,
+          "385": 24,
+          "3873": 34,
+          "388": 20,
+          "39": 225,
+          "3901": 25,
+          "391": 25,
+          "3929": 22,
+          "394": 27,
+          "3957": 15,
+          "397": 56,
+          "3985": 48,
+          "4": 959,
+          "40": 185,
+          "400": 44,
+          "4014": 18,
+          "403": 27,
+          "4043": 21,
+          "406": 36,
+          "4072": 36,
+          "409": 81,
+          "41": 122,
+          "4101": 23,
+          "412": 19,
+          "4130": 15,
+          "415": 27,
+          "4160": 29,
+          "418": 28,
+          "4190": 43,
+          "42": 92,
+          "421": 20,
+          "4220": 22,
+          "424": 24,
+          "4250": 16,
+          "427": 32,
+          "4280": 46,
+          "43": 94,
+          "430": 26,
+          "4311": 18,
+          "433": 21,
+          "4342": 9,
+          "436": 20,
+          "4373": 33,
+          "439": 23,
+          "44": 88,
+          "4404": 16,
+          "442": 19,
+          "4436": 18,
+          "445": 32,
+          "4468": 26,
+          "448": 45,
+          "45": 87,
+          "4500": 44,
+          "451": 23,
+          "4532": 10,
+          "454": 28,
+          "4564": 18,
+          "457": 28,
+          "4597": 38,
+          "46": 87,
+          "460": 20,
+          "463": 20,
+          "4630": 22,
+          "466": 21,
+          "4663": 18,
+          "469": 12,
+          "4696": 36,
+          "47": 93,
+          "472": 18,
+          "4730": 24,
+          "475": 32,
+          "4764": 21,
+          "478": 17,
+          "4798": 32,
+          "48": 86,
+          "481": 22,
+          "4832": 21,
+          "484": 17,
+          "4867": 30,
+          "487": 17,
+          "49": 299,
+          "490": 29,
+          "4902": 34,
+          "4937": 14,
+          "494": 28,
+          "4972": 27,
+          "498": 41,
+          "5": 832,
+          "50": 97,
+          "5008": 24,
+          "502": 42,
+          "5044": 21,
+          "506": 35,
+          "5080": 22,
+          "51": 107,
+          "510": 110,
+          "5116": 22,
+          "514": 30,
+          "5153": 11,
+          "518": 27,
+          "5190": 33,
+          "52": 144,
+          "522": 16,
+          "5227": 21,
+          "526": 28,
+          "5264": 15,
+          "53": 139,
+          "530": 28,
+          "5302": 19,
+          "534": 33,
+          "5340": 12,
+          "5378": 10,
+          "538": 22,
+          "54": 123,
+          "5417": 20,
+          "542": 19,
+          "5456": 23,
+          "546": 31,
+          "5495": 36,
+          "55": 112,
+          "550": 22,
+          "5534": 14,
+          "554": 23,
+          "5574": 18,
+          "558": 23,
+          "56": 98,
+          "5614": 40,
+          "562": 22,
+          "5654": 15,
+          "566": 25,
+          "5694": 22,
+          "57": 116,
+          "570": 22,
+          "5735": 24,
+          "574": 24,
+          "5776": 16,
+          "578": 28,
+          "58": 105,
+          "5817": 26,
+          "582": 31,
+          "5859": 15,
+          "586": 22,
+          "59": 129,
+          "590": 29,
+          "5901": 31,
+          "594": 27,
+          "5943": 16,
+          "598": 39,
+          "5986": 15,
+          "6": 748,
+          "60": 115,
+          "602": 31,
+          "6029": 20,
+          "606": 32,
+          "6072": 16,
+          "61": 104,
+          "610": 49,
+          "6115": 28,
+          "614": 68,
+          "6159": 10,
+          "618": 27,
+          "62": 95,
+          "6203": 23,
+          "622": 15,
+          "6247": 19,
+          "626": 24,
+          "6292": 9,
+          "63": 77,
+          "630": 19,
+          "6337": 22,
+          "635": 23,
+          "6382": 14,
+          "64": 75,
+          "640": 29,
+          "6428": 30,
+          "645": 21,
+          "6474": 16,
+          "65": 75,
+          "650": 31,
+          "6520": 18,
+          "655": 30,
+          "6567": 19,
+          "66": 68,
+          "660": 13,
+          "6614": 12,
+          "665": 15,
+          "6661": 8,
+          "67": 64,
+          "670": 24,
+          "6709": 21,
+          "675": 22,
+          "6757": 18,
+          "68": 61,
+          "680": 25,
+          "6805": 14,
+          "685": 22,
+          "6854": 12,
+          "69": 56,
+          "690": 30,
+          "6903": 27,
+          "695": 33,
+          "6952": 12,
+          "7": 452,
+          "70": 53,
+          "700": 33,
+          "7002": 13,
+          "705": 31,
+          "7052": 23,
+          "71": 43,
+          "710": 37,
+          "7103": 11,
+          "715": 80,
+          "7154": 18,
+          "72": 47,
+          "720": 18,
+          "7205": 12,
+          "725": 28,
+          "7257": 12,
+          "73": 48,
+          "730": 29,
+          "7309": 16,
+          "735": 16,
+          "7361": 21,
+          "74": 43,
+          "740": 22,
+          "7414": 11,
+          "745": 26,
+          "7467": 21,
+          "75": 53,
+          "750": 23,
+          "7520": 17,
+          "755": 26,
+          "7574": 9,
+          "76": 40,
+          "760": 17,
+          "7628": 27,
+          "765": 25,
+          "7683": 11,
+          "77": 48,
+          "770": 26,
+          "7738": 17,
+          "776": 26,
+          "7793": 10,
+          "78": 35,
+          "782": 31,
+          "7849": 18,
+          "788": 31,
+          "79": 44,
+          "7905": 10,
+          "794": 33,
+          "7962": 11,
+          "8": 312,
+          "80": 41,
+          "800": 28,
+          "8019": 7,
+          "806": 32,
+          "8076": 14,
+          "81": 55,
+          "812": 36,
+          "8134": 12,
+          "818": 97,
+          "8192": 9,
+          "82": 41,
+          "824": 29,
+          "8251": 16,
+          "83": 51,
+          "830": 27,
+          "8310": 11,
+          "836": 26,
+          "8370": 9,
+          "84": 65,
+          "842": 26,
+          "8430": 14,
+          "848": 24,
+          "8490": 13,
+          "85": 49,
+          "854": 26,
+          "8551": 18,
+          "86": 40,
+          "860": 20,
+          "8612": 12,
+          "866": 27,
+          "8674": 12,
+          "87": 52,
+          "872": 24,
+          "8736": 13,
+          "878": 28,
+          "8799": 16,
+          "88": 54,
+          "884": 24,
+          "8862": 19,
+          "89": 47,
+          "890": 28,
+          "8925": 9,
+          "896": 35,
+          "8989": 11,
+          "9": 218,
+          "90": 69,
+          "902": 31,
+          "9053": 18,
+          "908": 41,
+          "91": 47,
+          "9118": 4,
+          "915": 97,
+          "9183": 13,
+          "92": 47,
+          "922": 44,
+          "9249": 11,
+          "929": 37,
+          "93": 35,
+          "9315": 8,
+          "936": 26,
+          "9382": 11,
+          "94": 42,
+          "943": 44,
+          "9449": 3,
+          "95": 42,
+          "950": 36,
+          "9517": 14,
+          "957": 26,
+          "9585": 14,
+          "96": 43,
+          "964": 34,
+          "9654": 4,
+          "97": 43,
+          "971": 28,
+          "9723": 12,
+          "978": 71,
+          "9793": 9,
+          "98": 43,
+          "985": 72,
+          "9863": 11,
+          "99": 66,
+          "992": 38,
+          "9934": 61,
+          "999": 235
+        }
+      },
+      "STS_POLL_CYCLE": {
+        "bucket_count": 1000,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          60000
+        ],
+        "sum": 2734,
+        "values": {
+          "0": 103413,
+          "1": 408,
+          "10": 7,
+          "11": 7,
+          "12": 4,
+          "13": 6,
+          "14": 1,
+          "15": 2,
+          "16": 3,
+          "17": 4,
+          "18": 3,
+          "2": 165,
+          "21": 1,
+          "23": 1,
+          "27": 1,
+          "3": 91,
+          "32": 2,
+          "33": 6,
+          "34": 3,
+          "35": 1,
+          "4": 56,
+          "5": 37,
+          "6": 12,
+          "7": 13,
+          "8": 8,
+          "85": 1,
+          "86": 0,
+          "9": 5
+        }
+      },
+      "SUBJECT_PRINCIPAL_ACCESSED_WITHOUT_SCRIPT_ON_STACK": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK": {
+        "bucket_count": 50,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 5709,
+        "values": {
+          "0": 8,
+          "1": 2,
+          "2": 6,
+          "3": 2,
+          "39": 1,
+          "4": 1,
+          "5399": 1,
+          "6758": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK_FIRST": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          40000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "SYSTEM_FONT_FALLBACK_SCRIPT": {
+        "bucket_count": 111,
+        "histogram_type": 1,
+        "range": [
+          1,
+          110
+        ],
+        "sum": 572,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 14872,
+        "values": {
+          "25": 0,
+          "26": 22,
+          "27": 0
+        }
+      },
+      "TELEMETRY_ARCHIVE_CHECKING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_DIRECTORIES_COUNT": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTED_OLD_DIRS": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTED_OVER_QUOTA": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTING_DIRS_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_EVICTING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_OLDEST_DIRECTORY_AGE": {
+        "bucket_count": 12,
+        "histogram_type": 1,
+        "range": [
+          1,
+          13
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_SCAN_PING_COUNT": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_ARCHIVE_SESSION_PING_COUNT": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_ARCHIVE_SIZE_MB": {
+        "bucket_count": 60,
+        "histogram_type": 1,
+        "range": [
+          1,
+          300
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_COMPRESS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 6,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "TELEMETRY_MEMORY_REPORTER_MS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 284,
+        "values": {
+          "0": 3,
+          "1": 153,
+          "3": 10,
+          "9": 0
+        }
+      },
+      "TELEMETRY_PENDING_CHECKING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_EVICTING_OVER_QUOTA_MS": {
+        "bucket_count": 20,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          300000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_AGE": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          365
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_EVICTED_OVER_QUOTA": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          100000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "TELEMETRY_PENDING_PINGS_SIZE_MB": {
+        "bucket_count": 16,
+        "histogram_type": 1,
+        "range": [
+          1,
+          17
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TELEMETRY_PING": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 426,
+        "values": {
+          "1114": 0,
+          "154": 0,
+          "414": 1
+        }
+      },
+      "TELEMETRY_SEND": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 426,
+        "values": {
+          "1114": 0,
+          "154": 0,
+          "414": 1
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_LOAD": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_PARSE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_SAVE": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_SESSIONDATA_FAILED_VALIDATION": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_STRINGIFY": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 5,
+        "values": {
+          "1": 0,
+          "3": 1,
+          "8": 0
+        }
+      },
+      "TELEMETRY_SUCCESS": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "TELEMETRY_TEST_FLAG": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_TEST_RELEASE_OPTIN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TELEMETRY_TEST_RELEASE_OPTOUT": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "TOTAL_CONTENT_PAGE_LOAD_TIME": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          100,
+          30000
+        ],
+        "sum": 254,
+        "values": {
+          "227": 0,
+          "241": 1,
+          "255": 0
+        }
+      },
+      "TOTAL_COUNT_HIGH_ERRORS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          3000
+        ],
+        "sum": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "3": 0
+        }
+      },
+      "TRACKING_PROTECTION_ENABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TRACKING_PROTECTION_PBM_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "TRANSACTION_WAIT_TIME_HTTP": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 48061,
+        "values": {
+          "0": 388,
+          "1": 4,
+          "10": 46,
+          "100": 2,
+          "107": 6,
+          "1080": 1,
+          "11": 25,
+          "115": 8,
+          "1158": 0,
+          "12": 16,
+          "123": 6,
+          "13": 15,
+          "132": 9,
+          "14": 12,
+          "142": 4,
+          "15": 4,
+          "152": 6,
+          "16": 5,
+          "163": 5,
+          "17": 2,
+          "175": 1,
+          "18": 9,
+          "19": 6,
+          "2": 6,
+          "20": 2,
+          "202": 3,
+          "21": 6,
+          "217": 1,
+          "23": 8,
+          "233": 1,
+          "25": 7,
+          "268": 3,
+          "27": 4,
+          "287": 6,
+          "29": 5,
+          "3": 5,
+          "31": 7,
+          "33": 12,
+          "330": 5,
+          "35": 18,
+          "354": 7,
+          "38": 11,
+          "380": 7,
+          "4": 12,
+          "407": 7,
+          "41": 14,
+          "436": 3,
+          "44": 17,
+          "467": 3,
+          "47": 13,
+          "5": 10,
+          "50": 6,
+          "501": 2,
+          "537": 3,
+          "54": 12,
+          "576": 3,
+          "58": 11,
+          "6": 42,
+          "618": 1,
+          "62": 7,
+          "66": 4,
+          "663": 1,
+          "7": 38,
+          "71": 12,
+          "711": 2,
+          "76": 12,
+          "8": 20,
+          "81": 9,
+          "817": 2,
+          "87": 8,
+          "9": 27,
+          "93": 4,
+          "939": 2
+        }
+      },
+      "TRANSACTION_WAIT_TIME_SPDY": {
+        "bucket_count": 100,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 7088,
+        "values": {
+          "0": 3189,
+          "1": 1092,
+          "107": 1,
+          "11": 1,
+          "115": 1,
+          "12": 1,
+          "123": 1,
+          "15": 1,
+          "16": 2,
+          "163": 1,
+          "18": 2,
+          "19": 1,
+          "2": 460,
+          "20": 2,
+          "21": 2,
+          "23": 2,
+          "25": 2,
+          "29": 1,
+          "3": 315,
+          "308": 1,
+          "31": 2,
+          "33": 1,
+          "35": 9,
+          "38": 5,
+          "380": 1,
+          "4": 62,
+          "407": 0,
+          "41": 4,
+          "44": 4,
+          "47": 7,
+          "5": 5,
+          "50": 6,
+          "54": 3,
+          "58": 1,
+          "62": 2,
+          "7": 1,
+          "71": 3,
+          "8": 1,
+          "81": 1
+        }
+      },
+      "UPDATE_CHECK_CODE_NOTIFY": {
+        "bucket_count": 51,
+        "histogram_type": 1,
+        "range": [
+          1,
+          50
+        ],
+        "sum": 55,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 525,
+        "values": {
+          "10": 5,
+          "11": 0,
+          "4": 0,
+          "5": 1
+        }
+      },
+      "UPDATE_CHECK_NO_UPDATE_NOTIFY": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "UPDATE_DOWNLOAD_CODE_COMPLETE": {
+        "bucket_count": 51,
+        "histogram_type": 1,
+        "range": [
+          1,
+          50
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "UPDATE_LAST_NOTIFY_INTERVAL_DAYS_NOTIFY": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          180
+        ],
+        "sum": 0,
+        "values": {
+          "0": 6,
+          "1": 0
+        }
+      },
+      "UPDATE_PING_COUNT_NOTIFY": {
+        "bucket_count": 3,
+        "histogram_type": 4,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 6,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 6,
+        "values": {
+          "0": 6,
+          "1": 0
+        }
+      },
+      "UPDATE_STATE_CODE_COMPLETE_STAGE": {
+        "bucket_count": 21,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 7,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 49,
+        "values": {
+          "6": 0,
+          "7": 1,
+          "8": 0
+        }
+      },
+      "UPDATE_STATE_CODE_COMPLETE_STARTUP": {
+        "bucket_count": 21,
+        "histogram_type": 1,
+        "range": [
+          1,
+          20
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "URLCLASSIFIER_CL_CHECK_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 6,
+        "values": {
+          "0": 2168,
+          "1": 3,
+          "2": 1,
+          "4": 0
+        }
+      },
+      "URLCLASSIFIER_CL_UPDATE_TIME": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          20,
+          15000
+        ],
+        "sum": 2808,
+        "values": {
+          "1175": 0,
+          "153": 1,
+          "20": 0,
+          "33": 1,
+          "424": 1,
+          "55": 6,
+          "706": 1,
+          "92": 5
+        }
+      },
+      "URLCLASSIFIER_LC_COMPLETIONS": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          200
+        ],
+        "sum": 4,
+        "values": {
+          "0": 8,
+          "4": 1,
+          "8": 0
+        }
+      },
+      "URLCLASSIFIER_LC_PREFIXES": {
+        "bucket_count": 15,
+        "histogram_type": 1,
+        "range": [
+          1,
+          1500000
+        ],
+        "sum": 3406810,
+        "sum_squares_hi": 447,
+        "sum_squares_lo": 39363718,
+        "values": {
+          "0": 0,
+          "1": 4,
+          "461539": 3,
+          "576924": 2,
+          "692308": 0
+        }
+      },
+      "URLCLASSIFIER_LOOKUP_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          500
+        ],
+        "sum": 370,
+        "values": {
+          "0": 1728,
+          "1": 85,
+          "100": 1,
+          "2": 34,
+          "224": 0,
+          "4": 9
+        }
+      },
+      "URLCLASSIFIER_PS_CONSTRUCT_TIME": {
+        "bucket_count": 15,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          5000
+        ],
+        "sum": 91,
+        "values": {
+          "15": 2,
+          "2": 0,
+          "29": 0,
+          "4": 2,
+          "8": 5
+        }
+      },
+      "URLCLASSIFIER_PS_FALLOCATE_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {
+          "0": 9,
+          "1": 0
+        }
+      },
+      "URLCLASSIFIER_PS_FILELOAD_TIME": {
+        "bucket_count": 10,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          1000
+        ],
+        "sum": 0,
+        "values": {}
+      },
+      "URL_PATH_CONTAINS_EXCLAMATION_DOUBLE_SLASH": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 22078,
+          "1": 0
+        }
+      },
+      "URL_PATH_CONTAINS_EXCLAMATION_SLASH": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1878,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1878,
+        "values": {
+          "0": 20200,
+          "1": 1878,
+          "2": 0
+        }
+      },
+      "URL_PATH_ENDS_IN_EXCLAMATION": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 22078,
+          "1": 0
+        }
+      },
+      "USE_COUNTER2_DEPRECATED_GetPreventDefault_DOCUMENT": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 1,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 1,
+        "values": {
+          "0": 0,
+          "1": 1,
+          "2": 0
+        }
+      },
+      "VIDEO_ADOBE_GMP_DISAPPEARED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "VIDEO_CAN_CREATE_AAC_DECODER": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 3,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "VIDEO_CAN_CREATE_H264_DECODER": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 3,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 3,
+        "values": {
+          "0": 0,
+          "1": 3,
+          "2": 0
+        }
+      },
+      "VIDEO_EME_ADOBE_HIDDEN_REASON": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "VIDEO_EME_ADOBE_UNSUPPORTED_REASON": {
+        "bucket_count": 11,
+        "histogram_type": 1,
+        "range": [
+          1,
+          10
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "VIDEO_OPENH264_GMP_DISAPPEARED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "VIDEO_OPENH264_GMP_MISSING_FILES": {
+        "bucket_count": 5,
+        "histogram_type": 1,
+        "range": [
+          1,
+          4
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "WEAVE_CAN_FETCH_KEYS": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "WEAVE_CONFIGURED": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {}
+      },
+      "WEBSOCKETS_HANDSHAKE_TYPE": {
+        "bucket_count": 17,
+        "histogram_type": 1,
+        "range": [
+          1,
+          16
+        ],
+        "sum": 82,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 460,
+        "values": {
+          "3": 0,
+          "4": 4,
+          "6": 11,
+          "7": 0
+        }
+      },
+      "WORD_CACHE_HITS_CHROME": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 432068,
+        "values": {
+          "0": 0,
+          "1": 35471,
+          "11": 2217,
+          "13": 626,
+          "15": 998,
+          "18": 574,
+          "2": 5263,
+          "21": 792,
+          "25": 713,
+          "3": 4716,
+          "30": 254,
+          "35": 0,
+          "4": 9322,
+          "5": 5757,
+          "6": 9173,
+          "7": 8316,
+          "8": 2155,
+          "9": 7212
+        }
+      },
+      "WORD_CACHE_HITS_CONTENT": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 180509,
+        "values": {
+          "0": 0,
+          "1": 3003,
+          "11": 401,
+          "13": 182,
+          "15": 2699,
+          "18": 1474,
+          "2": 4871,
+          "21": 931,
+          "25": 786,
+          "3": 427,
+          "30": 453,
+          "35": 0,
+          "4": 83,
+          "5": 1705,
+          "6": 488,
+          "7": 159,
+          "8": 471,
+          "9": 1543
+        }
+      },
+      "WORD_CACHE_MISSES_CHROME": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 60170,
+        "values": {
+          "0": 0,
+          "1": 1972,
+          "11": 302,
+          "13": 135,
+          "15": 202,
+          "18": 126,
+          "2": 603,
+          "21": 132,
+          "25": 178,
+          "3": 730,
+          "30": 99,
+          "35": 0,
+          "4": 972,
+          "5": 830,
+          "6": 911,
+          "7": 996,
+          "8": 439,
+          "9": 953
+        }
+      },
+      "WORD_CACHE_MISSES_CONTENT": {
+        "bucket_count": 30,
+        "histogram_type": 0,
+        "log_sum": 0,
+        "log_sum_squares": 0,
+        "range": [
+          1,
+          256
+        ],
+        "sum": 22966,
+        "values": {
+          "0": 0,
+          "1": 36,
+          "11": 63,
+          "13": 216,
+          "15": 375,
+          "18": 157,
+          "2": 125,
+          "21": 90,
+          "25": 23,
+          "3": 138,
+          "30": 11,
+          "35": 0,
+          "4": 249,
+          "5": 339,
+          "6": 157,
+          "7": 100,
+          "8": 72,
+          "9": 195
+        }
+      },
+      "XMLHTTPREQUEST_ASYNC_OR_SYNC": {
+        "bucket_count": 3,
+        "histogram_type": 2,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 248,
+          "1": 0
+        }
+      },
+      "XUL_CACHE_DISABLED": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      },
+      "YOUTUBE_EMBED_SEEN": {
+        "bucket_count": 3,
+        "histogram_type": 3,
+        "range": [
+          1,
+          2
+        ],
+        "sum": 0,
+        "sum_squares_hi": 0,
+        "sum_squares_lo": 0,
+        "values": {
+          "0": 1,
+          "1": 0
+        }
+      }
+    },
+    "processes": {
+      "parent": {
+        "scalars": {
+          "telemetry.test.unsigned_int_kind": 2,
+          "telemetry.test.string_kind": "I'm a cool test string.",
+          "telemetry.test.boolean_kind": true
+        },
+        "keyedScalars": {
+          "telemetry.test.keyed_unsigned_int": {
+            "search_enter": 1,
+            "some_key": 37
+          },
+          "telemetry.test.keyed_boolean_kind": {
+            "key1": false,
+            "key2": true
+          }
+        },
+        "events": [
+          [
+            12141232,
+            "navigation",
+            "search",
+            "searchbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ],
+          [
+            12144813,
+            "navigation",
+            "search",
+            "searchbar",
+            "oneoff",
+            {
+              "engine": "amazondotcom"
+            }
+          ],
+          [
+            12152377,
+            "navigation",
+            "search",
+            "urlbar",
+            "enter",
+            {
+              "engine": "google"
+            }
+          ]
+        ]
+      },
+      "content": {
+        "histograms": {
+          "A11Y_IATABLE_USAGE_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "A11Y_INSTANTIATED_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "A11Y_ISIMPLEDOM_USAGE_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CANVAS_2D_USED": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 113,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 113,
+            "values": {
+              "0": 0,
+              "1": 113,
+              "2": 0
+            }
+          },
+          "CHARSET_OVERRIDE_USED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CHECK_JAVA_ENABLED": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 8,
+              "1": 0
+            }
+          },
+          "COMPONENTS_SHIM_ACCESSED_BY_CONTENT": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CONTENT_DOCUMENTS_DESTROYED": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 347,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 347,
+            "values": {
+              "0": 347,
+              "1": 0
+            }
+          },
+          "CYCLE_COLLECTOR": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 297534,
+            "values": {
+              "1062": 1,
+              "114": 14,
+              "135": 18,
+              "14": 1,
+              "1500": 1,
+              "160": 13,
+              "190": 13,
+              "2117": 1,
+              "226": 13,
+              "2516": 1,
+              "268": 10,
+              "29": 124,
+              "2990": 0,
+              "3": 0,
+              "318": 9,
+              "34": 5791,
+              "378": 9,
+              "4": 13,
+              "40": 168,
+              "449": 4,
+              "48": 5,
+              "5": 7,
+              "533": 2,
+              "57": 20,
+              "633": 2,
+              "68": 206,
+              "752": 5,
+              "81": 4,
+              "96": 216
+            }
+          },
+          "CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 1147,
+            "values": {
+              "0": 136266,
+              "1": 273,
+              "10": 9,
+              "12": 3,
+              "17": 1,
+              "2": 88,
+              "24": 1,
+              "29": 0,
+              "3": 65,
+              "4": 33,
+              "5": 15,
+              "6": 5,
+              "7": 1,
+              "8": 10
+            }
+          },
+          "CYCLE_COLLECTOR_COLLECTED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              100000
+            ],
+            "sum": 5904304,
+            "values": {
+              "0": 5171,
+              "10": 22,
+              "100000": 5,
+              "10589": 14,
+              "1122": 14,
+              "119": 22,
+              "13": 8,
+              "13255": 15,
+              "1404": 31,
+              "149": 10,
+              "16": 9,
+              "16592": 21,
+              "1757": 19,
+              "186": 9,
+              "2": 42,
+              "20": 13,
+              "20769": 9,
+              "2199": 11,
+              "233": 24,
+              "25": 5,
+              "25997": 14,
+              "2753": 20,
+              "292": 61,
+              "3": 29,
+              "31": 7,
+              "32541": 4,
+              "3446": 13,
+              "365": 42,
+              "39": 15,
+              "4": 23,
+              "40733": 14,
+              "4313": 15,
+              "457": 154,
+              "49": 3,
+              "5": 1,
+              "50987": 9,
+              "5399": 14,
+              "572": 522,
+              "6": 60,
+              "61": 4,
+              "63822": 3,
+              "6758": 22,
+              "716": 71,
+              "76": 2,
+              "79889": 2,
+              "8": 13,
+              "8459": 17,
+              "896": 15,
+              "95": 28
+            }
+          },
+          "CYCLE_COLLECTOR_FINISH_IGC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 6670,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_FULL": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 297746,
+            "values": {
+              "1062": 1,
+              "114": 14,
+              "135": 18,
+              "14": 1,
+              "1500": 1,
+              "160": 14,
+              "190": 13,
+              "2117": 1,
+              "226": 13,
+              "2516": 1,
+              "268": 10,
+              "29": 121,
+              "2990": 0,
+              "3": 0,
+              "318": 9,
+              "34": 5791,
+              "378": 9,
+              "4": 13,
+              "40": 171,
+              "449": 4,
+              "48": 5,
+              "5": 7,
+              "533": 2,
+              "57": 18,
+              "633": 2,
+              "68": 207,
+              "752": 5,
+              "81": 4,
+              "96": 216
+            }
+          },
+          "CYCLE_COLLECTOR_MAX_PAUSE": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 44247,
+            "values": {
+              "10": 112,
+              "12": 11,
+              "135": 2,
+              "14": 7,
+              "160": 1,
+              "17": 5,
+              "2": 0,
+              "24": 1,
+              "268": 1,
+              "29": 1,
+              "3": 6,
+              "4": 131,
+              "5": 1480,
+              "57": 1,
+              "6": 2574,
+              "7": 1353,
+              "752": 1,
+              "8": 984,
+              "894": 0
+            }
+          },
+          "CYCLE_COLLECTOR_NEED_GC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 6670,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_OOM": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "CYCLE_COLLECTOR_SYNC_SKIPPABLE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 5,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 5,
+            "values": {
+              "0": 6666,
+              "1": 5,
+              "2": 0
+            }
+          },
+          "CYCLE_COLLECTOR_TIME_BETWEEN": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              120
+            ],
+            "sum": 40309,
+            "values": {
+              "14": 1,
+              "2": 0,
+              "3": 18,
+              "4": 15,
+              "45": 1,
+              "5": 27,
+              "57": 1,
+              "6": 6353,
+              "61": 0,
+              "7": 218,
+              "8": 27,
+              "9": 9
+            }
+          },
+          "CYCLE_COLLECTOR_VISITED_GCED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              300000
+            ],
+            "sum": 9692588,
+            "values": {
+              "0": 7,
+              "11508": 5,
+              "1204": 442,
+              "141361": 1,
+              "14789": 14,
+              "1547": 146,
+              "19005": 10,
+              "1988": 177,
+              "24423": 15,
+              "2555": 24,
+              "267": 65,
+              "300000": 2,
+              "31386": 5,
+              "3283": 27,
+              "343": 745,
+              "40334": 9,
+              "4219": 20,
+              "441": 1261,
+              "51833": 2,
+              "5422": 8,
+              "567": 309,
+              "66610": 3,
+              "6968": 23,
+              "729": 385,
+              "85599": 2,
+              "8955": 9,
+              "937": 2955
+            }
+          },
+          "CYCLE_COLLECTOR_VISITED_REF_COUNTED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              300000
+            ],
+            "sum": 19987661,
+            "values": {
+              "11508": 18,
+              "1204": 1182,
+              "14789": 25,
+              "1547": 562,
+              "19005": 5,
+              "1988": 137,
+              "24423": 8,
+              "2555": 2724,
+              "31386": 5,
+              "3283": 1696,
+              "343": 0,
+              "40334": 0,
+              "4219": 195,
+              "441": 2,
+              "5422": 48,
+              "567": 2,
+              "6968": 30,
+              "729": 2,
+              "8955": 29,
+              "937": 1
+            }
+          },
+          "CYCLE_COLLECTOR_WORKER_OOM": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_IBM866": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_ISO2022JP": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_ISO_8859_5": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_KOI8R": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_KOI8U": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACARABIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCROATIAN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACCYRILLIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACDEVANAGARI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACFARSI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGREEK": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGUJARATI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACGURMUKHI": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACHEBREW": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACICELANDIC": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACROMANIAN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DECODER_INSTANTIATED_MACTURKISH": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEFERRED_FINALIZE_ASYNC": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 344,
+            "values": {
+              "0": 1186,
+              "1": 13,
+              "2": 13,
+              "3": 5,
+              "4": 5,
+              "5": 54,
+              "6": 0
+            }
+          },
+          "DEVTOOLS_ABOUTDEBUGGING_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_ANIMATIONINSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_BROWSERCONSOLE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_CANVASDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_COMPUTEDVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_CUSTOM_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_DEVELOPERTOOLBAR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_FONTINSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_INSPECTOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSBROWSERDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSDEBUGGER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_JSPROFILER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_LAYOUTVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_MENU_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_NETMONITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_OPTIONS_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PAINTFLASHING_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PERFTOOLS_RECORDING_EXPORT_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PERFTOOLS_RECORDING_IMPORT_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_PICKER_EYEDROPPER_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_RESPONSIVE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_RULEVIEW_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_SCRATCHPAD_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_SHADEREDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_STORAGE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_STYLEEDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_TILT_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_TOOLBOX_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBAUDIOEDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBCONSOLE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_IMPORT_PROJECT_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_NEW_PROJECT_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_PROJECT_EDITOR_OPENED_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "DEVTOOLS_WEBIDE_PROJECT_EDITOR_SAVE_PER_USER_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_AUTOSTART": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "E10S_AUTOSTART_STATUS": {
+            "bucket_count": 7,
+            "histogram_type": 1,
+            "range": [
+              1,
+              6
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_BLOCKED_FROM_RUNNING": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "E10S_STILL_ACCEPTED_FROM_PROMPT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "ENABLE_PRIVILEGE_EVER_CALLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "FETCH_IS_MAINTHREAD": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "FIND_PLUGINS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0.6931471824645996,
+            "log_sum_squares": 0.4804530143737793,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "3": 0
+            }
+          },
+          "FLASH_PLUGIN_AREA": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              256,
+              16777216
+            ],
+            "sum": 144000,
+            "values": {
+              "32807": 0,
+              "41332": 3,
+              "52073": 0
+            }
+          },
+          "FLASH_PLUGIN_HEIGHT": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 600,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 120000,
+            "values": {
+              "126": 0,
+              "168": 3,
+              "209": 0
+            }
+          },
+          "FLASH_PLUGIN_STATES": {
+            "bucket_count": 21,
+            "histogram_type": 1,
+            "range": [
+              1,
+              20
+            ],
+            "sum": 24,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 192,
+            "values": {
+              "7": 0,
+              "8": 3,
+              "9": 0
+            }
+          },
+          "FLASH_PLUGIN_WIDTH": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 720,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 172800,
+            "values": {
+              "168": 0,
+              "209": 3,
+              "251": 0
+            }
+          },
+          "FONT_CACHE_HIT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 1965,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1965,
+            "values": {
+              "0": 865,
+              "1": 1965,
+              "2": 0
+            }
+          },
+          "FORGET_SKIPPABLE_MAX": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 122221,
+            "values": {
+              "10": 21,
+              "10000": 1,
+              "114": 1,
+              "12": 64,
+              "14": 596,
+              "17": 451,
+              "2": 0,
+              "20": 66,
+              "24": 4,
+              "29": 1,
+              "3": 776,
+              "4": 4498,
+              "5": 169,
+              "57": 1,
+              "6": 11,
+              "7": 5,
+              "8": 6
+            }
+          },
+          "FXA_CONFIGURED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "GC_ANIMATION_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 46725,
+            "values": {
+              "0": 7,
+              "1": 15,
+              "10": 1448,
+              "12": 35,
+              "135": 1,
+              "14": 134,
+              "160": 2,
+              "17": 156,
+              "190": 2,
+              "2": 9,
+              "20": 436,
+              "226": 1,
+              "24": 373,
+              "268": 1,
+              "29": 75,
+              "3": 8,
+              "34": 46,
+              "4": 9,
+              "40": 24,
+              "449": 1,
+              "48": 4,
+              "5": 16,
+              "533": 0,
+              "6": 16,
+              "68": 1,
+              "7": 15,
+              "8": 22,
+              "81": 2
+            }
+          },
+          "GC_BUDGET_MS": {
+            "bucket_count": 10,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 370890,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 13927100,
+            "values": {
+              "0": 0,
+              "1": 2859,
+              "13": 127,
+              "38": 8494,
+              "51": 0
+            }
+          },
+          "GC_INCREMENTAL_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1203,
+              "1": 0
+            }
+          },
+          "GC_IS_COMPARTMENTAL": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 18,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 18,
+            "values": {
+              "0": 1185,
+              "1": 18,
+              "2": 0
+            }
+          },
+          "GC_MARK_GRAY_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              200
+            ],
+            "sum": 14378,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 194858,
+            "values": {
+              "0": 4,
+              "1": 1,
+              "13": 200,
+              "18": 15,
+              "22": 9,
+              "26": 9,
+              "30": 8,
+              "34": 4,
+              "38": 2,
+              "5": 15,
+              "51": 1,
+              "55": 1,
+              "80": 1,
+              "84": 0,
+              "9": 933
+            }
+          },
+          "GC_MARK_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 250845,
+            "values": {
+              "114": 68,
+              "135": 170,
+              "160": 74,
+              "190": 466,
+              "226": 343,
+              "268": 40,
+              "318": 5,
+              "378": 14,
+              "40": 1,
+              "449": 6,
+              "5": 0,
+              "533": 2,
+              "57": 1,
+              "6": 1,
+              "633": 0,
+              "96": 12
+            }
+          },
+          "GC_MARK_ROOTS_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              200
+            ],
+            "sum": 9510,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 109020,
+            "values": {
+              "0": 0,
+              "1": 27,
+              "13": 33,
+              "138": 1,
+              "142": 0,
+              "18": 18,
+              "22": 10,
+              "26": 8,
+              "30": 2,
+              "34": 2,
+              "38": 1,
+              "5": 933,
+              "9": 168
+            }
+          },
+          "GC_MAX_PAUSE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 20643017,
+            "sum_squares_hi": 98652,
+            "sum_squares_lo": 40718323,
+            "values": {
+              "0": 0,
+              "1": 8,
+              "1000": 1,
+              "105": 1,
+              "147": 2,
+              "168": 3,
+              "188": 1,
+              "209": 1,
+              "22": 1000,
+              "230": 3,
+              "251": 2,
+              "272": 6,
+              "292": 7,
+              "313": 3,
+              "334": 2,
+              "376": 2,
+              "43": 138,
+              "521": 2,
+              "605": 1,
+              "63": 18,
+              "84": 2
+            }
+          },
+          "GC_MINOR_REASON": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 524628,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 23805526,
+            "values": {
+              "10": 1057,
+              "11": 230,
+              "12": 103,
+              "14": 17,
+              "16": 2,
+              "36": 1061,
+              "37": 2,
+              "42": 2,
+              "47": 8338,
+              "48": 1528,
+              "5": 0,
+              "52": 123,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_MINOR_REASON_LONG": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 36457,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1342071,
+            "values": {
+              "10": 598,
+              "11": 118,
+              "12": 94,
+              "14": 13,
+              "16": 1,
+              "36": 187,
+              "37": 1,
+              "42": 1,
+              "47": 332,
+              "48": 42,
+              "5": 0,
+              "52": 65,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_MINOR_US": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000000
+            ],
+            "sum": 7411559,
+            "values": {
+              "0": 1,
+              "1026": 251,
+              "10619": 3,
+              "114": 3,
+              "1168": 234,
+              "130": 21,
+              "1330": 157,
+              "148": 96,
+              "1514": 209,
+              "15678": 1,
+              "168": 280,
+              "1724": 107,
+              "17852": 1,
+              "191": 479,
+              "1963": 66,
+              "20328": 0,
+              "217": 826,
+              "2235": 65,
+              "247": 963,
+              "2545": 59,
+              "281": 1621,
+              "2898": 61,
+              "320": 2517,
+              "3300": 37,
+              "364": 1285,
+              "3758": 44,
+              "414": 597,
+              "4279": 30,
+              "471": 380,
+              "4872": 34,
+              "536": 411,
+              "5548": 19,
+              "610": 429,
+              "6317": 18,
+              "695": 437,
+              "7193": 10,
+              "791": 388,
+              "8190": 8,
+              "901": 322
+            }
+          },
+          "GC_MMU_50": {
+            "bucket_count": 20,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 18829,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 340167,
+            "values": {
+              "0": 118,
+              "1": 24,
+              "12": 108,
+              "18": 901,
+              "23": 3,
+              "29": 1,
+              "7": 47,
+              "73": 1,
+              "78": 0
+            }
+          },
+          "GC_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 20945376,
+            "values": {
+              "10000": 1,
+              "135": 1,
+              "14": 0,
+              "160": 30,
+              "17": 1,
+              "190": 193,
+              "226": 59,
+              "268": 500,
+              "318": 339,
+              "378": 37,
+              "449": 16,
+              "533": 17,
+              "633": 5,
+              "752": 2,
+              "96": 2
+            }
+          },
+          "GC_NON_INCREMENTAL": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 34,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 34,
+            "values": {
+              "0": 1169,
+              "1": 34,
+              "2": 0
+            }
+          },
+          "GC_REASON_2": {
+            "bucket_count": 101,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 529565,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24574529,
+            "values": {
+              "14": 17,
+              "16": 2,
+              "36": 1061,
+              "37": 3,
+              "42": 2,
+              "47": 8494,
+              "48": 1776,
+              "5": 0,
+              "52": 123,
+              "53": 0,
+              "6": 7
+            }
+          },
+          "GC_RESET": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 11483,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "GC_SCC_SWEEP_MAX_PAUSE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 3744,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 14814,
+            "values": {
+              "0": 3,
+              "1": 1194,
+              "11": 5,
+              "22": 1,
+              "32": 0
+            }
+          },
+          "GC_SCC_SWEEP_TOTAL_MS": {
+            "bucket_count": 50,
+            "histogram_type": 1,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 10657,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 132547,
+            "values": {
+              "0": 2,
+              "1": 984,
+              "105": 0,
+              "11": 184,
+              "22": 23,
+              "32": 5,
+              "43": 2,
+              "74": 2,
+              "95": 1
+            }
+          },
+          "GC_SLICE_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 20943254,
+            "values": {
+              "0": 24,
+              "1": 42,
+              "10": 1564,
+              "10000": 1,
+              "114": 1,
+              "12": 142,
+              "135": 2,
+              "14": 241,
+              "160": 3,
+              "17": 278,
+              "190": 2,
+              "2": 32,
+              "20": 793,
+              "226": 5,
+              "24": 848,
+              "268": 13,
+              "29": 514,
+              "3": 37,
+              "318": 5,
+              "34": 349,
+              "378": 2,
+              "4": 62,
+              "40": 6149,
+              "449": 1,
+              "48": 65,
+              "5": 50,
+              "533": 2,
+              "57": 26,
+              "6": 47,
+              "68": 10,
+              "7": 51,
+              "8": 121,
+              "81": 2,
+              "96": 1
+            }
+          },
+          "GC_SLOW_PHASE": {
+            "bucket_count": 76,
+            "histogram_type": 1,
+            "range": [
+              1,
+              75
+            ],
+            "sum": 6046,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 39196,
+            "values": {
+              "2": 0,
+              "3": 45,
+              "46": 1,
+              "47": 0,
+              "6": 895,
+              "9": 55
+            }
+          },
+          "GC_SWEEP_MS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 83018,
+            "values": {
+              "0": 2,
+              "114": 31,
+              "135": 10,
+              "160": 6,
+              "17": 1,
+              "226": 1,
+              "268": 2,
+              "29": 1,
+              "3": 1,
+              "34": 1,
+              "40": 55,
+              "48": 171,
+              "533": 1,
+              "57": 492,
+              "633": 0,
+              "68": 318,
+              "81": 69,
+              "96": 41
+            }
+          },
+          "GEOLOCATION_ERROR": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "GHOST_WINDOWS": {
+            "bucket_count": 32,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              128
+            ],
+            "sum": 0,
+            "values": {
+              "0": 702,
+              "1": 0
+            }
+          },
+          "GRADIENT_DURATION": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              50000000
+            ],
+            "sum": 4451764,
+            "values": {
+              "1": 0,
+              "1056": 112,
+              "149": 1318,
+              "19895": 69,
+              "21": 2822,
+              "2810": 6,
+              "3": 15,
+              "397": 360,
+              "52939": 0,
+              "56": 9253,
+              "7477": 18,
+              "8": 395
+            }
+          },
+          "GRADIENT_RETENTION_TIME": {
+            "bucket_count": 20,
+            "histogram_type": 1,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 7969,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 63504961,
+            "values": {
+              "7223": 0,
+              "7778": 1,
+              "8334": 0
+            }
+          },
+          "HTML_FOREGROUND_REFLOW_MS_2": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 3415,
+            "values": {
+              "0": 25997,
+              "1": 842,
+              "13": 13,
+              "171": 1,
+              "2": 148,
+              "22": 4,
+              "284": 0,
+              "3": 117,
+              "37": 1,
+              "5": 57,
+              "62": 2,
+              "8": 74
+            }
+          },
+          "HTTP_CONTENT_ENCODING": {
+            "bucket_count": 7,
+            "histogram_type": 1,
+            "range": [
+              1,
+              6
+            ],
+            "sum": 4677,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4683,
+            "values": {
+              "0": 0,
+              "1": 4674,
+              "3": 1,
+              "4": 0
+            }
+          },
+          "HTTP_PAGE_COMPLETE_LOAD_NET_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 723.1046214103699,
+            "log_sum_squares": 3904.6454129219055,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 43641,
+            "values": {
+              "1023": 2,
+              "11": 0,
+              "115": 12,
+              "13": 2,
+              "140": 11,
+              "1522": 1,
+              "171": 6,
+              "1857": 2,
+              "20": 1,
+              "209": 11,
+              "24": 3,
+              "255": 13,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 2,
+              "379": 4,
+              "4111": 0,
+              "43": 3,
+              "462": 4,
+              "52": 1,
+              "564": 9,
+              "63": 15,
+              "688": 4,
+              "77": 12,
+              "839": 4,
+              "94": 8
+            }
+          },
+          "HTTP_PAGE_COMPLETE_LOAD_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 723.1046214103699,
+            "log_sum_squares": 3904.6454129219055,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 43641,
+            "values": {
+              "1023": 2,
+              "11": 0,
+              "115": 12,
+              "13": 2,
+              "140": 11,
+              "1522": 1,
+              "171": 6,
+              "1857": 2,
+              "20": 1,
+              "209": 11,
+              "24": 3,
+              "255": 13,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 2,
+              "379": 4,
+              "4111": 0,
+              "43": 3,
+              "462": 4,
+              "52": 1,
+              "564": 9,
+              "63": 15,
+              "688": 4,
+              "77": 12,
+              "839": 4,
+              "94": 8
+            }
+          },
+          "HTTP_PAGE_DNS_ISSUE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 28.51285696029663,
+            "log_sum_squares": 45.067949295043945,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 77,
+            "values": {
+              "0": 105,
+              "1": 8,
+              "11": 1,
+              "13": 1,
+              "16": 0,
+              "2": 4,
+              "3": 2,
+              "4": 4,
+              "7": 2
+            }
+          },
+          "HTTP_PAGE_DNS_LOOKUP_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 140.3366141319275,
+            "log_sum_squares": 561.517746925354,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 3100,
+            "values": {
+              "0": 87,
+              "1": 2,
+              "11": 3,
+              "13": 1,
+              "16": 1,
+              "20": 1,
+              "24": 1,
+              "29": 3,
+              "3": 1,
+              "311": 1,
+              "35": 4,
+              "379": 2,
+              "4": 3,
+              "43": 4,
+              "52": 5,
+              "564": 1,
+              "63": 5,
+              "688": 0,
+              "77": 1,
+              "9": 1
+            }
+          },
+          "HTTP_PAGE_FIRST_SENT_TO_LAST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 683.3113679885864,
+            "log_sum_squares": 3522.5544171333313,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 35602,
+            "values": {
+              "1023": 1,
+              "115": 17,
+              "13": 4,
+              "140": 7,
+              "1522": 1,
+              "171": 7,
+              "1857": 1,
+              "20": 5,
+              "209": 5,
+              "24": 4,
+              "255": 8,
+              "311": 5,
+              "3370": 1,
+              "35": 4,
+              "379": 3,
+              "4111": 0,
+              "43": 2,
+              "462": 5,
+              "52": 4,
+              "564": 6,
+              "63": 17,
+              "688": 4,
+              "7": 0,
+              "77": 11,
+              "839": 3,
+              "9": 1,
+              "94": 13
+            }
+          },
+          "HTTP_PAGE_OPEN_TO_FIRST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 704.9309685230255,
+            "log_sum_squares": 3702.2162618637085,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 37618,
+            "values": {
+              "1023": 1,
+              "11": 1,
+              "115": 19,
+              "13": 1,
+              "140": 16,
+              "1522": 1,
+              "16": 1,
+              "171": 8,
+              "1857": 2,
+              "209": 9,
+              "24": 3,
+              "255": 10,
+              "29": 1,
+              "311": 7,
+              "3370": 1,
+              "35": 3,
+              "379": 3,
+              "4111": 0,
+              "43": 2,
+              "462": 2,
+              "52": 1,
+              "564": 7,
+              "63": 17,
+              "688": 4,
+              "77": 11,
+              "839": 1,
+              "9": 0,
+              "94": 7
+            }
+          },
+          "HTTP_PAGE_OPEN_TO_FIRST_SENT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 324.95460772514343,
+            "log_sum_squares": 1228.9125940799713,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 7960,
+            "values": {
+              "0": 28,
+              "1": 8,
+              "11": 2,
+              "115": 7,
+              "1248": 1,
+              "13": 5,
+              "140": 1,
+              "1522": 0,
+              "16": 7,
+              "171": 2,
+              "2": 3,
+              "20": 3,
+              "209": 2,
+              "24": 1,
+              "255": 2,
+              "29": 2,
+              "3": 9,
+              "35": 3,
+              "379": 1,
+              "4": 15,
+              "43": 3,
+              "462": 1,
+              "5": 7,
+              "52": 8,
+              "564": 2,
+              "6": 4,
+              "63": 2,
+              "7": 4,
+              "77": 4,
+              "9": 1,
+              "94": 1
+            }
+          },
+          "HTTP_PAGE_TCP_CONNECTION": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 2.079441547393799,
+            "log_sum_squares": 4.324077129364014,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 7,
+            "values": {
+              "6": 0,
+              "7": 1,
+              "9": 0
+            }
+          },
+          "HTTP_REQUEST_PER_PAGE": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 364.44632732868195,
+            "log_sum_squares": 814.5372350215912,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 1687,
+            "values": {
+              "0": 5,
+              "1": 40,
+              "10": 5,
+              "11": 3,
+              "12": 3,
+              "14": 4,
+              "16": 13,
+              "18": 4,
+              "2": 36,
+              "20": 12,
+              "23": 1,
+              "26": 1,
+              "29": 2,
+              "3": 8,
+              "33": 5,
+              "37": 2,
+              "4": 28,
+              "47": 1,
+              "5": 7,
+              "6": 13,
+              "7": 8,
+              "8": 6,
+              "84": 1,
+              "9": 1,
+              "95": 0
+            }
+          },
+          "HTTP_REQUEST_PER_PAGE_FROM_CACHE": {
+            "bucket_count": 102,
+            "histogram_type": 1,
+            "range": [
+              1,
+              101
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 204,
+              "1": 0
+            }
+          },
+          "HTTP_SUBITEM_FIRST_BYTE_LATENCY_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 4616.2988312244415,
+            "log_sum_squares": 29666.51225376129,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5230826,
+            "values": {
+              "1023": 49,
+              "11": 0,
+              "11106": 2,
+              "115": 29,
+              "1248": 31,
+              "13": 2,
+              "140": 28,
+              "1522": 23,
+              "171": 39,
+              "1857": 14,
+              "20": 1,
+              "209": 32,
+              "2265": 13,
+              "24": 3,
+              "255": 36,
+              "2763": 10,
+              "29": 1,
+              "30000": 4,
+              "311": 41,
+              "3370": 7,
+              "35": 1,
+              "379": 87,
+              "43": 6,
+              "462": 56,
+              "5015": 2,
+              "52": 2,
+              "564": 48,
+              "6118": 9,
+              "63": 18,
+              "688": 69,
+              "7463": 1,
+              "77": 13,
+              "839": 52,
+              "94": 14
+            }
+          },
+          "HTTP_SUBITEM_OPEN_LATENCY_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 9152.890920162201,
+            "log_sum_squares": 57017.12989783287,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5842391,
+            "values": {
+              "0": 76,
+              "1": 56,
+              "1023": 49,
+              "11": 5,
+              "11106": 5,
+              "115": 23,
+              "1248": 42,
+              "13548": 1,
+              "140": 53,
+              "1522": 62,
+              "16": 8,
+              "171": 101,
+              "1857": 31,
+              "2": 39,
+              "20": 6,
+              "209": 69,
+              "2265": 17,
+              "24": 4,
+              "255": 120,
+              "2763": 9,
+              "29": 15,
+              "3": 7,
+              "30000": 4,
+              "311": 57,
+              "3370": 10,
+              "35": 49,
+              "379": 184,
+              "4": 5,
+              "4111": 1,
+              "43": 6,
+              "462": 110,
+              "5": 2,
+              "5015": 20,
+              "52": 11,
+              "564": 88,
+              "6": 2,
+              "6118": 21,
+              "63": 17,
+              "688": 114,
+              "7": 4,
+              "77": 31,
+              "839": 110,
+              "9": 5,
+              "94": 38
+            }
+          },
+          "HTTP_SUB_COMPLETE_LOAD_NET_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3341.598597764969,
+            "log_sum_squares": 15924.448185920715,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 126848,
+            "values": {
+              "1023": 3,
+              "11": 7,
+              "115": 52,
+              "13": 12,
+              "140": 40,
+              "1522": 2,
+              "16": 19,
+              "171": 31,
+              "1857": 3,
+              "20": 36,
+              "209": 19,
+              "24": 29,
+              "255": 31,
+              "29": 42,
+              "311": 24,
+              "3370": 1,
+              "35": 30,
+              "379": 23,
+              "4111": 0,
+              "43": 51,
+              "462": 16,
+              "52": 52,
+              "564": 11,
+              "6": 0,
+              "63": 64,
+              "688": 13,
+              "7": 8,
+              "77": 64,
+              "839": 14,
+              "9": 4,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_COMPLETE_LOAD_V2": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3341.598597764969,
+            "log_sum_squares": 15924.448185920715,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 126848,
+            "values": {
+              "1023": 3,
+              "11": 7,
+              "115": 52,
+              "13": 12,
+              "140": 40,
+              "1522": 2,
+              "16": 19,
+              "171": 31,
+              "1857": 3,
+              "20": 36,
+              "209": 19,
+              "24": 29,
+              "255": 31,
+              "29": 42,
+              "311": 24,
+              "3370": 1,
+              "35": 30,
+              "379": 23,
+              "4111": 0,
+              "43": 51,
+              "462": 16,
+              "52": 52,
+              "564": 11,
+              "6": 0,
+              "63": 64,
+              "688": 13,
+              "7": 8,
+              "77": 64,
+              "839": 14,
+              "9": 4,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_DNS_ISSUE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 362.8482222557068,
+            "log_sum_squares": 869.1513342857361,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 2486,
+            "values": {
+              "0": 380,
+              "1": 59,
+              "11": 2,
+              "13": 21,
+              "16": 35,
+              "2": 26,
+              "20": 1,
+              "209": 3,
+              "24": 4,
+              "29": 1,
+              "3": 18,
+              "311": 1,
+              "379": 0,
+              "4": 20,
+              "5": 3,
+              "6": 4,
+              "63": 1,
+              "7": 6
+            }
+          },
+          "HTTP_SUB_DNS_LOOKUP_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 375.6888391971588,
+            "log_sum_squares": 1165.4497253894806,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 5224,
+            "values": {
+              "0": 415,
+              "1": 38,
+              "11": 3,
+              "13": 1,
+              "16": 6,
+              "171": 2,
+              "2": 13,
+              "20": 2,
+              "24": 1,
+              "29": 5,
+              "3": 14,
+              "311": 1,
+              "35": 6,
+              "379": 3,
+              "4": 10,
+              "43": 6,
+              "5": 9,
+              "52": 8,
+              "564": 1,
+              "6": 8,
+              "63": 6,
+              "688": 0,
+              "7": 21,
+              "77": 3,
+              "9": 1,
+              "94": 2
+            }
+          },
+          "HTTP_SUB_FIRST_SENT_TO_LAST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3043.365156650543,
+            "log_sum_squares": 13596.140334129333,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 98996,
+            "values": {
+              "1023": 2,
+              "11": 28,
+              "115": 54,
+              "13": 36,
+              "140": 26,
+              "1522": 3,
+              "16": 26,
+              "171": 23,
+              "1857": 1,
+              "20": 37,
+              "209": 15,
+              "24": 28,
+              "255": 23,
+              "29": 25,
+              "311": 17,
+              "3370": 1,
+              "35": 50,
+              "379": 18,
+              "4111": 0,
+              "43": 51,
+              "462": 15,
+              "5": 0,
+              "52": 42,
+              "564": 7,
+              "6": 20,
+              "63": 50,
+              "688": 8,
+              "7": 23,
+              "77": 47,
+              "839": 9,
+              "9": 25,
+              "94": 32
+            }
+          },
+          "HTTP_SUB_OPEN_TO_FIRST_RECEIVED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3251.081452727318,
+            "log_sum_squares": 15134.920769453049,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 112572,
+            "values": {
+              "1023": 2,
+              "11": 12,
+              "115": 60,
+              "13": 12,
+              "140": 37,
+              "1522": 3,
+              "16": 24,
+              "171": 31,
+              "1857": 2,
+              "20": 37,
+              "209": 22,
+              "24": 33,
+              "255": 26,
+              "29": 41,
+              "311": 24,
+              "3370": 1,
+              "35": 40,
+              "379": 22,
+              "4": 0,
+              "4111": 0,
+              "43": 47,
+              "462": 12,
+              "5": 1,
+              "52": 45,
+              "564": 8,
+              "6": 3,
+              "63": 69,
+              "688": 8,
+              "7": 13,
+              "77": 50,
+              "839": 10,
+              "9": 6,
+              "94": 41
+            }
+          },
+          "HTTP_SUB_OPEN_TO_FIRST_SENT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 1550.930715084076,
+            "log_sum_squares": 5546.309858798981,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 27455,
+            "values": {
+              "0": 195,
+              "1": 48,
+              "11": 23,
+              "115": 18,
+              "1248": 1,
+              "13": 28,
+              "140": 4,
+              "1522": 0,
+              "16": 30,
+              "171": 9,
+              "2": 16,
+              "20": 27,
+              "209": 9,
+              "24": 16,
+              "255": 8,
+              "29": 15,
+              "3": 51,
+              "311": 6,
+              "35": 11,
+              "379": 3,
+              "4": 38,
+              "43": 18,
+              "462": 3,
+              "5": 24,
+              "52": 21,
+              "564": 2,
+              "6": 26,
+              "63": 21,
+              "7": 21,
+              "77": 17,
+              "9": 15,
+              "94": 18
+            }
+          },
+          "HTTP_SUB_TCP_CONNECTION": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 49.86611020565033,
+            "log_sum_squares": 178.6136667728424,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 638,
+            "values": {
+              "115": 0,
+              "29": 2,
+              "3": 0,
+              "35": 1,
+              "4": 2,
+              "5": 3,
+              "6": 1,
+              "63": 4,
+              "7": 1,
+              "77": 1,
+              "94": 1
+            }
+          },
+          "IMAGE_DECODE_CHUNKS": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 1952,
+            "values": {
+              "0": 0,
+              "1": 1584,
+              "11": 1,
+              "111": 1,
+              "123": 0,
+              "2": 14,
+              "3": 5,
+              "4": 4,
+              "40": 1,
+              "5": 1,
+              "60": 1,
+              "66": 1,
+              "8": 1
+            }
+          },
+          "IMAGE_DECODE_COUNT": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              500
+            ],
+            "sum": 1617,
+            "values": {
+              "0": 301,
+              "1": 623,
+              "12": 2,
+              "13": 1,
+              "14": 10,
+              "16": 3,
+              "18": 1,
+              "2": 88,
+              "20": 2,
+              "22": 1,
+              "27": 1,
+              "3": 15,
+              "30": 1,
+              "33": 1,
+              "4": 11,
+              "40": 1,
+              "44": 1,
+              "5": 5,
+              "6": 7,
+              "66": 1,
+              "7": 9,
+              "73": 0,
+              "8": 4
+            }
+          },
+          "IMAGE_DECODE_ON_DRAW_LATENCY": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              50,
+              50000000
+            ],
+            "sum": 411042409,
+            "values": {
+              "0": 2,
+              "101216": 3,
+              "102": 1,
+              "10610": 5,
+              "1112": 2,
+              "116539": 1,
+              "117": 1,
+              "12216": 10,
+              "1280": 14,
+              "134181": 3,
+              "135": 2,
+              "14065": 27,
+              "1473830": 1,
+              "1474": 5,
+              "155": 3,
+              "16194": 45,
+              "1697": 7,
+              "177882": 1,
+              "178": 1,
+              "18646": 15,
+              "1954": 1,
+              "21469": 15,
+              "2250": 3,
+              "236": 1,
+              "24719": 14,
+              "2591": 4,
+              "28461": 18,
+              "2983": 2,
+              "312620": 1,
+              "313": 2,
+              "32770": 22,
+              "3435": 4,
+              "359946": 1,
+              "360": 1,
+              "37731": 34,
+              "3953609": 1,
+              "3955": 4,
+              "414437": 1,
+              "43443": 46,
+              "4554": 6,
+              "50000000": 1,
+              "50020": 28,
+              "5243": 4,
+              "549415": 1,
+              "550": 1,
+              "57592": 36,
+              "6037": 3,
+              "632589": 1,
+              "633": 9,
+              "66311": 26,
+              "6951": 2,
+              "729": 6,
+              "76350": 17,
+              "77": 1,
+              "8003": 2,
+              "839": 1,
+              "87908": 9,
+              "9215": 3,
+              "965572": 1,
+              "966": 2
+            }
+          },
+          "IMAGE_DECODE_SPEED_GIF": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 2471648,
+            "values": {
+              "0": 0,
+              "1027": 11,
+              "11306": 1,
+              "1305": 14,
+              "14370": 3,
+              "1659": 9,
+              "18265": 8,
+              "2109": 13,
+              "23216": 4,
+              "2681": 45,
+              "29509": 7,
+              "3408": 20,
+              "37507": 7,
+              "4332": 4,
+              "47673": 9,
+              "500": 2,
+              "5506": 1,
+              "60595": 6,
+              "636": 3,
+              "6998": 6,
+              "77019": 4,
+              "808": 5,
+              "8895": 1,
+              "97895": 0
+            }
+          },
+          "IMAGE_DECODE_SPEED_JPEG": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 4775122,
+            "values": {
+              "1027": 2,
+              "11306": 62,
+              "1305": 2,
+              "14370": 48,
+              "1659": 1,
+              "18265": 23,
+              "201023": 3,
+              "2109": 4,
+              "23216": 14,
+              "255510": 0,
+              "2681": 3,
+              "29509": 6,
+              "3408": 12,
+              "37507": 1,
+              "4332": 19,
+              "5506": 41,
+              "6998": 51,
+              "808": 0,
+              "8895": 50,
+              "97895": 1
+            }
+          },
+          "IMAGE_DECODE_SPEED_PNG": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              500,
+              50000000
+            ],
+            "sum": 8616699,
+            "values": {
+              "0": 5,
+              "1027": 20,
+              "11306": 80,
+              "1305": 17,
+              "14370": 58,
+              "1659": 38,
+              "18265": 36,
+              "2109": 59,
+              "23216": 19,
+              "2681": 80,
+              "29509": 12,
+              "3408": 82,
+              "37507": 4,
+              "4332": 100,
+              "47673": 0,
+              "500": 4,
+              "5506": 153,
+              "636": 5,
+              "6998": 200,
+              "808": 13,
+              "8895": 101
+            }
+          },
+          "IMAGE_DECODE_TIME": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              50,
+              50000000
+            ],
+            "sum": 1785143,
+            "values": {
+              "0": 581,
+              "102": 34,
+              "10610": 8,
+              "1112": 22,
+              "117": 27,
+              "12216": 6,
+              "1280": 16,
+              "134181": 1,
+              "135": 21,
+              "14065": 19,
+              "1474": 17,
+              "154494": 0,
+              "155": 33,
+              "16194": 3,
+              "1697": 17,
+              "178": 21,
+              "18646": 5,
+              "1954": 13,
+              "205": 17,
+              "21469": 3,
+              "2250": 9,
+              "236": 37,
+              "2591": 8,
+              "272": 30,
+              "28461": 4,
+              "2983": 4,
+              "313": 41,
+              "3435": 3,
+              "360": 48,
+              "3955": 4,
+              "415": 61,
+              "4554": 1,
+              "478": 51,
+              "50": 45,
+              "5243": 3,
+              "550": 72,
+              "58": 42,
+              "6037": 6,
+              "633": 44,
+              "67": 34,
+              "6951": 2,
+              "729": 50,
+              "77": 31,
+              "8003": 14,
+              "839": 33,
+              "89": 31,
+              "9215": 9,
+              "966": 33
+            }
+          },
+          "IMAGE_MAX_DECODE_COUNT": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              10000
+            ],
+            "sum": 70,
+            "values": {
+              "63": 0,
+              "68": 1,
+              "74": 0
+            }
+          },
+          "INNERWINDOWS_WITH_MUTATION_LISTENERS": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 776,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "LINK_ICON_SIZES_ATTR_DIMENSION": {
+            "bucket_count": 64,
+            "histogram_type": 1,
+            "range": [
+              1,
+              513
+            ],
+            "sum": 1008,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 349440,
+            "values": {
+              "1": 0,
+              "125": 1,
+              "249": 1,
+              "26": 1,
+              "505": 1,
+              "513": 0,
+              "59": 1,
+              "9": 1
+            }
+          },
+          "LINK_ICON_SIZES_ATTR_USAGE": {
+            "bucket_count": 5,
+            "histogram_type": 1,
+            "range": [
+              1,
+              4
+            ],
+            "sum": 12,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24,
+            "values": {
+              "0": 71,
+              "2": 6,
+              "3": 0
+            }
+          },
+          "LOCALDOMSTORAGE_GETVALUE_BLOCKING_MS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              3000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 9,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 9,
+            "values": {
+              "0": 12,
+              "1": 9,
+              "2": 0
+            }
+          },
+          "MAC_INITFONTLIST_TOTAL": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 2.7725887298583984,
+            "log_sum_squares": 7.687248229980469,
+            "range": [
+              1,
+              30000
+            ],
+            "sum": 15,
+            "values": {
+              "14": 1,
+              "4": 0,
+              "50": 0
+            }
+          },
+          "MASTER_PASSWORD_ENABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "MEMORY_HEAP_ALLOCATED": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 8809.515153884888,
+            "log_sum_squares": 110612.54148864746,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 206044098,
+            "values": {
+              "137661": 0,
+              "144576": 5,
+              "151838": 10,
+              "159465": 15,
+              "167475": 19,
+              "175887": 39,
+              "184722": 33,
+              "194001": 16,
+              "203746": 20,
+              "213980": 51,
+              "224728": 37,
+              "236016": 21,
+              "247871": 4,
+              "260322": 2,
+              "273398": 4,
+              "287131": 16,
+              "301554": 26,
+              "316701": 83,
+              "332609": 110,
+              "349316": 53,
+              "366862": 64,
+              "385290": 51,
+              "404644": 13,
+              "424970": 8,
+              "446317": 1,
+              "468736": 1,
+              "492281": 0
+            }
+          },
+          "MEMORY_HEAP_COMMITTED_UNUSED_RATIO": {
+            "bucket_count": 25,
+            "histogram_type": 1,
+            "range": [
+              1,
+              100
+            ],
+            "sum": 1738,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4628,
+            "values": {
+              "0": 0,
+              "1": 700,
+              "10": 0,
+              "5": 2
+            }
+          },
+          "MEMORY_IMAGES_CONTENT_USED_UNCOMPRESSED": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 4823.088839054108,
+            "log_sum_squares": 34751.68099427223,
+            "range": [
+              1024,
+              1048576
+            ],
+            "sum": 1657367,
+            "values": {
+              "0": 345,
+              "1024": 3,
+              "10317": 1,
+              "1183": 23,
+              "1367": 65,
+              "1579": 67,
+              "1824": 53,
+              "2107": 4,
+              "21240": 1,
+              "28353": 11,
+              "3249": 18,
+              "3754": 1,
+              "4337": 9,
+              "43728": 1,
+              "5011": 63,
+              "50522": 0,
+              "5790": 8,
+              "6690": 4,
+              "7729": 22,
+              "8930": 3
+            }
+          },
+          "MEMORY_JS_COMPARTMENTS_SYSTEM": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3860.0667686462402,
+            "log_sum_squares": 21225.674673080444,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 170897,
+            "values": {
+              "192": 0,
+              "216": 271,
+              "243": 431,
+              "273": 0
+            }
+          },
+          "MEMORY_JS_COMPARTMENTS_USER": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 3392.333098888397,
+            "log_sum_squares": 16404.058506011963,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 88087,
+            "values": {
+              "107": 181,
+              "120": 267,
+              "135": 120,
+              "152": 43,
+              "171": 0,
+              "84": 0,
+              "95": 91
+            }
+          },
+          "MEMORY_JS_GC_HEAP": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 8520.874587059021,
+            "log_sum_squares": 103489.8610534668,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 136859648,
+            "values": {
+              "102590": 0,
+              "107743": 52,
+              "113155": 37,
+              "124808": 11,
+              "131077": 71,
+              "137661": 100,
+              "144576": 1,
+              "167475": 20,
+              "175887": 2,
+              "236016": 397,
+              "247871": 11,
+              "260322": 0
+            }
+          },
+          "MEMORY_JS_MAIN_RUNTIME_TEMPORARY_PEAK": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 6170.476452827454,
+            "log_sum_squares": 54237.576599121094,
+            "range": [
+              1024,
+              16777216
+            ],
+            "sum": 4609516,
+            "values": {
+              "5979": 0,
+              "6279": 702,
+              "6594": 0
+            }
+          },
+          "MEMORY_RESIDENT": {
+            "bucket_count": 200,
+            "histogram_type": 0,
+            "log_sum": 9436.214457511902,
+            "log_sum_squares": 126885.07312011719,
+            "range": [
+              32768,
+              16777216
+            ],
+            "sum": 499028228,
+            "values": {
+              "1016084": 3,
+              "1048607": 5,
+              "1082171": 11,
+              "108501": 0,
+              "1116809": 21,
+              "111974": 1,
+              "1152556": 24,
+              "1189447": 1,
+              "1227519": 0,
+              "288141": 1,
+              "477020": 10,
+              "492288": 14,
+              "508045": 16,
+              "524306": 62,
+              "541088": 39,
+              "558407": 71,
+              "576280": 20,
+              "594726": 25,
+              "613762": 50,
+              "633407": 31,
+              "653681": 60,
+              "674604": 66,
+              "696197": 19,
+              "718481": 16,
+              "741478": 14,
+              "765211": 3,
+              "789704": 22,
+              "814981": 10,
+              "841067": 5,
+              "867988": 14,
+              "895771": 19,
+              "924443": 8,
+              "954033": 3,
+              "984570": 38
+            }
+          },
+          "MEMORY_VSIZE": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 10687.191714286804,
+            "log_sum_squares": 162706.16564941406,
+            "range": [
+              32768,
+              16777216
+            ],
+            "sum": 2881356800,
+            "values": {
+              "3205781": 0,
+              "3416485": 23,
+              "3641037": 254,
+              "3880348": 17,
+              "4135388": 153,
+              "4407191": 255,
+              "4696859": 0
+            }
+          },
+          "MIXED_CONTENT_PAGE_LOAD": {
+            "bucket_count": 5,
+            "histogram_type": 1,
+            "range": [
+              1,
+              4
+            ],
+            "sum": 1,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 1,
+            "values": {
+              "0": 54,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "MIXED_CONTENT_UNBLOCK_COUNTER": {
+            "bucket_count": 4,
+            "histogram_type": 1,
+            "range": [
+              1,
+              3
+            ],
+            "sum": 55,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 55,
+            "values": {
+              "0": 0,
+              "1": 55,
+              "2": 0
+            }
+          },
+          "PAGE_FAULTS_HARD": {
+            "bucket_count": 13,
+            "histogram_type": 0,
+            "log_sum": 112.41163563728333,
+            "log_sum_squares": 378.23194670677185,
+            "range": [
+              8,
+              65536
+            ],
+            "sum": 1605,
+            "values": {
+              "0": 677,
+              "18": 11,
+              "211": 2,
+              "41": 2,
+              "479": 0,
+              "8": 5,
+              "93": 4
+            }
+          },
+          "PAINT_BUILD_DISPLAYLIST_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 91347,
+            "values": {
+              "0": 24585,
+              "1": 43110,
+              "10": 1,
+              "12": 2,
+              "14": 1,
+              "16": 3,
+              "18": 2,
+              "2": 7010,
+              "20": 1,
+              "3": 4456,
+              "33": 1,
+              "4": 3409,
+              "5": 1157,
+              "6": 162,
+              "7": 15,
+              "75": 1,
+              "8": 5,
+              "84": 0,
+              "9": 4
+            }
+          },
+          "PAINT_RASTERIZE_TIME": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 241605,
+            "values": {
+              "0": 2640,
+              "1": 31283,
+              "10": 302,
+              "107": 9,
+              "11": 309,
+              "12": 711,
+              "120": 6,
+              "135": 3,
+              "14": 634,
+              "152": 1,
+              "16": 687,
+              "171": 2,
+              "18": 537,
+              "192": 0,
+              "2": 29700,
+              "20": 226,
+              "23": 144,
+              "26": 84,
+              "29": 81,
+              "3": 9804,
+              "33": 75,
+              "37": 71,
+              "4": 2260,
+              "42": 83,
+              "47": 77,
+              "5": 1392,
+              "53": 45,
+              "6": 810,
+              "60": 32,
+              "67": 21,
+              "7": 756,
+              "75": 15,
+              "8": 644,
+              "84": 19,
+              "9": 428,
+              "95": 34
+            }
+          },
+          "PLUGIN_CALLED_DIRECTLY": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "PUSH_API_USED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "PWMGR_FORM_AUTOFILL_RESULT": {
+            "bucket_count": 21,
+            "histogram_type": 1,
+            "range": [
+              1,
+              20
+            ],
+            "sum": 8,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 32,
+            "values": {
+              "0": 2,
+              "4": 2,
+              "5": 0
+            }
+          },
+          "PWMGR_LOGIN_PAGE_SAFETY": {
+            "bucket_count": 9,
+            "histogram_type": 1,
+            "range": [
+              1,
+              8
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 8,
+            "values": {
+              "0": 2,
+              "2": 2,
+              "3": 0
+            }
+          },
+          "PWMGR_PASSWORD_INPUT_IN_FORM": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "REFRESH_DRIVER_TICK": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              1000
+            ],
+            "sum": 425742,
+            "values": {
+              "0": 87151,
+              "1": 2709,
+              "10": 637,
+              "107": 16,
+              "11": 612,
+              "12": 1051,
+              "120": 6,
+              "135": 5,
+              "14": 725,
+              "152": 1,
+              "16": 651,
+              "171": 5,
+              "18": 655,
+              "2": 14226,
+              "20": 720,
+              "216": 1,
+              "23": 732,
+              "243": 1,
+              "26": 269,
+              "273": 3,
+              "29": 163,
+              "3": 26479,
+              "307": 2,
+              "33": 116,
+              "345": 0,
+              "37": 78,
+              "4": 16819,
+              "42": 59,
+              "47": 94,
+              "5": 6402,
+              "53": 63,
+              "6": 3829,
+              "60": 31,
+              "67": 24,
+              "7": 3544,
+              "75": 21,
+              "8": 2499,
+              "84": 26,
+              "9": 1005,
+              "95": 31
+            }
+          },
+          "SEARCH_SERVICE_US_COUNTRY_MISMATCHED_TIMEZONE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SEARCH_SERVICE_US_TIMEZONE_MISMATCHED_COUNTRY": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SERVICE_WORKER_REQUEST_PASSTHROUGH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 2,
+              "1": 0
+            }
+          },
+          "SHOULD_AUTO_DETECT_LANGUAGE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SHOULD_TRANSLATION_UI_APPEAR": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SOCIAL_ENABLED_ON_SESSION": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_CACHE_INVALID": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_CRASH_DETECTED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_MEASUREMENT_ERRORS": {
+            "bucket_count": 17,
+            "histogram_type": 1,
+            "range": [
+              1,
+              16
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "1": 0,
+              "2": 1,
+              "3": 0
+            }
+          },
+          "STARTUP_STARTUP_CACHE_INVALID": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STARTUP_XUL_CACHE_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "STS_NUMBER_OF_ONSOCKETREADY_CALLS": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 42,
+              "1": 0
+            }
+          },
+          "STS_NUMBER_OF_PENDING_EVENTS": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              2000
+            ],
+            "sum": 80,
+            "values": {
+              "1": 0,
+              "2": 13,
+              "4": 1,
+              "5": 10,
+              "6": 0
+            }
+          },
+          "STS_POLL_AND_EVENTS_CYCLE": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 175,
+            "values": {
+              "0": 14,
+              "10": 1,
+              "13": 2,
+              "16": 1,
+              "17": 1,
+              "19": 1,
+              "21": 1,
+              "29": 1,
+              "30": 1,
+              "31": 0,
+              "7": 1
+            }
+          },
+          "STS_POLL_BLOCK_TIME": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 33886288,
+            "values": {
+              "0": 25,
+              "125": 1,
+              "138": 1,
+              "18": 1,
+              "197": 1,
+              "3480": 1,
+              "35": 1,
+              "60000": 10,
+              "830": 1
+            }
+          },
+          "STS_POLL_CYCLE": {
+            "bucket_count": 1000,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              60000
+            ],
+            "sum": 0,
+            "values": {
+              "0": 42,
+              "1": 0
+            }
+          },
+          "SUBJECT_PRINCIPAL_ACCESSED_WITHOUT_SCRIPT_ON_STACK": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "SYSTEM_FONT_FALLBACK": {
+            "bucket_count": 50,
+            "histogram_type": 0,
+            "log_sum": 87.43857419490814,
+            "log_sum_squares": 198.41094660758972,
+            "range": [
+              1,
+              100000
+            ],
+            "sum": 4604,
+            "values": {
+              "0": 57,
+              "1": 27,
+              "1122": 1,
+              "13": 1,
+              "2": 36,
+              "2753": 1,
+              "3": 3,
+              "3446": 0,
+              "4": 1,
+              "5": 2,
+              "6": 1
+            }
+          },
+          "SYSTEM_FONT_FALLBACK_FIRST": {
+            "bucket_count": 20,
+            "histogram_type": 0,
+            "log_sum": 0.6931471824645996,
+            "log_sum_squares": 0.4804530143737793,
+            "range": [
+              1,
+              40000
+            ],
+            "sum": 1,
+            "values": {
+              "0": 0,
+              "1": 1,
+              "2": 0
+            }
+          },
+          "SYSTEM_FONT_FALLBACK_SCRIPT": {
+            "bucket_count": 111,
+            "histogram_type": 1,
+            "range": [
+              1,
+              110
+            ],
+            "sum": 2706,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 69656,
+            "values": {
+              "0": 0,
+              "1": 28,
+              "26": 103,
+              "27": 0
+            }
+          },
+          "TELEMETRY_MEMORY_REPORTER_MS": {
+            "bucket_count": 10,
+            "histogram_type": 0,
+            "log_sum": 843.2068462371826,
+            "log_sum_squares": 1059.1628289222717,
+            "range": [
+              1,
+              5000
+            ],
+            "sum": 1730,
+            "values": {
+              "0": 0,
+              "1": 417,
+              "26": 1,
+              "3": 283,
+              "74": 0,
+              "9": 1
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_LOAD": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_PARSE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_SAVE": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_SESSIONDATA_FAILED_VALIDATION": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_RELEASE_OPTIN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TELEMETRY_TEST_RELEASE_OPTOUT": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 55,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 55,
+            "values": {
+              "0": 55,
+              "1": 0
+            }
+          },
+          "TOTAL_CONTENT_PAGE_LOAD_TIME": {
+            "bucket_count": 100,
+            "histogram_type": 0,
+            "log_sum": 1238.1626212596893,
+            "log_sum_squares": 7688.37299156189,
+            "range": [
+              100,
+              30000
+            ],
+            "sum": 163364,
+            "values": {
+              "0": 36,
+              "100": 1,
+              "1027": 6,
+              "106": 1,
+              "1089": 5,
+              "1154": 3,
+              "119": 2,
+              "1223": 2,
+              "126": 1,
+              "1296": 4,
+              "13285": 1,
+              "134": 2,
+              "1374": 2,
+              "14081": 0,
+              "142": 3,
+              "1456": 3,
+              "151": 4,
+              "160": 5,
+              "1635": 2,
+              "170": 4,
+              "1733": 2,
+              "180": 1,
+              "1837": 1,
+              "191": 3,
+              "1947": 1,
+              "202": 1,
+              "2064": 2,
+              "2188": 2,
+              "227": 5,
+              "2319": 1,
+              "241": 4,
+              "2458": 3,
+              "255": 4,
+              "2605": 1,
+              "270": 8,
+              "286": 3,
+              "303": 2,
+              "321": 1,
+              "340": 1,
+              "360": 2,
+              "3693": 1,
+              "382": 7,
+              "3914": 1,
+              "405": 3,
+              "4149": 1,
+              "455": 4,
+              "482": 4,
+              "511": 2,
+              "542": 2,
+              "574": 2,
+              "5883": 1,
+              "608": 8,
+              "644": 8,
+              "683": 3,
+              "724": 4,
+              "7425": 1,
+              "767": 4,
+              "813": 6,
+              "862": 3,
+              "914": 5,
+              "969": 4
+            }
+          },
+          "URL_PATH_CONTAINS_EXCLAMATION_DOUBLE_SLASH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 18484,
+              "1": 0
+            }
+          },
+          "URL_PATH_CONTAINS_EXCLAMATION_SLASH": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4183,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4183,
+            "values": {
+              "0": 14301,
+              "1": 4183,
+              "2": 0
+            }
+          },
+          "URL_PATH_ENDS_IN_EXCLAMATION": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 18484,
+              "1": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetAttributeNode_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 11,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 11,
+            "values": {
+              "0": 0,
+              "1": 11,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetAttributeNode_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 6,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 6,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetPreventDefault_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 51,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 51,
+            "values": {
+              "0": 0,
+              "1": 51,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_GetPreventDefault_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 24,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 24,
+            "values": {
+              "0": 0,
+              "1": 24,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_MutationEvent_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_MutationEvent_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 2,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 2,
+            "values": {
+              "0": 0,
+              "1": 2,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_NodeValue_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 3,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 3,
+            "values": {
+              "0": 0,
+              "1": 3,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_NodeValue_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 3,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 3,
+            "values": {
+              "0": 0,
+              "1": 3,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_PrefixedVisibilityAPI_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 9,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 9,
+            "values": {
+              "0": 0,
+              "1": 9,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_PrefixedVisibilityAPI_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_SyncXMLHttpRequest_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 7,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 7,
+            "values": {
+              "0": 0,
+              "1": 7,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_DEPRECATED_SyncXMLHttpRequest_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILLOPACITY_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 6,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 6,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILLOPACITY_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 4,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4,
+            "values": {
+              "0": 0,
+              "1": 4,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILL_DOCUMENT": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 27,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 27,
+            "values": {
+              "0": 0,
+              "1": 27,
+              "2": 0
+            }
+          },
+          "USE_COUNTER2_PROPERTY_FILL_PAGE": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 12,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 12,
+            "values": {
+              "0": 0,
+              "1": 12,
+              "2": 0
+            }
+          },
+          "VIDEO_ADOBE_GMP_DISAPPEARED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_CONSTRAINT_SET_FLAG": {
+            "bucket_count": 129,
+            "histogram_type": 1,
+            "range": [
+              1,
+              128
+            ],
+            "sum": 1120,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 250880,
+            "values": {
+              "127": 0,
+              "128": 5
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_LEVEL": {
+            "bucket_count": 52,
+            "histogram_type": 1,
+            "range": [
+              1,
+              51
+            ],
+            "sum": 150,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 4500,
+            "values": {
+              "29": 0,
+              "30": 5,
+              "31": 0
+            }
+          },
+          "VIDEO_CANPLAYTYPE_H264_PROFILE": {
+            "bucket_count": 245,
+            "histogram_type": 1,
+            "range": [
+              1,
+              244
+            ],
+            "sum": 330,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 21780,
+            "values": {
+              "65": 0,
+              "66": 5,
+              "67": 0
+            }
+          },
+          "VIDEO_OPENH264_GMP_DISAPPEARED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "WEAVE_CAN_FETCH_KEYS": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "WORD_CACHE_HITS_CHROME": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 4514,
+            "values": {
+              "0": 0,
+              "1": 198,
+              "11": 0,
+              "2": 93,
+              "3": 91,
+              "4": 213,
+              "5": 101,
+              "6": 27,
+              "7": 26,
+              "8": 120,
+              "9": 122
+            }
+          },
+          "WORD_CACHE_HITS_CONTENT": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 2017098,
+            "values": {
+              "0": 0,
+              "1": 113127,
+              "11": 10287,
+              "13": 1782,
+              "15": 1929,
+              "18": 1014,
+              "2": 66473,
+              "21": 832,
+              "25": 399,
+              "3": 83407,
+              "30": 118,
+              "35": 0,
+              "4": 71929,
+              "5": 44779,
+              "6": 32537,
+              "7": 32348,
+              "8": 19981,
+              "9": 21989
+            }
+          },
+          "WORD_CACHE_MISSES_CHROME": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 2131,
+            "values": {
+              "0": 0,
+              "1": 6,
+              "11": 0,
+              "2": 24,
+              "3": 64,
+              "4": 48,
+              "5": 69,
+              "6": 35,
+              "7": 35,
+              "8": 65,
+              "9": 40
+            }
+          },
+          "WORD_CACHE_MISSES_CONTENT": {
+            "bucket_count": 30,
+            "histogram_type": 0,
+            "log_sum": 0,
+            "log_sum_squares": 0,
+            "range": [
+              1,
+              256
+            ],
+            "sum": 663507,
+            "values": {
+              "0": 0,
+              "1": 6501,
+              "11": 3924,
+              "13": 1602,
+              "15": 1190,
+              "18": 701,
+              "2": 9497,
+              "21": 651,
+              "25": 387,
+              "3": 15296,
+              "30": 105,
+              "35": 0,
+              "4": 18345,
+              "5": 17136,
+              "6": 10814,
+              "7": 11810,
+              "8": 8561,
+              "9": 9606
+            }
+          },
+          "XMLHTTPREQUEST_ASYNC_OR_SYNC": {
+            "bucket_count": 3,
+            "histogram_type": 2,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 23,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 23,
+            "values": {
+              "0": 6046,
+              "1": 23,
+              "2": 0
+            }
+          },
+          "XUL_CACHE_DISABLED": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "YOUTUBE_EMBED_SEEN": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        },
+        "keyedHistograms": {
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_FAILURE_TIME_MS": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_RATE": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_TIME_MS": {},
+          "ABOUT_ACCOUNTS_CONTENT_SERVER_LOAD_STARTED_COUNT": {},
+          "ADDON_SHIM_USAGE": {},
+          "BLOCKED_ON_PLUGINASYNCSURROGATE_WAITFORINIT_MS": {},
+          "BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS": {},
+          "BLOCKED_ON_PLUGIN_INSTANCE_INIT_MS": {},
+          "BLOCKED_ON_PLUGIN_MODULE_INIT_MS": {},
+          "BLOCKED_ON_PLUGIN_STREAM_INIT_MS": {},
+          "DEVTOOLS_HUD_APP_MEMORY_CONTENTINTERACTIVE_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_FULLYLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_MEDIAENUMERATED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONINTERACTIVE_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_SCANEND_V2": {},
+          "DEVTOOLS_HUD_APP_MEMORY_VISUALLYLOADED_V2": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_CONTENTINTERACTIVE": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_FULLYLOADED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_MEDIAENUMERATED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONINTERACTIVE": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONLOADED": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_SCANEND": {},
+          "DEVTOOLS_HUD_APP_STARTUP_TIME_VISUALLYLOADED": {},
+          "DEVTOOLS_HUD_ERRORS": {},
+          "DEVTOOLS_HUD_JANK": {},
+          "DEVTOOLS_HUD_REFLOWS": {},
+          "DEVTOOLS_HUD_REFLOW_DURATION": {},
+          "DEVTOOLS_HUD_SECURITY_CATEGORY": {},
+          "DEVTOOLS_HUD_WARNINGS": {},
+          "DEVTOOLS_PERFTOOLS_RECORDING_FEATURES_USED": {},
+          "DEVTOOLS_PERFTOOLS_SELECTED_VIEW_MS": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_APP_TYPE": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_ID": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_OS": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PLATFORM_VERSION": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PROCESSOR": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_TYPE": {},
+          "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_VERSION": {},
+          "FXA_HAWK_ERRORS": {},
+          "FXA_SERVER_ERRORS": {},
+          "FXA_UNVERIFIED_ACCOUNT_ERRORS": {},
+          "FX_MIGRATION_ERRORS": {},
+          "FX_MIGRATION_HOMEPAGE_IMPORTED": {},
+          "FX_MIGRATION_USAGE": {},
+          "FX_TABLETMODE_PAGE_LOAD": {},
+          "JS_TELEMETRY_ADDON_EXCEPTIONS": {},
+          "KEYGEN_GENERATED_KEY_TYPE": {},
+          "MISBEHAVING_ADDONS_CPOW_TIME_MS": {},
+          "MISBEHAVING_ADDONS_JANK_LEVEL": {},
+          "PLUGIN_ACTIVATION_COUNT": {},
+          "POPUP_NOTIFICATION_DISMISSAL_MS": {},
+          "POPUP_NOTIFICATION_MAIN_ACTION_MS": {},
+          "POPUP_NOTIFICATION_STATS": {},
+          "PROCESS_CRASH_SUBMIT_ATTEMPT": {},
+          "PROCESS_CRASH_SUBMIT_SUCCESS": {},
+          "PWMGR_MANAGE_SORTED": {},
+          "SEARCH_COUNTS": {},
+          "SUBPROCESS_ABNORMAL_ABORT": {},
+          "SUBPROCESS_CRASHES_WITH_DUMP": {},
+          "TELEMETRY_INVALID_PING_TYPE_SUBMITTED": {},
+          "TELEMETRY_TEST_KEYED_COUNT": {},
+          "TELEMETRY_TEST_KEYED_FLAG": {},
+          "TELEMETRY_TEST_KEYED_RELEASE_OPTIN": {},
+          "TELEMETRY_TEST_KEYED_RELEASE_OPTOUT": {},
+          "TOKENSERVER_AUTH_ERRORS": {},
+          "TRANSLATED_PAGES_BY_LANGUAGE": {},
+          "TRANSLATION_OPPORTUNITIES_BY_LANGUAGE": {},
+          "UPDATE_CHECK_EXTENDED_ERROR_EXTERNAL": {},
+          "UPDATE_CHECK_EXTENDED_ERROR_NOTIFY": {},
+          "WEAVE_ENGINE_APPLY_FAILURES": {},
+          "WEAVE_ENGINE_APPLY_NEW_FAILURES": {},
+          "WEAVE_ENGINE_SYNC_ERRORS": {},
+          "WEAVE_STORAGE_AUTH_ERRORS": {}
+        }
+      },
+      "gpu": {
+        "histograms": {
+          "A11Y_INSTANTIATED_FLAG": {
+            "bucket_count": 3,
+            "histogram_type": 3,
+            "range": [
+              1,
+              2
+            ],
+            "sum": 0,
+            "sum_squares_hi": 0,
+            "sum_squares_lo": 0,
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        },
+        "keyedHistograms": {
+          "ADDON_SHIM_USAGE": {}
+        }
+      }
+    },
+    "info": {
+      "addons": "masspasswordreset%40johnathan.nightingale:1.05.1-signed,foxyproxy%40eric.h.jung:4.5.5,eliteproxyswitcher%40my-proxy.com:1.2.0.2.1-signed,%7B972ce4c6-7e08-4474-a285-3208198ce6fd%7D:45.0,fxos_2_1_simulator%40mozilla.org:2.1.20141223.1-signed,fxos_1_4_simulator%40mozilla.org:1.4.20140506.1-signed,adbhelper%40mozilla.org:0.8.5,fxdevtools-adapters%40mozilla.org:0.3.3",
+      "asyncPluginInit": false,
+      "flashVersion": "19.0.0.226",
+      "previousBuildId": "20151102030241",
+      "previousSessionId": "3f4b8574-44f5-4173-a2fe-fbf1939ec516",
+      "previousSubsessionId": "f2af8461-80c2-4560-8131-bfc313f3d0fa",
+      "profileSubsessionCounter": 197,
+      "reason": "shutdown",
+      "revision": "https://hg.mozilla.org/mozilla-central/rev/bb4d614a0b09",
+      "sessionId": "a472b0c5-1498-4cd0-a953-954bbd474317",
+      "sessionLength": 44180,
+      "sessionStartDate": "2015-11-03T00:00:00.0-08:00",
+      "subsessionCounter": 2,
+      "subsessionId": "6e52dd1f-408a-483a-9406-d43d8c39e3a4",
+      "subsessionLength": 38376,
+      "subsessionStartDate": "2015-11-04T00:00:00.0-08:00",
+      "timezoneOffset": -480
+    },
+    "keyedHistograms": {
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_FAILURE_TIME_MS": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_RATE": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOADED_TIME_MS": {},
+      "ABOUT_ACCOUNTS_CONTENT_SERVER_LOAD_STARTED_COUNT": {},
+      "ADDON_SHIM_USAGE": {
+        "foxyproxy@eric.h.jung": {
+          "bucket_count": 16,
+          "histogram_type": 1,
+          "range": [
+            1,
+            15
+          ],
+          "sum": 258,
+          "sum_squares_hi": 0,
+          "sum_squares_lo": 378,
+          "values": {
+            "0": 0,
+            "1": 234,
+            "6": 4,
+            "7": 0
+          }
+        }
+      },
+      "BLOCKED_ON_PLUGINASYNCSURROGATE_WAITFORINIT_MS": {},
+      "BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS": {},
+      "BLOCKED_ON_PLUGIN_INSTANCE_INIT_MS": {},
+      "BLOCKED_ON_PLUGIN_MODULE_INIT_MS": {},
+      "BLOCKED_ON_PLUGIN_STREAM_INIT_MS": {},
+      "DEVTOOLS_HUD_APP_MEMORY_CONTENTINTERACTIVE_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_FULLYLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_MEDIAENUMERATED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONINTERACTIVE_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_NAVIGATIONLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_SCANEND_V2": {},
+      "DEVTOOLS_HUD_APP_MEMORY_VISUALLYLOADED_V2": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_CONTENTINTERACTIVE": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_FULLYLOADED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_MEDIAENUMERATED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONINTERACTIVE": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_NAVIGATIONLOADED": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_SCANEND": {},
+      "DEVTOOLS_HUD_APP_STARTUP_TIME_VISUALLYLOADED": {},
+      "DEVTOOLS_HUD_ERRORS": {},
+      "DEVTOOLS_HUD_JANK": {},
+      "DEVTOOLS_HUD_REFLOWS": {},
+      "DEVTOOLS_HUD_REFLOW_DURATION": {},
+      "DEVTOOLS_HUD_SECURITY_CATEGORY": {},
+      "DEVTOOLS_HUD_WARNINGS": {},
+      "DEVTOOLS_PERFTOOLS_RECORDING_FEATURES_USED": {},
+      "DEVTOOLS_PERFTOOLS_SELECTED_VIEW_MS": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_APP_TYPE": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_ID": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_OS": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PLATFORM_VERSION": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_PROCESSOR": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_TYPE": {},
+      "DEVTOOLS_WEBIDE_CONNECTED_RUNTIME_VERSION": {},
+      "FXA_HAWK_ERRORS": {},
+      "FXA_SERVER_ERRORS": {},
+      "FXA_UNVERIFIED_ACCOUNT_ERRORS": {},
+      "FX_MIGRATION_ERRORS": {},
+      "FX_MIGRATION_HOMEPAGE_IMPORTED": {},
+      "FX_MIGRATION_USAGE": {},
+      "FX_TABLETMODE_PAGE_LOAD": {
+        "desktop": {
+          "bucket_count": 30,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            100000
+          ],
+          "sum": 0,
+          "values": {
+            "0": 6,
+            "1": 0
+          }
+        },
+        "tablet": {
+          "bucket_count": 30,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            100000
+          ],
+          "sum": 0,
+          "values": {
+            "0": 6,
+            "1": 0
+          }
+        }
+      },
+      "JS_TELEMETRY_ADDON_EXCEPTIONS": {},
+      "KEYGEN_GENERATED_KEY_TYPE": {},
+      "MISBEHAVING_ADDONS_CPOW_TIME_MS": {
+        "foxyproxy@eric.h.jung": {
+          "bucket_count": 20,
+          "histogram_type": 0,
+          "log_sum": 17.722850799560547,
+          "log_sum_squares": 19.94512128829956,
+          "range": [
+            1,
+            10000
+          ],
+          "sum": 34,
+          "values": {
+            "0": 36,
+            "1": 10,
+            "2": 4,
+            "3": 3,
+            "5": 1,
+            "8": 0
+          }
+        },
+        "fxos_1_4_simulator@mozilla.org": {
+          "bucket_count": 20,
+          "histogram_type": 0,
+          "log_sum": 33.526108741760254,
+          "log_sum_squares": 49.915854930877686,
+          "range": [
+            1,
+            10000
+          ],
+          "sum": 83,
+          "values": {
+            "0": 28,
+            "1": 11,
+            "13": 0,
+            "2": 4,
+            "3": 5,
+            "5": 5,
+            "8": 2
+          }
+        }
+      },
+      "MISBEHAVING_ADDONS_JANK_LEVEL": {},
+      "PLUGIN_ACTIVATION_COUNT": {},
+      "POPUP_NOTIFICATION_DISMISSAL_MS": {},
+      "POPUP_NOTIFICATION_MAIN_ACTION_MS": {},
+      "POPUP_NOTIFICATION_STATS": {},
+      "PROCESS_CRASH_SUBMIT_ATTEMPT": {},
+      "PROCESS_CRASH_SUBMIT_SUCCESS": {},
+      "PWMGR_MANAGE_SORTED": {},
+      "SEARCH_COUNTS": {
+        "google.urlbar": {
+          "bucket_count": 3,
+          "histogram_type": 4,
+          "range": [
+            1,
+            2
+          ],
+          "sum": 5,
+          "sum_squares_hi": 0,
+          "sum_squares_lo": 5,
+          "values": {
+            "0": 5,
+            "1": 0
+          }
+        }
+      },
+      "SUBPROCESS_ABNORMAL_ABORT": {},
+      "SUBPROCESS_CRASHES_WITH_DUMP": {},
+      "TELEMETRY_INVALID_PING_TYPE_SUBMITTED": {},
+      "TELEMETRY_TEST_KEYED_COUNT": {},
+      "TELEMETRY_TEST_KEYED_FLAG": {},
+      "TELEMETRY_TEST_KEYED_RELEASE_OPTIN": {},
+      "TELEMETRY_TEST_KEYED_RELEASE_OPTOUT": {},
+      "TOKENSERVER_AUTH_ERRORS": {},
+      "TRANSLATED_PAGES_BY_LANGUAGE": {},
+      "TRANSLATION_OPPORTUNITIES_BY_LANGUAGE": {},
+      "UPDATE_CHECK_EXTENDED_ERROR_EXTERNAL": {},
+      "UPDATE_CHECK_EXTENDED_ERROR_NOTIFY": {},
+      "WEAVE_ENGINE_APPLY_FAILURES": {},
+      "WEAVE_ENGINE_APPLY_NEW_FAILURES": {},
+      "WEAVE_ENGINE_SYNC_ERRORS": {},
+      "WEAVE_STORAGE_AUTH_ERRORS": {}
+    },
+    "lateWrites": {
+      "memoryMap": [
+        ["foo", "bar"],
+        ["baz", "foo"]
+      ],
+      "stacks": [
+        [
+          [0, 0],
+          [0, 1],
+          [10, 10]
+        ],
+        [
+          [100, 0],
+          [200, -1],
+          [300, 10],
+          [400, 20]
+        ]
+      ]
+    },
+    "log": [
+      [
+        "EXPERIMENT_ACTIVATION",
+        1430,
+        "REJECTED",
+        "e10s-enabled-aurora-20151020@experiments.mozilla.org",
+        "endTime"
+      ],
+      [
+        "EXPERIMENT_ACTIVATION",
+        16393806,
+        "REJECTED",
+        "e10s-enabled-aurora-20151020@experiments.mozilla.org",
+        "endTime"
+      ]
+    ],
+    "simpleMeasurements": {
+      "AMI_startup_begin": 544,
+      "AMI_startup_end": 895,
+      "UITelemetry": {
+        "UITour": {
+          "seenPageIDs": [
+            "australis-29-release-no-tour"
+          ]
+        },
+        "contextmenu": {},
+        "toolbars": {
+          "addonToolbars": 1,
+          "bookmarksBarEnabled": true,
+          "countableEvents": {
+            "__DEFAULT__": {
+              "click-bookmarks-bar": {
+                "chevron": {
+                  "left": 1
+                }
+              },
+              "click-builtin-item": {
+                "alltabs-button": {
+                  "left": 2
+                },
+                "new-tab-button": {
+                  "left": 1
+                },
+                "tabbrowser-tabs": {
+                  "left": 25
+                }
+              },
+              "search": {
+                "urlbar": 6
+              }
+            }
+          },
+          "currentSearchEngine": "Google",
+          "defaultKept": [
+            "edit-controls",
+            "zoom-controls",
+            "new-window-button",
+            "privatebrowsing-button",
+            "save-page-button",
+            "print-button",
+            "history-panelmenu",
+            "fullscreen-button",
+            "find-button",
+            "preferences-button",
+            "add-ons-button",
+            "developer-button",
+            "urlbar-container",
+            "search-container",
+            "bookmarks-menu-button",
+            "pocket-button",
+            "downloads-button",
+            "home-button",
+            "social-share-button",
+            "tabbrowser-tabs",
+            "new-tab-button",
+            "alltabs-button",
+            "personal-bookmarks"
+          ],
+          "defaultMoved": [],
+          "defaultRemoved": [],
+          "durations": {
+            "customization": []
+          },
+          "hiddenTabs": [
+            0,
+            0
+          ],
+          "menuBarEnabled": false,
+          "nondefaultAdded": [
+            "tabview-button"
+          ],
+          "sizemode": "normal",
+          "titleBarEnabled": false,
+          "visibleTabs": [
+            46,
+            21
+          ]
+        }
+      },
+      "XPI_bootstrap_addons_begin": 749,
+      "XPI_bootstrap_addons_end": 889,
+      "XPI_finalUIStartup": 1156,
+      "XPI_startup_begin": 557,
+      "XPI_startup_end": 889,
+      "activeTicks": 1034,
+      "addonManager": {
+        "XPIDB_parseDB_MS": 2,
+        "XPIDB_saves_late": 0,
+        "XPIDB_saves_overlapped": 0,
+        "XPIDB_saves_total": 2,
+        "XPIDB_startup_load_reasons": [
+          "directoryState"
+        ],
+        "XPIDB_syncRead_MS": 1,
+        "default_providers": true
+      },
+      "createTopLevelWindow": 1244,
+      "debuggerAttached": 0,
+      "delayedStartupFinished": 1959,
+      "delayedStartupStarted": 1927,
+      "firstLoadURI": 2223,
+      "firstPaint": 1881,
+      "js": {
+        "customIter": 23,
+        "setProto": 0
+      },
+      "main": 133,
+      "maximalNumberOfConcurrentThreads": 45,
+      "pingsOverdue": 0,
+      "profileBeforeChange": 44180512,
+      "quitApplication": 44179631,
+      "savedPings": 0,
+      "selectProfile": 447,
+      "sessionRestoreInit": 1157,
+      "sessionRestoreInitialized": 1197,
+      "sessionRestoreRestoring": 1966,
+      "sessionRestored": 2481,
+      "shutdownDuration": 1476,
+      "start": 0,
+      "startupCrashDetectionBegin": 540,
+      "startupCrashDetectionEnd": 31951,
+      "startupInterrupted": 0,
+      "totalTime": 79083,
+      "uptime": 1318
+    },
+    "slowSQL": {
+      "mainThread": {},
+      "otherThreads": {
+        "COMMIT TRANSACTION /* cookies.sqlite */": [
+          1,
+          1137
+        ],
+        "SELECT :query_type, h.url, h.title, f.url, EXISTS(SELECT 1 FROM moz_bookmarks WHERE fk = h.id) AS bookmarked,\n   ( SELECT title FROM moz_bookmarks WHERE fk = h.id AND title NOTNULL\n     ORDER BY lastModified DESC LIMIT 1\n   ) AS btitle,\n   ( SELECT GROUP_CONCAT(t.title, :private)\n     FROM moz_bookmarks b\n     JOIN moz_bookmarks t ON t.id = +b.parent AND t.parent = :parent\n     WHERE b.fk = h.id\n   ) AS tags,\n            h.visit_count, h.typed, h.id, t.open_count, h.frecency\n     FROM moz_places h\n     LEFT JOIN moz_favicons f ON f.id = h.favicon_id\n     LEFT JOIN moz_openpages_temp t ON t.url = h.url\n     WHERE h.frecency <> 0\n       AND AUTOCOMPLETE_MATCH(:searchString, h.url,\n                              IFNULL(btitle, h.title), tags,\n                              h.visit_count, h.typed,\n                              bookmarked, t.open_count,\n                              :matchBehavior, :searchBehavior)\n       \n     ORDER BY h.frecency DESC, h.id DESC\n     LIMIT :maxResults /* places.sqlite */": [
+          80,
+          9995
+        ],
+        "UPDATE moz_cookies SET lastAccessed = :lastAccessed WHERE name = :name AND host = :host AND path = :path /* cookies.sqlite */": [
+          3,
+          1551
+        ],
+        "UPDATE moz_places SET frecency = CALCULATE_FRECENCY(id) WHERE frecency < 0 /* places.sqlite */": [
+          1,
+          102
+        ]
+      }
+    },
+    "threadHangStats": [
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 2285595,
+            "1023": 1,
+            "127": 334,
+            "15": 82830,
+            "2047": 0,
+            "255": 200,
+            "3": 68207,
+            "31": 19816,
+            "511": 19,
+            "63": 4295,
+            "7": 74255
+          }
+        },
+        "hangs": [
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "(chrome script)"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "nsBrowserGlue.js:282",
+              "gre/modules/XPCOMUtils.jsm:197",
+              "gre/modules/XPCOMUtils.jsm:271",
+              "/modules/RemotePrompt.jsm:8"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 3,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "ChildView::drawUsingOpenGL"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "gre/modules/Promise-backend.js:747",
+              "gre/modules/Promise-backend.js:805",
+              "/modules/sessionstore/SessionStore.jsm:1137",
+              "(chrome script)"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 5,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "Timer::Fire",
+              "nsJSContext::RunCycleCollectorSlice",
+              "nsCycleCollector::collectSlice"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 1,
+                "127": 0,
+                "2047": 0,
+                "255": 184,
+                "511": 14
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 1,
+                "2047": 0,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "IPDL::PBrowser::RecvAsyncMessage",
+              "gre/modules/RemoteWebProgress.jsm:183"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "nsRefreshDriver::Tick",
+              "EventDispatcher::Dispatch",
+              "global/content/bindings/scrollbox.xml:572",
+              "global/content/bindings/scrollbox.xml:172",
+              "PresShell::Flush",
+              "PresShell::Paint",
+              "nsLayoutUtils::PaintFrame",
+              "nsDisplayList::PaintRoot",
+              "BasicLayerManager::EndTransactionInternal",
+              "FrameLayerBuilder::DrawPaintedLayer",
+              "DisplayList::Draw"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "EventDispatcher::Dispatch",
+              "browser/content/places/browserPlacesViews.js:1812",
+              "browser/content/places/browserPlacesViews.js:674",
+              "gre/components/nsLivemarkService.js:290",
+              "gre/modules/Task.jsm:164",
+              "gre/modules/Task.jsm:226"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 4
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "Events::ProcessGeckoEvents",
+              "gre/components/nsLoginManagerPrompter.js:105",
+              "gre/components/nsPrompter.js:107"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "255": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "ChildView::drawUsingOpenGL",
+              "IPDL::PCompositor::SendFlushRendering"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "Startup::XRE_Main",
+              "EventDispatcher::Dispatch",
+              "browser/content/hiddenWindow.xul:1",
+              "nsBrowserGlue.js:282",
+              "gre/modules/XPCOMUtils.jsm:197",
+              "gre/modules/XPCOMUtils.jsm:271",
+              "/modules/CustomizationTabPreloader.jsm:9"
+            ]
+          }
+        ],
+        "name": "Gecko"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 5058912,
+            "127": 37,
+            "15": 33710,
+            "2047": 2,
+            "255": 6,
+            "3": 42286,
+            "31": 17226,
+            "4095": 0,
+            "63": 1035,
+            "7": 38624
+          }
+        },
+        "hangs": [
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "2047": 1,
+                "255": 0,
+                "4095": 0,
+                "511": 1
+              }
+            },
+            "stack": [
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render",
+              "LayerManagerComposite::EndFrame",
+              "CompositorOGL::EndFrame",
+              "GLContextCGL::SwapBuffers"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "1023": 0,
+                "2047": 1,
+                "4095": 0
+              }
+            },
+            "stack": [
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 4,
+                "511": 0
+              }
+            },
+            "stack": [
+              "IPDL::PLayerTransaction::RecvUpdateNoSwap",
+              "LayerTransactionParent::RecvUpdate"
+            ]
+          },
+          {
+            "histogram": {
+              "bucket_count": 33,
+              "histogram_type": 0,
+              "log_sum": 0,
+              "log_sum_squares": 0,
+              "range": [
+                1,
+                0
+              ],
+              "sum": 0,
+              "values": {
+                "127": 0,
+                "255": 1,
+                "511": 0
+              }
+            },
+            "stack": [
+              "IPDL::PCompositor::RecvFlushRendering",
+              "CompositorParent::ForceComposeToTarget",
+              "CompositorParent::Composite",
+              "LayerManagerComposite::Render",
+              "LayerManagerComposite::EndFrame",
+              "CompositorOGL::EndFrame",
+              "GLContextCGL::SwapBuffers"
+            ]
+          }
+        ],
+        "name": "Compositor"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 13,
+            "3": 0
+          }
+        },
+        "hangs": [],
+        "name": "ImageBridgeChild"
+      },
+      {
+        "activity": {
+          "bucket_count": 33,
+          "histogram_type": 0,
+          "log_sum": 0,
+          "log_sum_squares": 0,
+          "range": [
+            1,
+            0
+          ],
+          "sum": 0,
+          "values": {
+            "0": 0,
+            "1": 20,
+            "15": 1,
+            "3": 1,
+            "31": 0
+          }
+        },
+        "hangs": [],
+        "name": "ProcessHangMonitor"
+      }
+    ],
+    "ver": 4,
+    "webrtc": {
+      "IceCandidatesStats": {
+        "loop": {},
+        "webrtc": {}
+      }
+    }
+  },
+  "type": "main",
+  "version": 4
+}


### PR DESCRIPTION
This adds some of the missing fields from https://github.com/mozilla/mozilla-schema-generator/issues/47

A couple of things to note - I allowed for nulls in some, but not all, of the boolean fields based on nearby fields, and I couldn't find a real example of lateWrites, so I'm going by what's in the [main ping docs](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/main-ping.html#latewrites).

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
