### PR TITLE
Add more valid values for Activity Stream Events

### DIFF
--- a/schemas/activity-stream/events/events.1.schema.json
+++ b/schemas/activity-stream/events/events.1.schema.json
@@ -24,7 +24,9 @@
         "about:newtab",
         "about:home",
         "about:welcome",
-        "unknown"
+        "unknown",
+        "n/a",
+        "both"
       ],
       "type": "string"
     },
@@ -39,7 +41,7 @@
     },
     "session_id": {
       "description": "A UUID representing the session, in which this event occurred",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$",
       "type": "string"
     },
     "shield_id": {

--- a/templates/activity-stream/events/events.1.schema.json
+++ b/templates/activity-stream/events/events.1.schema.json
@@ -22,11 +22,11 @@
     "session_id": {
       "description": "A UUID representing the session, in which this event occurred",
       "type": "string",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$"
     },
     "page": {
       "type": "string",
-      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown" ]
+      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown", "n/a", "both" ]
     },
     "source": {
       "type": "string"

--- a/validation/activity-stream/events.1.alternative.pass.json
+++ b/validation/activity-stream/events.1.alternative.pass.json
@@ -1,0 +1,17 @@
+{
+  "locale": "en-US",
+  "client_id": "4dd69e99-07e7-c040-a514-ccde0cfd4881",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20191119043902",
+  "user_prefs": 255,
+  "session_id": "n/a",
+  "page": "n/a",
+  "event": "CLICK",
+  "source": "TOP_SITES",
+  "action_position": 0,
+  "value": "{\"icon_type\": \"rich_icon\"}",
+  "profile_creation_date": 16587,
+  "region": "CA",
+  "shield_id": "activity-stream-shield-study-bug-1238122"
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`

The local tests worked great, only identified a few missing valid values for `page` and `session_id`. Note that the "page" for the Chinese build needs to be added in the future, so expect some validation errors for that.

@jklukas r?
