### PR TITLE
Bug 1595063 - Add ua attribution to environment data

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -443,6 +443,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -443,6 +443,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -443,6 +443,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -442,6 +442,10 @@
                 "source": {
                   "type": "string"
                 },
+                "ua": {
+                  "description": "derived user agent, see bug 1595063",
+                  "type": "string"
+                },
                 "variation": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -340,6 +340,10 @@
             "variation": {
               "type": "string",
               "description": "funnel experiment parameters, see bug 1567339"
+            },
+            "ua": {
+              "type": "string",
+              "description": "derived user agent, see bug 1595063"
             }
           }
         },

--- a/validation/telemetry/main.4.attribution.pass.json
+++ b/validation/telemetry/main.4.attribution.pass.json
@@ -21,7 +21,8 @@
                 "campaign": "campaign",
                 "content": "content",
                 "experiment": "experiment",
-                "variation": "variation"
+                "variation": "variation",
+                "ua": "ua"
             }
         }
     }


### PR DESCRIPTION
r?@acmiyaguchi Similar to #357 but for `ua` added in https://bugzilla.mozilla.org/show_bug.cgi?id=1595063

https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/environment.html

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
