### PR TITLE
Add new Firefox Voice telemetry fields

### DIFF
--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1130,9 +1130,33 @@
     },
     "payload": {
       "properties": {
+        "audioTime": {
+          "description": "Time in milliseconds of the recording",
+          "title": "Amount of spoken time",
+          "type": "integer"
+        },
+        "country": {
+          "title": "User country code",
+          "type": "string"
+        },
+        "deepSpeechConfidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence of DeepSpeech text-to-speech transcription",
+          "type": "number"
+        },
         "deepSpeechMatches": {
           "title": "Did the DeepSpeech transcription match with Google's?",
           "type": "boolean"
+        },
+        "deepSpeechServerTime": {
+          "description": "Milliseconds for the DeepSpeech transcription to complete and respond",
+          "title": "Response time of DeepSpeech server",
+          "type": "integer"
+        },
+        "extensionInstallDate": {
+          "title": "Timestamp when the extension was installed",
+          "type": "integer"
         },
         "extensionInstallationChannel": {
           "description": "Where the user first installed the extension (e.g., internal_beta, external_beta, etc)",
@@ -1218,12 +1242,28 @@
           "title": "Was the intent action successful?",
           "type": "boolean"
         },
+        "intentTime": {
+          "description": "Milliseconds between getting the utterance and execution the intent",
+          "title": "Time to execute the intent",
+          "type": "integer"
+        },
         "internalError": {
           "title": "If there was an unexpected error, the name of that error",
           "type": "string"
         },
+        "localHour": {
+          "description": "The hour, 0-23, in the local timezone when the action was run",
+          "title": "Local hour of action",
+          "type": "integer"
+        },
+        "numberOfOpenTabs": {
+          "description": "A count of the number of tabs in all windows, that are open when the tool is activated",
+          "title": "Number of open tabs",
+          "type": "integer"
+        },
         "serverErrorIntentParser": {
-          "title": "Error with the server intent parser",
+          "description": "Error with the server intent parser",
+          "title": "DEPRECATED",
           "type": "string"
         },
         "serverErrorSpeech": {
@@ -1231,8 +1271,9 @@
           "type": "string"
         },
         "serverTimeIntentParser": {
+          "description": "Time in milliseconds for server intent parsing",
           "minimum": 0,
-          "title": "Time in milliseconds for server intent parsing",
+          "title": "DEPRECATED",
           "type": "number"
         },
         "serverTimeSpeech": {

--- a/templates/telemetry/voice/voice.4.schema.json
+++ b/templates/telemetry/voice/voice.4.schema.json
@@ -29,6 +29,10 @@
           "description": "Where the user first installed the extension (e.g., internal_beta, external_beta, etc)",
           "type": "string"
         },
+        "extensionInstallDate": {
+          "title": "Timestamp when the extension was installed",
+          "type": "integer"
+        },
         "siteCategoryOpened": {
           "title": "Category of site opened by intent",
           "type": "string"
@@ -46,6 +50,10 @@
         "hasCard": {
           "title": "Does the intent produce a card-like output?",
           "type": "boolean"
+        },
+        "country": {
+          "title": "User country code",
+          "type": "string"
         },
         "inputCancelled": {
           "title": "Was the interaction cancelled?",
@@ -109,20 +117,22 @@
           "type": "string"
         },
         "serverErrorIntentParser": {
-          "title": "Error with the server intent parser",
+          "title": "DEPRECATED",
+          "description": "Error with the server intent parser",
           "type": "string"
         },
         "serverErrorSpeech": {
           "title": "Error with the server speech-to-text parser",
           "type": "string"
         },
+        "serverTimeIntentParser": {
+          "title": "DEPRECATED",
+          "minimum": 0,
+          "description": "Time in milliseconds for server intent parsing",
+          "type": "number"
+        },
         "serverTimeSpeech": {
           "title": "Time in milliseconds for server TTS",
-          "type": "number",
-          "minimum": 0
-        },
-        "serverTimeIntentParser": {
-          "title": "Time in milliseconds for server intent parsing",
           "type": "number",
           "minimum": 0
         },
@@ -136,10 +146,31 @@
           "minimum": 0.0,
           "maximum": 1.0
         },
+        "deepSpeechConfidence": {
+          "title": "Confidence of DeepSpeech text-to-speech transcription",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
         "timestamp": {
           "title": "Milliseconds-since-the-epoch when intent was started",
           "type": "number",
           "minimum": 0
+        },
+        "localHour": {
+          "title": "Local hour of action",
+          "description": "The hour, 0-23, in the local timezone when the action was run",
+          "type": "integer"
+        },
+        "audioTime": {
+          "title": "Amount of spoken time",
+          "description": "Time in milliseconds of the recording",
+          "type": "integer"
+        },
+        "intentTime": {
+          "title": "Time to execute the intent",
+          "description": "Milliseconds between getting the utterance and execution the intent",
+          "type": "integer"
         },
         "utterance": {
           "title": "Text utterance by user",
@@ -167,6 +198,16 @@
         "deepSpeechMatches": {
           "title": "Did the DeepSpeech transcription match with Google's?",
           "type": "boolean"
+        },
+        "deepSpeechServerTime": {
+          "title": "Response time of DeepSpeech server",
+          "description": "Milliseconds for the DeepSpeech transcription to complete and respond",
+          "type": "integer"
+        },
+        "numberOfOpenTabs": {
+          "title": "Number of open tabs",
+          "description": "A count of the number of tabs in all windows, that are open when the tool is activated",
+          "type": "integer"
         }
       },
       "required": [

--- a/validation/telemetry/voice.4.full.pass.json
+++ b/validation/telemetry/voice.4.full.pass.json
@@ -7,8 +7,11 @@
     "extensionVersion": "0.1",
     "extensionTemporaryInstall": false,
     "extensionInstallationChannel": "internal_alpha",
+    "extensionInstallDate": 1573083365230,
+    "localHour": 17,
     "siteCategoryOpened": "search",
-    "inputLength": 10,
+    "country": "us",
+    "inputLength": 20,
     "hasCard": false,
     "inputCancelled": false,
     "inputTyped": false,
@@ -25,6 +28,8 @@
     "serverTimeSpeech": 1082,
     "serverVersion": "1.0",
     "transcriptionConfidence": 0.9,
+    "audioTime": 2103,
+    "intentTime": 3011,
     "timestamp": 1567635586896,
     "utterance": "search for something",
     "utteranceChars": 20,
@@ -33,7 +38,9 @@
     },
     "utteranceDeepSpeech": "search for something",
     "utteranceDeepSpeechChars": 20,
-    "deepSpeechMatches": true
+    "deepSpeechMatches": true,
+    "deepSpeechServerTime": 2001,
+    "numberOfOpenTabs": 12
   },
   "creationDate": "2019-02-16T17:23:29.850Z",
   "application": {


### PR DESCRIPTION
Voice bug: https://github.com/mozilla/firefox-voice/issues/546

Adds to ping:
* Date of first installation
* Number of tabs open
* Local time of day (hour)
* Country
* Server timing for DeepSpeech
* Audio recording time
* Performance measure (time) post-processing

~Also removes some fields related to a component (intent parser) that we decided not to implement separately.~

Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
