### PR TITLE
 Bug 1604913 - Add payload.minidumpSha256Hash to telemetry.crash_v4

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1273,6 +1273,10 @@
           },
           "type": "object"
         },
+        "minidumpSha256Hash": {
+          "description": "SHA256 hash of the minidump file. Added to schema in bug 1604913.",
+          "type": "string"
+        },
         "processType": {
           "type": "string"
         },

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -151,6 +151,10 @@
             }
           }
         },
+        "minidumpSha256Hash": {
+          "description": "SHA256 hash of the minidump file. Added to schema in bug 1604913.",
+          "type": "string"
+        },
         "processType": {
           "type": "string"
         },


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1604913)

Reference: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/crash-ping.html

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)