### PR TITLE
Bug 1595904 - Add missing metadata fields to crash pings from "crash" ping source docs

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1139,52 +1139,132 @@
         },
         "metadata": {
           "properties": {
+            "AsyncShutdownTimeout": {
+              "description": "<json>, Optional, present when a shutdown blocker failed to respond within a reasonable amount of time",
+              "type": "string"
+            },
             "AvailablePageFile": {
+              "description": "<size>, Windows-only, available paging file in bytes",
               "type": "string"
             },
             "AvailablePhysicalMemory": {
+              "description": "<size>, Windows-only, available physical memory in bytes",
               "type": "string"
             },
             "AvailableVirtualMemory": {
+              "description": "<size>, Windows-only, available virtual memory in bytes",
+              "type": "string"
+            },
+            "BlockedDllList": {
+              "description": "<list>, Windows-only, see WindowsDllBlocklist.cpp for details",
+              "type": "string"
+            },
+            "BlocklistInitFailed": {
+              "description": "1, Windows-only, present only if the DLL blocklist initialization failed",
               "type": "string"
             },
             "BuildID": {
+              "description": "YYYYMMDDHHMMSS",
+              "type": "string"
+            },
+            "ContainsMemoryReport": {
+              "description": "1, Optional, if set indicates that the crash had a memory report attached",
+              "type": "string"
+            },
+            "CrashTime": {
+              "description": "<time>, Seconds since the Epoch",
+              "type": "string"
+            },
+            "EventLoopNestingLevel": {
+              "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
               "type": "string"
             },
             "IsGarbageCollecting": {
+              "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
+              "type": "string"
+            },
+            "LowCommitSpaceEvents": {
+              "description": "<num>, Windows-only, present only if >0, number of low commit space events detected by the available memory tracker",
+              "type": "string"
+            },
+            "MemoryErrorCorrection": {
+              "description": "<type>, Windows-only, indicates the type of ECC memory in use, see below",
+              "type": "string"
+            },
+            "MozCrashReason": {
+              "description": "<reason>, Optional, contains the string passed to MOZ_CRASH()",
+              "type": "string"
+            },
+            "OOMAllocationSize": {
+              "description": "<size>, Size of the allocation that caused an OOM",
               "type": "string"
             },
             "ProductID": {
+              "description": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
               "type": "string"
             },
             "ProductName": {
+              "description": "Firefox",
               "type": "string"
             },
             "ReleaseChannel": {
+              "description": "<channel>",
+              "type": "string"
+            },
+            "RemoteType": {
+              "description": "<type>, Optional, type of content process, see below for a list of types",
               "type": "string"
             },
             "SecondsSinceLastCrash": {
+              "description": "<duration>, Seconds elapsed since the last crash occurred",
+              "type": "string"
+            },
+            "ShutdownProgress": {
+              "description": "<phase>, Optional, contains a string describing the shutdown phase in which the crash occurred",
               "type": "string"
             },
             "StartupCrash": {
+              "description": "1, Optional, if set indicates that Firefox crashed during startup",
               "type": "string"
             },
             "SystemMemoryUsePercentage": {
+              "description": "<percentage>, Windows-only, percent of memory in use",
+              "type": "string"
+            },
+            "TelemetrySessionId": {
+              "description": "<id>, Active telemetry session ID when the crash was recorded",
+              "type": "string"
+            },
+            "TextureUsage": {
+              "description": "<usage>, Optional, usage of texture memory in bytes",
               "type": "string"
             },
             "TotalPageFile": {
+              "description": "<size>, Windows-only, paging file in use expressed in bytes",
               "type": "string"
             },
             "TotalPhysicalMemory": {
+              "description": "<size>, Windows-only, physical memory in use expressed in bytes",
               "type": "string"
             },
             "TotalVirtualMemory": {
+              "description": "<size>, Windows-only, virtual memory in use expressed in bytes",
+              "type": "string"
+            },
+            "UptimeTS": {
+              "description": "<duration>, Seconds since Firefox was started, this can have a fractional component",
+              "type": "string"
+            },
+            "User32BeforeBlocklist": {
+              "description": "1, Windows-only, present only if user32.dll was loaded before the DLL blocklist has been initialized",
               "type": "string"
             },
             "Version": {
+              "description": "<version number>",
               "type": "string"
             },
             "ipc_channel_error": {
+              "description": "<error string>, Optional, contains the string processing error reason for an ipc-based content crash",
               "type": "string"
             }
           },

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -21,52 +21,132 @@
         "metadata": {
           "type": "object",
           "properties": {
+            "AsyncShutdownTimeout": {
+              "description": "<json>, Optional, present when a shutdown blocker failed to respond within a reasonable amount of time",
+              "type": "string"
+            },
             "AvailablePageFile": {
+              "description": "<size>, Windows-only, available paging file in bytes",
               "type": "string"
             },
             "AvailablePhysicalMemory": {
+              "description": "<size>, Windows-only, available physical memory in bytes",
               "type": "string"
             },
             "AvailableVirtualMemory": {
+              "description": "<size>, Windows-only, available virtual memory in bytes",
+              "type": "string"
+            },
+            "BlockedDllList": {
+              "description": "<list>, Windows-only, see WindowsDllBlocklist.cpp for details",
+              "type": "string"
+            },
+            "BlocklistInitFailed": {
+              "description": "1, Windows-only, present only if the DLL blocklist initialization failed",
               "type": "string"
             },
             "BuildID": {
+              "description": "YYYYMMDDHHMMSS",
+              "type": "string"
+            },
+            "ContainsMemoryReport": {
+              "description": "1, Optional, if set indicates that the crash had a memory report attached",
+              "type": "string"
+            },
+            "CrashTime": {
+              "description": "<time>, Seconds since the Epoch",
+              "type": "string"
+            },
+            "EventLoopNestingLevel": {
+              "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
               "type": "string"
             },
             "ipc_channel_error": {
+              "description": "<error string>, Optional, contains the string processing error reason for an ipc-based content crash",
               "type": "string"
             },
             "IsGarbageCollecting": {
+              "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
+              "type": "string"
+            },
+            "LowCommitSpaceEvents": {
+              "description": "<num>, Windows-only, present only if >0, number of low commit space events detected by the available memory tracker",
+              "type": "string"
+            },
+            "MemoryErrorCorrection": {
+              "description": "<type>, Windows-only, indicates the type of ECC memory in use, see below",
+              "type": "string"
+            },
+            "MozCrashReason": {
+              "description": "<reason>, Optional, contains the string passed to MOZ_CRASH()",
+              "type": "string"
+            },
+            "OOMAllocationSize": {
+              "description": "<size>, Size of the allocation that caused an OOM",
               "type": "string"
             },
             "ProductID": {
+              "description": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
               "type": "string"
             },
             "ProductName": {
+              "description": "Firefox",
               "type": "string"
             },
             "ReleaseChannel": {
+              "description": "<channel>",
+              "type": "string"
+            },
+            "RemoteType": {
+              "description": "<type>, Optional, type of content process, see below for a list of types",
               "type": "string"
             },
             "SecondsSinceLastCrash": {
+              "description": "<duration>, Seconds elapsed since the last crash occurred",
+              "type": "string"
+            },
+            "ShutdownProgress": {
+              "description": "<phase>, Optional, contains a string describing the shutdown phase in which the crash occurred",
               "type": "string"
             },
             "StartupCrash": {
+              "description": "1, Optional, if set indicates that Firefox crashed during startup",
               "type": "string"
             },
             "SystemMemoryUsePercentage": {
+              "description": "<percentage>, Windows-only, percent of memory in use",
+              "type": "string"
+            },
+            "TelemetrySessionId": {
+              "description": "<id>, Active telemetry session ID when the crash was recorded",
+              "type": "string"
+            },
+            "TextureUsage": {
+              "description": "<usage>, Optional, usage of texture memory in bytes",
               "type": "string"
             },
             "TotalPageFile": {
+              "description": "<size>, Windows-only, paging file in use expressed in bytes",
               "type": "string"
             },
             "TotalPhysicalMemory": {
+              "description": "<size>, Windows-only, physical memory in use expressed in bytes",
               "type": "string"
             },
             "TotalVirtualMemory": {
+              "description": "<size>, Windows-only, virtual memory in use expressed in bytes",
+              "type": "string"
+            },
+            "UptimeTS": {
+              "description": "<duration>, Seconds since Firefox was started, this can have a fractional component",
+              "type": "string"
+            },
+            "User32BeforeBlocklist": {
+              "description": "1, Windows-only, present only if user32.dll was loaded before the DLL blocklist has been initialized",
               "type": "string"
             },
             "Version": {
+              "description": "<version number>",
               "type": "string"
             }
           }


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1595904)

This [redash query](https://sql.telemetry.mozilla.org/queries/66131/source) verifies that all fields in the metadata structure are strings. 

Row | key | type | freq |  
-- | -- | -- | -- | --
1 | AsyncShutdownTimeout | string | 644 |  
2 | BlockedDllList | string | 549 |  
3 | BlocklistInitFailed | string | 171 |  
4 | ContainsMemoryReport | string | 1718 |  
5 | CrashTime | string | 14726 |  
6 | EventLoopNestingLevel | string | 1487 |  
7 | IndexedDBShutdownTimeout | string | 21 |  
8 | LowCommitSpaceEvents | string | 2057 |  
9 | MemoryErrorCorrection | string | 10303 |  
10 | MozCrashReason | string | 7293 |  
11 | OOMAllocationSize | string | 4000 |  
12 | RemoteType | string | 7423 |  
13 | ShutdownProgress | string | 3757 |  
14 | TextureUsage | string | 526 |  
15 | UptimeTS | string | 14726 |  
16 | User32BeforeBlocklist | string | 325 |  


Script used to generate the metadata section:

```python
#!/usr/bin/env python3

data = """AsyncShutdownTimeout: <json>, Optional, present when a shutdown blocker failed to respond within a reasonable amount of time
AvailablePageFile: <size>, Windows-only, available paging file in bytes
AvailablePhysicalMemory: <size>, Windows-only, available physical memory in bytes
AvailableVirtualMemory: <size>, Windows-only, available virtual memory in bytes
BlockedDllList: <list>, Windows-only, see WindowsDllBlocklist.cpp for details
BlocklistInitFailed: "1", Windows-only, present only if the DLL blocklist initialization failed
BuildID: "YYYYMMDDHHMMSS"
ContainsMemoryReport: "1", Optional, if set indicates that the crash had a memory report attached
CrashTime: <time>, Seconds since the Epoch
EventLoopNestingLevel: <levels>, Optional, present only if >0, indicates the nesting level of the event-loop
ipc_channel_error: <error string>, Optional, contains the string processing error reason for an ipc-based content crash
IsGarbageCollecting: "1", Optional, if set indicates that the crash occurred while the garbage collector was running
LowCommitSpaceEvents: <num>, Windows-only, present only if >0, number of low commit space events detected by the available memory tracker
MemoryErrorCorrection: <type>, Windows-only, indicates the type of ECC memory in use, see below
MozCrashReason: <reason>, Optional, contains the string passed to MOZ_CRASH()
OOMAllocationSize: <size>, Size of the allocation that caused an OOM
ProductID: "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
ProductName: "Firefox"
ReleaseChannel: <channel>
RemoteType: <type>, Optional, type of content process, see below for a list of types
SecondsSinceLastCrash: <duration>, Seconds elapsed since the last crash occurred
ShutdownProgress: <phase>, Optional, contains a string describing the shutdown phase in which the crash occurred
StartupCrash: "1", Optional, if set indicates that Firefox crashed during startup
SystemMemoryUsePercentage: <percentage>, Windows-only, percent of memory in use
TelemetrySessionId: <id>, Active telemetry session ID when the crash was recorded
TextureUsage: <usage>, Optional, usage of texture memory in bytes
TotalPageFile: <size>, Windows-only, paging file in use expressed in bytes
TotalPhysicalMemory: <size>, Windows-only, physical memory in use expressed in bytes
TotalVirtualMemory: <size>, Windows-only, virtual memory in use expressed in bytes
UptimeTS: <duration>, Seconds since Firefox was started, this can have a fractional component
User32BeforeBlocklist: "1", Windows-only, present only if user32.dll was loaded before the DLL blocklist has been initialized
Version: <version number>
"""

import json
metadata = {}
for line in data.split("\n"):
    if not line: continue
    name, desc = [x.strip() for x in line.split(":")]
    metadata[name] = {
        "description": desc.replace('"', '').rstrip(","),
        "type": "string",
    }

print(json.dumps(metadata, indent=2))
```

https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/crash-ping.html


Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)
