### PR TITLE
Bug 1602463 - Add a schema for the new default-browser ping

### DIFF
--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -9,15 +9,6 @@
     },
     "default_browser": {
       "description": "The current default browser",
-      "enum": [
-        "firefox",
-        "chrome",
-        "edge",
-        "edge-chrome",
-        "ie",
-        "opera",
-        "brave"
-      ],
       "type": "string"
     },
     "os_locale": {
@@ -30,15 +21,6 @@
     },
     "previous_default_browser": {
       "description": "What the default browser was before it was changed to the current one",
-      "enum": [
-        "firefox",
-        "chrome",
-        "edge",
-        "edge-chrome",
-        "ie",
-        "opera",
-        "brave"
-      ],
       "type": "string"
     }
   },

--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "build_channel": {
+      "type": "string"
+    },
+    "build_version": {
+      "type": "string"
+    },
+    "default_browser": {
+      "description": "The current default browser",
+      "enum": [
+        "firefox",
+        "chrome",
+        "edge",
+        "edge-chrome",
+        "ie",
+        "opera",
+        "brave"
+      ],
+      "type": "string"
+    },
+    "os_locale": {
+      "description": "The current user's OS locale setting",
+      "type": "string"
+    },
+    "os_version": {
+      "description": "Windows version numnber in major.minor.build.UBR format (UBR is optional, only available on Win10)",
+      "type": "string"
+    },
+    "previous_default_browser": {
+      "description": "What the default browser was before it was changed to the current one",
+      "enum": [
+        "firefox",
+        "chrome",
+        "edge",
+        "edge-chrome",
+        "ie",
+        "opera",
+        "brave"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "build_channel",
+    "build_version",
+    "os_version",
+    "os_locale"
+  ],
+  "title": "default-browser",
+  "type": "object"
+}

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -17,13 +17,11 @@
     },
     "default_browser": {
       "description": "The current default browser",
-      "type": "string",
-      "enum": [ "firefox", "chrome", "edge", "edge-chrome", "ie", "opera", "brave" ]
+      "type": "string"
     },
     "previous_default_browser": {
       "description": "What the default browser was before it was changed to the current one",
-      "type": "string",
-      "enum": [ "firefox", "chrome", "edge", "edge-chrome", "ie", "opera", "brave" ]
+      "type": "string"
     }
   },
   "required": [

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "build_channel": {
+      "type": "string"
+    },
+    "build_version": {
+      "type": "string"
+    },
+    "os_version": {
+      "description": "Windows version numnber in major.minor.build.UBR format (UBR is optional, only available on Win10)",
+      "type": "string"
+    },
+    "os_locale": {
+      "description": "The current user's OS locale setting",
+      "type": "string"
+    },
+    "default_browser": {
+      "description": "The current default browser",
+      "type": "string",
+      "enum": [ "firefox", "chrome", "edge", "edge-chrome", "ie", "opera", "brave" ]
+    },
+    "previous_default_browser": {
+      "description": "What the default browser was before it was changed to the current one",
+      "type": "string",
+      "enum": [ "firefox", "chrome", "edge", "edge-chrome", "ie", "opera", "brave" ]
+    }
+  },
+  "required": [
+    "build_channel",
+    "build_version",
+    "os_version",
+    "os_locale"
+  ],
+  "title": "default-browser",
+  "type": "object"
+}

--- a/validation/default-browser-agent/default-browser/default-browser.1.pass.json
+++ b/validation/default-browser-agent/default-browser/default-browser.1.pass.json
@@ -1,0 +1,8 @@
+{
+  "build_channel": "nightly",
+  "build_version": "74.0a1",
+  "os_version": "10.0.18363.592",
+  "os_locale": "en-US",
+  "default_browser": "firefox",
+  "previous_default_browser": "edge"
+}


### PR DESCRIPTION
See the bug [https://bugzilla.mozilla.org/show_bug.cgi?id=1602463] for the details.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
