### PR TITLE
Add $id field for identifying main and placeholder schemas

### DIFF
--- a/schemas/telemetry/addon-install-blocked/addon-install-blocked.4.schema.json
+++ b/schemas/telemetry/addon-install-blocked/addon-install-blocked.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/advancedtelemetry/advancedtelemetry.4.schema.json
+++ b/schemas/telemetry/advancedtelemetry/advancedtelemetry.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.1.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.1.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.10.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.10.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.2.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.2.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.3.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.3.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.4.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.5.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.5.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.6.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.6.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.7.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.7.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.8.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.8.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/android-anr-report/android-anr-report.9.schema.json
+++ b/schemas/telemetry/android-anr-report/android-anr-report.9.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/block-autoplay/block-autoplay.4.schema.json
+++ b/schemas/telemetry/block-autoplay/block-autoplay.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/certificate-checker/certificate-checker.4.schema.json
+++ b/schemas/telemetry/certificate-checker/certificate-checker.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/crash/crash.2.schema.json
+++ b/schemas/telemetry/crash/crash.2.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/deletion/deletion.4.schema.json
+++ b/schemas/telemetry/deletion/deletion.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/deployment-checker/deployment-checker.4.schema.json
+++ b/schemas/telemetry/deployment-checker/deployment-checker.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/disable-sha1rollout/disable-sha1rollout.4.schema.json
+++ b/schemas/telemetry/disable-sha1rollout/disable-sha1rollout.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/disableSHA1rollout/disableSHA1rollout.4.schema.json
+++ b/schemas/telemetry/disableSHA1rollout/disableSHA1rollout.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/main/ping/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "application": {

--- a/schemas/telemetry/flash-shield-study/flash-shield-study.4.schema.json
+++ b/schemas/telemetry/flash-shield-study/flash-shield-study.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/frecency-update/frecency-update.1.schema.json
+++ b/schemas/telemetry/frecency-update/frecency-update.1.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/ftu/ftu.3.schema.json
+++ b/schemas/telemetry/ftu/ftu.3.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/health/health.2.schema.json
+++ b/schemas/telemetry/health/health.2.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/health/health.9.schema.json
+++ b/schemas/telemetry/health/health.9.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/main/ping/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "application": {

--- a/schemas/telemetry/malware-addon-states/malware-addon-states.4.schema.json
+++ b/schemas/telemetry/malware-addon-states/malware-addon-states.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/outofdate-notifications-system-addon/outofdate-notifications-system-addon.4.schema.json
+++ b/schemas/telemetry/outofdate-notifications-system-addon/outofdate-notifications-system-addon.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/main/ping/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "application": {

--- a/schemas/telemetry/searchvol/searchvol.4.schema.json
+++ b/schemas/telemetry/searchvol/searchvol.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/searchvolextra/searchvolextra.4.schema.json
+++ b/schemas/telemetry/searchvolextra/searchvolextra.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/shield-study-addon/shield-study-addon.4.schema.json
+++ b/schemas/telemetry/shield-study-addon/shield-study-addon.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/shield-study-error/shield-study-error.4.schema.json
+++ b/schemas/telemetry/shield-study-error/shield-study-error.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/shield-study/shield-study.4.schema.json
+++ b/schemas/telemetry/shield-study/shield-study.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/system-addon-deployment-diagnostics/system-addon-deployment-diagnostics.4.schema.json
+++ b/schemas/telemetry/system-addon-deployment-diagnostics/system-addon-deployment-diagnostics.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/testpilottest/testpilottest.4.schema.json
+++ b/schemas/telemetry/testpilottest/testpilottest.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls-13-study-v1/tls-13-study-v1.4.schema.json
+++ b/schemas/telemetry/tls-13-study-v1/tls-13-study-v1.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls-13-study-v2/tls-13-study-v2.4.schema.json
+++ b/schemas/telemetry/tls-13-study-v2/tls-13-study-v2.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls-13-study-v3/tls-13-study-v3.4.schema.json
+++ b/schemas/telemetry/tls-13-study-v3/tls-13-study-v3.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls-13-study-v4/tls-13-study-v4.4.schema.json
+++ b/schemas/telemetry/tls-13-study-v4/tls-13-study-v4.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls-13-study/tls-13-study.4.schema.json
+++ b/schemas/telemetry/tls-13-study/tls-13-study.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-alt-server-hello-1/tls13-middlebox-alt-server-hello-1.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-alt-server-hello-1/tls13-middlebox-alt-server-hello-1.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-beta/tls13-middlebox-beta.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-beta/tls13-middlebox-beta.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-draft22/tls13-middlebox-draft22.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-draft22/tls13-middlebox-draft22.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-ghack/tls13-middlebox-ghack.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-ghack/tls13-middlebox-ghack.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-repetition/tls13-middlebox-repetition.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-repetition/tls13-middlebox-repetition.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/tls13-middlebox-testing/tls13-middlebox-testing.4.schema.json
+++ b/schemas/telemetry/tls13-middlebox-testing/tls13-middlebox-testing.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/uitour-tag/uitour-tag.4.schema.json
+++ b/schemas/telemetry/uitour-tag/uitour-tag.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/schemas/telemetry/x-contextual-feature-recommendation/x-contextual-feature-recommendation.4.schema.json
+++ b/schemas/telemetry/x-contextual-feature-recommendation/x-contextual-feature-recommendation.4.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {},
   "title": "placeholder_schema",

--- a/templates/include/common/placeholder.1.schema.json
+++ b/templates/include/common/placeholder.1.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema" : "http://json-schema.org/draft-04/schema#",
+  "$id": "moz://mozilla.org/schemas/placeholder/schema/1",
   "type" : "object",
   "title" : "placeholder_schema",
   "properties" : {

--- a/templates/include/telemetry/mainSchemaId.1.schema.json
+++ b/templates/include/telemetry/mainSchemaId.1.schema.json
@@ -1,0 +1,1 @@
+"$id": "moz://mozilla.org/schemas/main/ping/1"

--- a/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    @TELEMETRY_MAINSCHEMAID_1_JSON@,
     "type": "object",
     "title": "first-shutdown",
     "properties": {

--- a/templates/telemetry/main/main.4.schema.json
+++ b/templates/telemetry/main/main.4.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  @TELEMETRY_MAINSCHEMAID_1_JSON@,
   "type": "object",
   "title": "main",
   "properties": {

--- a/templates/telemetry/saved-session/saved-session.4.schema.json
+++ b/templates/telemetry/saved-session/saved-session.4.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  @TELEMETRY_MAINSCHEMAID_1_JSON@,
   "type": "object",
   "title": "saved-session",
   "properties": {


### PR DESCRIPTION
This will be relevant once we start publishing the $id field as a label on
BigQuery tables per https://github.com/mozilla-services/cloudops-infra/pull/1723

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
