### PR TITLE
 Bug 1595586 - Add environment.system.gfx.ContentBackend

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -714,6 +714,9 @@
             },
             "gfx": {
               "properties": {
+                "ContentBackend": {
+                  "type": "string"
+                },
                 "D2DEnabled": {
                   "type": [
                     "boolean",

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -564,6 +564,9 @@
         "gfx": {
           "type": "object",
           "properties": {
+            "ContentBackend": {
+              "type": "string"
+            },
             "D2DEnabled": {
               "type": [
                 "boolean",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1595586)

In the bug, the documentation was updated to include this field in the graphics subsection. This PR adds the field to be transformed into a BigQuery column.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
