### PR TITLE
Bug 1607315 - Add Activity Stream session ping

### DIFF
--- a/schemas/activity-stream/events/events.1.schema.json
+++ b/schemas/activity-stream/events/events.1.schema.json
@@ -41,7 +41,7 @@
       "type": "string"
     },
     "session_id": {
-      "description": "A UUID representing the session, in which this event occurred",
+      "description": "A UUID representing an Activity Stream session. This can be used to do table joins between `sessions` and `events` in Activity Stream. Note that `n/a` denotes that the session is not applicable in the context.",
       "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$",
       "type": "string"
     },

--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -30,6 +30,8 @@
         "about:home",
         "about:welcome",
         "unknown",
+        "n/a",
+        "both",
         "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
       ],
       "type": "string"

--- a/schemas/activity-stream/sessions/sessions.1.schema.json
+++ b/schemas/activity-stream/sessions/sessions.1.schema.json
@@ -17,6 +17,8 @@
         "about:home",
         "about:welcome",
         "unknown",
+        "n/a",
+        "both",
         "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
       ],
       "type": "string"
@@ -28,11 +30,11 @@
           "type": "integer"
         },
         "is_preloaded": {
-          "description": "Whether or not is this session preloaded?",
+          "description": "Whether or not this session is preloaded",
           "type": "boolean"
         },
         "load_trigger_ts": {
-          "description": "To store the timestamp (in ms) when this session gets triggered",
+          "description": "To store the timestamp (ms since Unix epoch) when this session gets triggered",
           "type": "integer"
         },
         "load_trigger_type": {
@@ -48,7 +50,7 @@
           "type": "integer"
         },
         "topsites_first_painted_ts": {
-          "description": "To store the timestamp (in ms) when the Top Sites is first painted",
+          "description": "To store the timestamp (ms since Unix epoch) when the Top Sites is first painted",
           "type": "integer"
         },
         "topsites_icon_stats": {
@@ -84,7 +86,7 @@
           "type": "integer"
         },
         "visibility_event_rcvd_ts": {
-          "description": "To store the timestamp (in ms) when the page is made visible to the user in this session",
+          "description": "To store the timestamp (ms since Unix epoch) when the page is made visible to the user in this session",
           "type": "integer"
         }
       },
