### PR TITLE
Allow negative sessionLengths and event timestamps

### DIFF
--- a/schemas/mozza/event/event.1.schema.json
+++ b/schemas/mozza/event/event.1.schema.json
@@ -13,7 +13,6 @@
     "event": {
       "items": [
         {
-          "minimum": 0,
           "type": "integer"
         },
         {

--- a/schemas/pocket/fire-tv-events/fire-tv-events.1.schema.json
+++ b/schemas/pocket/fire-tv-events/fire-tv-events.1.schema.json
@@ -11,7 +11,6 @@
       "items": {
         "items": [
           {
-            "minimum": 0,
             "type": "integer"
           },
           {

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -1139,7 +1139,6 @@
               "items": {
                 "items": [
                   {
-                    "minimum": 0,
                     "type": "integer"
                   },
                   {
@@ -1180,7 +1179,6 @@
               "items": {
                 "items": [
                   {
-                    "minimum": 0,
                     "type": "integer"
                   },
                   {
@@ -1221,7 +1219,6 @@
               "items": {
                 "items": [
                   {
-                    "minimum": 0,
                     "type": "integer"
                   },
                   {
@@ -1262,7 +1259,6 @@
               "items": {
                 "items": [
                   {
-                    "minimum": 0,
                     "type": "integer"
                   },
                   {
@@ -1303,7 +1299,6 @@
               "items": {
                 "items": [
                   {
-                    "minimum": 0,
                     "type": "integer"
                   },
                   {

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1285,8 +1285,7 @@
               "type": "string"
             },
             "sessionLength": {
-              "description": "the session length until now in seconds, monotonic",
-              "minimum": 0,
+              "description": "the session length until now in seconds, monotonic; some clients report erroneous negative values",
               "type": [
                 "integer",
                 "null"
@@ -1425,7 +1424,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -1717,7 +1715,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2009,7 +2006,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2301,7 +2297,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2593,7 +2588,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2888,7 +2882,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -26,7 +26,6 @@
       "items": {
         "items": [
           {
-            "minimum": 0,
             "type": "integer"
           },
           {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1285,8 +1285,7 @@
               "type": "string"
             },
             "sessionLength": {
-              "description": "the session length until now in seconds, monotonic",
-              "minimum": 0,
+              "description": "the session length until now in seconds, monotonic; some clients report erroneous negative values",
               "type": [
                 "integer",
                 "null"
@@ -1425,7 +1424,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -1717,7 +1715,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2009,7 +2006,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2301,7 +2297,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2593,7 +2588,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2888,7 +2882,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -26,7 +26,6 @@
       "items": {
         "items": [
           {
-            "minimum": 0,
             "type": "integer"
           },
           {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1144,7 +1144,6 @@
                       "items": {
                         "items": [
                           {
-                            "minimum": 0,
                             "type": "integer"
                           },
                           {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1285,8 +1285,7 @@
               "type": "string"
             },
             "sessionLength": {
-              "description": "the session length until now in seconds, monotonic",
-              "minimum": 0,
+              "description": "the session length until now in seconds, monotonic; some clients report erroneous negative values",
               "type": [
                 "integer",
                 "null"
@@ -1425,7 +1424,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -1717,7 +1715,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2009,7 +2006,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2301,7 +2297,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2593,7 +2588,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {
@@ -2888,7 +2882,6 @@
                   "items": {
                     "items": [
                       {
-                        "minimum": 0,
                         "type": "integer"
                       },
                       {

--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -72,7 +72,6 @@
           "items": {
             "items": [
               {
-                "minimum": 0,
                 "type": "integer"
               },
               {

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -86,7 +86,6 @@
           "items": {
             "items": [
               {
-                "minimum": 0,
                 "type": "integer"
               },
               {

--- a/templates/include/common/event.1.schema.json
+++ b/templates/include/common/event.1.schema.json
@@ -2,8 +2,7 @@
   "type": "array",
   "items": [
     {
-      "type": "integer",
-      "minimum": 0
+      "type": "integer"
     },
     {
       "type": "string"

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -81,8 +81,7 @@
         },
         "sessionLength": {
           "type": [ "integer", "null" ],
-          "minimum": 0,
-          "description": "the session length until now in seconds, monotonic"
+          "description": "the session length until now in seconds, monotonic; some clients report erroneous negative values"
         },
         "subsessionLength": {
           "type": [ "integer", "null" ],


### PR DESCRIPTION
These values should never be negative, but we are seeing a significant number
of negative values since Firefox 71. Since we have not been able to determine
the cause and the current situation is leading us to undercount in all desktop
analyses, we are going to allow negative values to start flowing through.

See bugs
https://bugzilla.mozilla.org/show_bug.cgi?id=1592012#c15
and
https://bugzilla.mozilla.org/show_bug.cgi?id=1602521

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
