### PR TITLE
Bug 1611168 Allow null device version in sync pings

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -85,7 +85,10 @@
                 "type": "string"
               },
               "version": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": "object"

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -99,7 +99,10 @@
                 "type": "string"
               },
               "version": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "type": "object"

--- a/templates/include/telemetry/syncPayload.1.schema.json
+++ b/templates/include/telemetry/syncPayload.1.schema.json
@@ -20,7 +20,7 @@
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "os": { "type": ["string", "null"] },
-          "version": { "type": "string" },
+          "version": { "type": ["string", "null"] },
           "type": { "type": "string" },
           "syncID": { "type": "string" }
         }

--- a/validation/telemetry/sync.4.null_device_version.pass.json
+++ b/validation/telemetry/sync.4.null_device_version.pass.json
@@ -1,0 +1,155 @@
+{
+  "type": "sync",
+  "id": "180bbc67-ed08-7846-a3d6-b82ada0b6f08",
+  "creationDate": "2019-02-16T17:23:29.850Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20190213102848",
+    "name": "Firefox",
+    "version": "67.0a1",
+    "displayVersion": "67.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "67.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "payload": {
+    "os": {
+      "name": "Darwin",
+      "version": "18.0.0",
+      "locale": "en-CA"
+    },
+    "devices": [
+      {
+        "os": null,
+        "version": null,
+        "id": "f38b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba",
+        "type": "mobile",
+        "syncID": "e21b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba"
+      }
+    ],
+    "why": "schedule",
+    "version": 1,
+    "syncs": [
+      {
+        "when": 1550298047806,
+        "took": 2077,
+        "why": "schedule",
+        "engines": [
+          {
+            "name": "clients",
+            "took": 277
+          },
+          {
+            "name": "tabs",
+            "took": 6
+          },
+          {
+            "name": "bookmarks",
+            "took": 16
+          },
+          {
+            "name": "forms",
+            "took": 4
+          },
+          {
+            "name": "history",
+            "took": 394,
+            "outgoing": [
+              {
+                "sent": 8
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "when": 1550301657882,
+        "took": 2058,
+        "devices": [
+          {
+            "os": "Android",
+            "version": "65.0.1",
+            "id": "f38b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba"
+          }
+        ],
+        "why": "schedule",
+        "engines": [
+          {
+            "name": "clients",
+            "took": 624
+          },
+          {
+            "name": "tabs",
+            "took": 3
+          },
+          {
+            "name": "bookmarks",
+            "took": 12,
+            "steps": [
+              {
+                "name": "fetchLocalTree",
+                "took": 123,
+                "counts": [
+                  {
+                    "name": "items",
+                    "count": 1000
+                  },
+                  {
+                    "name": "deletions",
+                    "count": 10
+                  }
+                ]
+              },
+              {
+                "name": "fetchRemoteTree",
+                "took": 456
+              }
+            ]
+          },
+          {
+            "name": "forms",
+            "took": 5
+          },
+          {
+            "name": "history",
+            "took": 413,
+            "outgoing": [
+              {
+                "sent": 8
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "uid": "43720380d3e0935ca8d715b98d0da438",
+    "deviceID": "0dd0695bf3753be0bf3de5f9809b145f68441b65bfeac85d89b31e04718bbaa6",
+    "sessionStartDate": "2019-02-15T13:00:00.0-04:00",
+    "syncNodeType": "some-type",
+    "histograms": {
+      "PWMGR_NUM_SAVED_PASSWORDS": {
+        "min": 0,
+        "max": 100,
+        "histogram_type": 0,
+        "sum": 5,
+        "ranges": [1, 50, 100],
+        "counts": [0, 1, 0]
+      },
+      "PWMGR_BLOCKLIST_NUM_SITES": {
+        "min": 0,
+        "max": 750,
+        "histogram_type": 0,
+        "sum": 208,
+        "ranges": [175, 196, 219],
+        "counts": [0, 1, 0]
+      }
+    },
+    "events": [
+      [145994282,"sync","run","maintenance","bookmarks"],
+      [162808985,"sync","run","maintenance","bookmarks"],
+      [165025232,"sync","open","mirror","success",{"size":"352","serverTime":"1566174585.14"}]
+    ]
+  }
+}


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1611168

We already allow device `os` to be null, but we also need to allow
null `version`.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
