### PR TITLE
Bug 1604666 - Add `payload.crashId` in telemetry.crash_v4

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1138,6 +1138,8 @@
           "type": "string"
         },
         "crashId": {
+          "description": "Optional, ID of the associated crash. Added to schema in bug 1604666.",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
           "type": "string"
         },
         "hasCrashEnvironment": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1139,7 +1139,6 @@
         },
         "crashId": {
           "description": "Optional, ID of the associated crash. Added to schema in bug 1604666.",
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
           "type": "string"
         },
         "hasCrashEnvironment": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1137,6 +1137,9 @@
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
           "type": "string"
         },
+        "crashId": {
+          "type": "string"
+        },
         "hasCrashEnvironment": {
           "type": "boolean"
         },

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -17,7 +17,6 @@
         },
         "crashId": {
           "type": "string",
-          @COMMON_PATTERN_UUID_1_JSON@,
           "description": "Optional, ID of the associated crash. Added to schema in bug 1604666."
         },
         "hasCrashEnvironment": {

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -16,7 +16,9 @@
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
         },
         "crashId": {
-          "type": "string"
+          "type": "string",
+          @COMMON_PATTERN_UUID_1_JSON@,
+          "description": "Optional, ID of the associated crash. Added to schema in bug 1604666."
         },
         "hasCrashEnvironment": {
           "type": "boolean"

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -15,6 +15,9 @@
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
         },
+        "crashId": {
+          "type": "string"
+        },
         "hasCrashEnvironment": {
           "type": "boolean"
         },


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1604666)

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
