### PR TITLE
Bug 1572744 - Add schema for v5 of Sync ping

### DIFF
--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -1,6 +1,551 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {},
-  "title": "placeholder_schema",
+  "additionalProperties": false,
+  "description": "Schema for v5 of sync pings added for GCP compatibility. This is a copy of v4 schema, as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1572744#c3",
+  "properties": {
+    "application": {
+      "$comment": "The application section is included here inline due to incompatible incoming data",
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "$comment": "Note that we drop the pattern requirement commonly used by other ping types for this field due to observed values in incoming data.",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "channel",
+        "name",
+        "platformVersion",
+        "version"
+      ],
+      "type": "object"
+    },
+    "creationDate": {
+      "$comment": "Note that we drop the pattern requirement commonly used by other ping types for this field due to observed values in incoming data.",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "payload": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "description": "schema for Sync pings, documentation avaliable in toolkit/components/telemetry/docs/sync-ping.rst",
+      "properties": {
+        "deviceID": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "discarded": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "events": {
+          "items": {
+            "items": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            ],
+            "maxItems": 6,
+            "minItems": 4,
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "histograms": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$comment": "Desktop-style histograms",
+                "additionalProperties": false,
+                "properties": {
+                  "bucket_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "histogram_type": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "log_sum": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "log_sum_squares": {
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "range": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array"
+                  },
+                  "sum": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "sum_squares_hi": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "sum_squares_lo": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "values": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^[0-9]+$": {
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "$comment": "Nondesktop-style histograms",
+                "additionalProperties": false,
+                "properties": {
+                  "counts": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array"
+                  },
+                  "histogram_type": {
+                    "type": "integer"
+                  },
+                  "max": {
+                    "type": "integer"
+                  },
+                  "min": {
+                    "type": "integer"
+                  },
+                  "ranges": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array"
+                  },
+                  "sum": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        "os": {
+          "properties": {
+            "locale": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "sessionStartDate": {
+          "type": "string"
+        },
+        "syncs": {
+          "items": {
+            "properties": {
+              "devices": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "pattern": "^[0-9a-f]{64}$",
+                      "type": "string"
+                    },
+                    "os": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "didLogin": {
+                "type": "boolean"
+              },
+              "engines": {
+                "items": {
+                  "properties": {
+                    "failureReason": {
+                      "properties": {
+                        "code": {
+                          "type": "integer"
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "incoming": {
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {
+                          "required": [
+                            "applied"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "failed"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "newFailed"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "reconciled"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "applied": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "failed": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "newFailed": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "reconciled": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "succeeded": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "outgoing": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "failed": {
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "sent": {
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": [
+                        "array",
+                        "object"
+                      ]
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "steps": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "counts": {
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "count"
+                              ],
+                              "type": "object"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "took": {
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "took": {
+                      "minimum": -1,
+                      "type": "integer"
+                    },
+                    "validation": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "checked": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "failureReason": {
+                          "properties": {
+                            "code": {
+                              "type": "integer"
+                            },
+                            "error": {
+                              "type": "string"
+                            },
+                            "from": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "problems": {
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "count"
+                            ],
+                            "type": "object"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "took": {
+                          "minimum": -1,
+                          "type": "integer"
+                        },
+                        "version": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "minItems": 0,
+                "type": "array"
+              },
+              "failureReason": {
+                "properties": {
+                  "code": {
+                    "type": "integer"
+                  },
+                  "error": {
+                    "type": "string"
+                  },
+                  "from": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "status": {
+                "additionalProperties": false,
+                "anyOf": [
+                  {
+                    "required": [
+                      "sync"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "service"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "service": {
+                    "type": "string"
+                  },
+                  "sync": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "took": {
+                "minimum": -1,
+                "type": "integer"
+              },
+              "when": {
+                "type": "integer"
+              },
+              "why": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "uid": {
+          "pattern": "^[0-9a-f]{32}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "why": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "type": {
+      "enum": [
+        "sync"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 5,
+      "minimum": 5,
+      "type": "number"
+    }
+  },
+  "required": [
+    "application",
+    "type",
+    "id",
+    "creationDate",
+    "version",
+    "payload"
+  ],
+  "title": "sync",
   "type": "object"
 }

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -53,6 +53,20 @@
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"
     },
+    "os": {
+      "properties": {
+        "locale": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "payload": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "description": "schema for Sync pings, documentation avaliable in toolkit/components/telemetry/docs/sync-ping.rst",

--- a/scripts/assert-telemetry-version
+++ b/scripts/assert-telemetry-version
@@ -12,6 +12,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+""" List of schemas that shouldn't be validated"""
+SCHEMAS_TO_IGNORE = {
+    "sync", # sync v5 is sent from Android
+}
+
+
 def is_placeholder(schema: Dict[str, Any]) -> bool:
     return schema["title"] == "placeholder_schema" and not schema.get("properties")
 
@@ -39,6 +45,8 @@ def main(project_root: Path) -> None:
         schema = json.load(open(path))
         relative_path = "/".join(path.parts[-3:])
         if is_placeholder(schema):
+            continue
+        if path.parts[-2] in SCHEMAS_TO_IGNORE:
             continue
         is_valid, err_msg = is_valid_telemetry_version(schema)
         if not is_valid:

--- a/templates/telemetry/sync/sync.5.schema.json
+++ b/templates/telemetry/sync/sync.5.schema.json
@@ -1,1 +1,74 @@
-@COMMON_PLACEHOLDER_1_JSON@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "sync",
+  "description": "Schema for v5 of sync pings added for GCP compatibility. This is a copy of v4 schema, as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1572744#c3",
+  "properties": {
+    "creationDate": {
+      "type": "string",
+      "$comment": "Note that we drop the pattern requirement commonly used by other ping types for this field due to observed values in incoming data."
+    },
+    "application": {
+      "$comment": "The application section is included here inline due to incompatible incoming data",
+      "type": "object",
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "type": "string",
+          "$comment": "Note that we drop the pattern requirement commonly used by other ping types for this field due to observed values in incoming data."
+        },
+        "channel": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "channel",
+        "name",
+        "platformVersion",
+        "version"
+      ],
+      "additionalProperties": false
+    },
+    @TELEMETRY_ID_1_JSON@,
+    "type": {
+      "type": "string",
+      "enum": [ "sync" ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 5,
+      "maximum": 5
+    },
+    "payload": @TELEMETRY_SYNCPAYLOAD_1_JSON@
+  },
+  "required": [
+    "application",
+    "type",
+    "id",
+    "creationDate",
+    "version",
+    "payload"
+  ],
+  "additionalProperties": false
+}

--- a/templates/telemetry/sync/sync.5.schema.json
+++ b/templates/telemetry/sync/sync.5.schema.json
@@ -60,6 +60,14 @@
       "minimum": 5,
       "maximum": 5
     },
+    "os": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "locale": { "type": "string" }
+      }
+    },
     "payload": @TELEMETRY_SYNCPAYLOAD_1_JSON@
   },
   "required": [

--- a/validation/telemetry/sync.5.sample.pass.json
+++ b/validation/telemetry/sync.5.sample.pass.json
@@ -1,0 +1,37 @@
+{
+  "os": {
+    "name": "Android",
+    "version": "15",
+    "locale": "en-GB"
+  },
+  "application": {
+    "platformVersion": "55.0.2",
+    "displayVersion": "55.0.2",
+    "xpcomAbi": "arm-eabi-gcc3",
+    "buildId": "20170815231002",
+    "vendor": "Mozilla",
+    "name": "Fennec",
+    "architecture": "armeabi-v7a",
+    "channel": "release",
+    "version": "55.0.2"
+  },
+  "payload": {
+    "syncs": [
+      {
+        "took": 2403,
+        "failureReason": {
+          "error": "TokenServerInvalidCredentialsException",
+          "name": "token"
+        },
+        "when": 1571615226508,
+        "engines": []
+      }
+    ],
+    "why": "schedule",
+    "version": 1
+  },
+  "id": "5f21e326-2e2d-4240-b060-1591ed483c4e",
+  "creationDate": "2019-10-20T23:47:06Z",
+  "type": "sync",
+  "version": 5
+}


### PR DESCRIPTION
This is a copy of v4 schema that will support migration of sync queries
to GCP.

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