@@ -94,7 +96,7 @@
       "type": "object"
     },
     "profile_creation_date": {
-      "description": "Profile age in days relative to the epoch (1970-01-01)",
+      "description": "Profile age in days since Unix epoch",
       "type": "integer"
     },
     "release_channel": {
@@ -105,8 +107,8 @@
       "type": "integer"
     },
     "session_id": {
-      "description": "A UUID representing this session. Could be joined against the activity-stream/event ping",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "description": "A UUID representing an Activity Stream session. This can be used to do table joins between `sessions` and `events` in Activity Stream. Note that `n/a` denotes that the session is not applicable in the context.",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$",
       "type": "string"
     },
     "shield_id": {

--- a/schemas/activity-stream/sessions/sessions.1.schema.json
+++ b/schemas/activity-stream/sessions/sessions.1.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "addon_version": {
+      "type": "string"
+    },
+    "client_id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "page": {
+      "enum": [
+        "about:newtab",
+        "about:home",
+        "about:welcome",
+        "unknown",
+        "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
+      ],
+      "type": "string"
+    },
+    "perf": {
+      "properties": {
+        "highlights_data_late_by_ms": {
+          "description": "Latency of the data availability for Highlights",
+          "type": "integer"
+        },
+        "is_preloaded": {
+          "description": "Whether or not is this session preloaded?",
+          "type": "boolean"
+        },
+        "load_trigger_ts": {
+          "description": "To store the timestamp (in ms) when this session gets triggered",
+          "type": "integer"
+        },
+        "load_trigger_type": {
+          "enum": [
+            "menu_plus_or_keyboard",
+            "unexpected",
+            "first_window_opened"
+          ],
+          "type": "string"
+        },
+        "topsites_data_late_by_ms": {
+          "description": "Latency of the data availability for Top Sites",
+          "type": "integer"
+        },
+        "topsites_first_painted_ts": {
+          "description": "To store the timestamp (in ms) when the Top Sites is first painted",
+          "type": "integer"
+        },
+        "topsites_icon_stats": {
+          "description": "Icon stats for Top Sites, only sent if Top Sites is enabled",
+          "properties": {
+            "custom_screenshot": {
+              "type": "integer"
+            },
+            "no_image": {
+              "type": "integer"
+            },
+            "rich_icon": {
+              "type": "integer"
+            },
+            "screenshot": {
+              "type": "integer"
+            },
+            "screenshot_with_icon": {
+              "type": "integer"
+            },
+            "tippytop": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "topsites_pinned": {
+          "description": "The total number of pinned Top Sites in this session",
+          "type": "integer"
+        },
+        "topsites_search_shortcuts": {
+          "description": "The total number of search shortcuts in this session",
+          "type": "integer"
+        },
+        "visibility_event_rcvd_ts": {
+          "description": "To store the timestamp (in ms) when the page is made visible to the user in this session",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "load_trigger_type"
+      ],
+      "type": "object"
+    },
+    "profile_creation_date": {
+      "description": "Profile age in days relative to the epoch (1970-01-01)",
+      "type": "integer"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "session_duration": {
+      "description": "The duration of this session in milliseconds. The session begins at `perf.visibility_event_rcvd_ts` and ends when the page is navigated away",
+      "type": "integer"
+    },
+    "session_id": {
+      "description": "A UUID representing this session. Could be joined against the activity-stream/event ping",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
+      "type": "string"
+    },
+    "user_prefs": {
+      "description": "An encoded integer representing user's preferences of Activity Stream",
+      "type": "integer"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "client_id",
+    "addon_version",
+    "page",
+    "version",
+    "locale",
+    "session_id",
+    "session_duration",
+    "perf",
+    "user_prefs",
+    "profile_creation_date"
+  ],
+  "title": "sessions",
+  "type": "object"
+}

--- a/templates/activity-stream/events/events.1.schema.json
+++ b/templates/activity-stream/events/events.1.schema.json
@@ -7,6 +7,8 @@
       "type": "string",
       @COMMON_PATTERN_UUID_1_JSON@
     },
+    @ACTIVITY-STREAM_SESSIONID_1_JSON@,
+    @ACTIVITY-STREAM_PAGE_1_JSON@,
     "shield_id": {
       "description": "A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
@@ -18,11 +20,6 @@
     "value": {
         "description": "A string that describes the context about this event",
         "type": "string"
-    },
-    "session_id": {
-      "description": "A UUID representing the session, in which this event occurred",
-      "type": "string",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$"
     },
     "page": {
       "type": "string",

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -3,11 +3,8 @@
   "type": "object",
   "title": "impression-stats",
   "properties": {
-    "impression_id": {
-      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
-      "type": "string",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
-    },
+    @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
+    @ACTIVITY-STREAM_PAGE_1_JSON@,
     "shield_id": {
       "description": "A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
@@ -26,10 +23,6 @@
     },
     "source": {
       "type": "string"
-    },
-    "page": {
-      "type": "string",
-      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown", "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html" ]
     },
     "region": {
       "type": "string"

--- a/templates/activity-stream/sessions/sessions.1.schema.json
+++ b/templates/activity-stream/sessions/sessions.1.schema.json
@@ -11,17 +11,8 @@
       "description": "A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
     },
-    "session_id": {
-      "description": "A UUID representing this session. Could be joined against the activity-stream/event ping",
-      "type": "string",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
-    },
-    "page": {
-      "type": "string",
-      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown",
-        "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
-      ]
-    },
+    @ACTIVITY-STREAM_SESSIONID_1_JSON@,
+    @ACTIVITY-STREAM_PAGE_1_JSON@,
     "addon_version": {
       "type": "string"
     },
@@ -43,14 +34,14 @@
       "type": "integer"
     },
     "profile_creation_date": {
-      "description": "Profile age in days relative to the epoch (1970-01-01)",
+      "description": "Profile age in days since Unix epoch",
       "type": "integer"
     },
     "perf": {
       "type": "object",
       "properties": {
         "is_preloaded": {
-          "description": "Whether or not is this session preloaded?",
+          "description": "Whether or not this session is preloaded",
           "type": "boolean"
         },
         "load_trigger_type": {
@@ -58,15 +49,15 @@
           "enum": [ "menu_plus_or_keyboard", "unexpected", "first_window_opened" ]
         },
         "load_trigger_ts": {
-          "description": "To store the timestamp (in ms) when this session gets triggered",
+          "description": "To store the timestamp (ms since Unix epoch) when this session gets triggered",
           "type": "integer"
         },
         "visibility_event_rcvd_ts": {
-          "description": "To store the timestamp (in ms) when the page is made visible to the user in this session",
+          "description": "To store the timestamp (ms since Unix epoch) when the page is made visible to the user in this session",
           "type": "integer"
         },
         "topsites_first_painted_ts": {
-          "description": "To store the timestamp (in ms) when the Top Sites is first painted",
+          "description": "To store the timestamp (ms since Unix epoch) when the Top Sites is first painted",
           "type": "integer"
         },
         "topsites_data_late_by_ms": {

--- a/templates/activity-stream/sessions/sessions.1.schema.json
+++ b/templates/activity-stream/sessions/sessions.1.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "sessions",
+  "properties": {
+    "client_id": {
+      "type": "string",
+      @COMMON_PATTERN_UUID_1_JSON@
+    },
+    "shield_id": {
+      "description": "A semicolon separated string to store a list of Shield study IDs",
+      "type": "string"
+    },
+    "session_id": {
+      "description": "A UUID representing this session. Could be joined against the activity-stream/event ping",
+      "type": "string",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    },
+    "page": {
+      "type": "string",
+      "enum": [ "about:newtab", "about:home", "about:welcome", "unknown",
+        "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
+      ]
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "session_duration": {
+      "description": "The duration of this session in milliseconds. The session begins at `perf.visibility_event_rcvd_ts` and ends when the page is navigated away",
+      "type": "integer"
+    },
+    "user_prefs": {
+      "description": "An encoded integer representing user's preferences of Activity Stream",
+      "type": "integer"
+    },
+    "profile_creation_date": {
+      "description": "Profile age in days relative to the epoch (1970-01-01)",
+      "type": "integer"
+    },
+    "perf": {
+      "type": "object",
+      "properties": {
+        "is_preloaded": {
+          "description": "Whether or not is this session preloaded?",
+          "type": "boolean"
+        },
+        "load_trigger_type": {
+          "type": "string",
+          "enum": [ "menu_plus_or_keyboard", "unexpected", "first_window_opened" ]
+        },
+        "load_trigger_ts": {
+          "description": "To store the timestamp (in ms) when this session gets triggered",
+          "type": "integer"
+        },
+        "visibility_event_rcvd_ts": {
+          "description": "To store the timestamp (in ms) when the page is made visible to the user in this session",
+          "type": "integer"
+        },
+        "topsites_first_painted_ts": {
+          "description": "To store the timestamp (in ms) when the Top Sites is first painted",
+          "type": "integer"
+        },
+        "topsites_data_late_by_ms": {
+          "description": "Latency of the data availability for Top Sites",
+          "type": "integer"
+        },
+        "highlights_data_late_by_ms": {
+          "description": "Latency of the data availability for Highlights",
+          "type": "integer"
+        },
+        "topsites_pinned": {
+          "description": "The total number of pinned Top Sites in this session",
+          "type": "integer"
+        },
+        "topsites_search_shortcuts": {
+          "description": "The total number of search shortcuts in this session",
+          "type": "integer"
+        },
+        "topsites_icon_stats": {
+          "description": "Icon stats for Top Sites, only sent if Top Sites is enabled",
+          "type": "object",
+          "properties": {
+            "custom_screenshot": {
+              "type": "integer"
+            },
+            "screenshot_with_icon": {
+              "type": "integer"
+            },
+            "screenshot": {
+              "type": "integer"
+            },
+            "tippytop": {
+              "type": "integer"
+            },
+            "rich_icon": {
+              "type": "integer"
+            },
+            "no_image": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "required": [
+        "load_trigger_type"
+      ]
+    }
+  },
+  "required": [
+    "client_id",
+    "addon_version",
+    "page",
+    "version",
+    "locale",
+    "session_id",
+    "session_duration",
+    "perf",
+    "user_prefs",
+    "profile_creation_date"
+  ]
+}

--- a/templates/activity-stream/spoc-fills/spoc-fills.1.schema.json
+++ b/templates/activity-stream/spoc-fills/spoc-fills.1.schema.json
@@ -3,11 +3,7 @@
   "type": "object",
   "title": "spoc-fills",
   "properties": {
-    "impression_id": {
-      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
-      "type": "string",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
-    },
+    @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
     "locale": {
       "type": "string"
     },

--- a/templates/include/activity-stream/impressionId.1.schema.json
+++ b/templates/include/activity-stream/impressionId.1.schema.json
@@ -1,0 +1,5 @@
+"impression_id": {
+  "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
+  "type": "string",
+  "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+}

--- a/templates/include/activity-stream/page.1.schema.json
+++ b/templates/include/activity-stream/page.1.schema.json
@@ -1,0 +1,6 @@
+"page": {
+  "type": "string",
+  "enum": [ "about:newtab", "about:home", "about:welcome", "unknown", "n/a", "both",
+    "https://newtab.firefoxchina.cn/newtab/as/activity-stream.html"
+  ]
+}

--- a/templates/include/activity-stream/sessionId.1.schema.json
+++ b/templates/include/activity-stream/sessionId.1.schema.json
@@ -1,0 +1,5 @@
+"session_id": {
+  "description": "A UUID representing an Activity Stream session. This can be used to do table joins between `sessions` and `events` in Activity Stream. Note that `n/a` denotes that the session is not applicable in the context.",
+  "type": "string",
+  "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$|^n/a$"
+}

--- a/validation/activity-stream/sessions.1.sample.pass.json
+++ b/validation/activity-stream/sessions.1.sample.pass.json
@@ -9,6 +9,7 @@
   "page": "about:home",
   "profile_creation_date": 16587,
   "shield_id": "activity-stream-shield-study-bug-1238122",
+  "session_duration": 7000,
   "perf": {
     "load_trigger_type": "first_window_opened",
     "is_preloaded": false,

--- a/validation/activity-stream/sessions.1.sample.pass.json
+++ b/validation/activity-stream/sessions.1.sample.pass.json
@@ -1,0 +1,31 @@
+{
+  "locale": "en-US",
+  "client_id": "4dd69e99-07e7-c040-a514-ccde0cfd4881",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20191119043902",
+  "user_prefs": 255,
+  "session_id": "{3e3fce7a-d015-7d44-9404-3547a600a9ec}",
+  "page": "about:home",
+  "profile_creation_date": 16587,
+  "shield_id": "activity-stream-shield-study-bug-1238122",
+  "perf": {
+    "load_trigger_type": "first_window_opened",
+    "is_preloaded": false,
+    "load_trigger_ts": 1578946833472,
+    "visibility_event_rcvd_ts": 1578946834265,
+    "topsites_icon_stats": {
+      "custom_screenshot": 0,
+      "screenshot_with_icon": 0,
+      "screenshot": 0,
+      "tippytop": 6,
+      "rich_icon": 0,
+      "no_image": 0
+    },
+    "topsites_pinned": 0,
+    "topsites_search_shortcuts": 1,
+    "topsites_data_late_by_ms": 197,
+    "highlights_data_late_by_ms": 241,
+    "topsites_first_painted_ts": 1578946834726
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`

r? @jklukas 

This migrates the table `Tiles.assa_sessions_daily_by_client_id` to BQ.

Schema updates:
* Remove the `is_prerendered` and `client_region`
* Type change from "double" to "integer" for `load_trigger_ts`, `visibility_event_rcvd_ts`, and `topsites_first_painted_ts`

~~Looks the like there is a test bustage in `mozilla-pipeline-schemas-hindsight`, still investigating if it relates to this change.~~

[Update 1]: test failure is now fixed.
