### PR TITLE
Bug 1609149 Make the `ping_type` optional for Glean pings

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -782,7 +782,6 @@
         }
       },
       "required": [
-        "ping_type",
         "seq",
         "start_time",
         "end_time"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- `ping_type` in the the `ping_info` section is now optional. See [Bug 1609149](https://bugzilla.mozilla.org/show_bug.cgi?id=1609149).
+
 - Glean ping_type is kebab-case instead of snake_case.
 
 - Label names can now be arbitrary strings, not just dotted snake_case.

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -87,7 +87,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "ping_type",
         "seq",
         "start_time",
         "end_time"


### PR DESCRIPTION
It's already in the submission URL and thus just data duplication.
It needs to stay optional, so that old pings are still valid against the
same version of the schema.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
