### PR TITLE
1609218: Add ping reason field in ping_info

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -773,6 +773,10 @@
           "pattern": "^[a-z-_][a-z0-9-_]*$",
           "type": "string"
         },
+        "reason": {
+          "maxLength": 30,
+          "type": "string"
+        },
         "seq": {
           "type": "integer"
         },

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `ping_type` in the the `ping_info` section is now optional. See [Bug 1609149](https://bugzilla.mozilla.org/show_bug.cgi?id=1609149).
 
+- An optional `reason` field has been added to `ping_info`.
+
 - Glean ping_type is kebab-case instead of snake_case.
 
 - Label names can now be arbitrary strings, not just dotted snake_case.

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - `ping_type` in the the `ping_info` section is now optional. See [Bug 1609149](https://bugzilla.mozilla.org/show_bug.cgi?id=1609149).
 
-- An optional `reason` field has been added to `ping_info`.
+- An optional `reason` field has been added to `ping_info`. See [1609218](https://bugzilla.mozilla.org/show_bug.cgi?id=1609218)
 
 - Glean ping_type is kebab-case instead of snake_case.
 

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -83,6 +83,10 @@
             ],
             "additionalProperties": false
           }
+        },
+        "reason": {
+          "type": "string",
+          "maxLength": 30
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
