### PR TITLE
Bug 1613225 Remove IP addresses from error schema

### DIFF
--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -69,9 +69,6 @@
     "protocol": {
       "type": "string"
     },
-    "remote_addr": {
-      "type": "string"
-    },
     "stack_trace": {
       "type": "string"
     },
@@ -112,13 +109,7 @@
     "x_debug_id": {
       "type": "string"
     },
-    "x_forwarded_for": {
-      "type": "string"
-    },
     "x_pingsender_version": {
-      "type": "string"
-    },
-    "x_pipeline_proxy": {
       "type": "string"
     }
   },

--- a/templates/include/metadata/ipAddresses.1.schema.json
+++ b/templates/include/metadata/ipAddresses.1.schema.json
@@ -1,0 +1,9 @@
+"remote_addr": {
+  "type": "string"
+},
+"x_forwarded_for": {
+  "type": "string"
+},
+"x_pipeline_proxy": {
+  "type": "string"
+}

--- a/templates/include/metadata/raw.1.schema.json
+++ b/templates/include/metadata/raw.1.schema.json
@@ -23,9 +23,6 @@
 "protocol": {
   "type": "string"
 },
-"remote_addr": {
-  "type": "string"
-},
 "submission_timestamp": {
   "format": "date-time",
   "type": "string"
@@ -39,12 +36,6 @@
 "x_debug_id": {
   "type": "string"
 },
-"x_forwarded_for": {
-  "type": "string"
-},
 "x_pingsender_version": {
-  "type": "string"
-},
-"x_pipeline_proxy": {
   "type": "string"
 }

--- a/templates/metadata/raw/raw.1.schema.json
+++ b/templates/metadata/raw/raw.1.schema.json
@@ -3,7 +3,8 @@
   "id": "http://jsonschema.net",
   "type": "object",
   "properties": {
-    @METADATA_RAW_1_JSON@
+    @METADATA_RAW_1_JSON@,
+    @METADATA_IPADDRESSES_1_JSON@
   },
   "required": ["submission_timestamp"]
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1613225

We don't want to merge this until we are ready with operational steps to
recreate the error tables with these fields removed and codify the change
in terraform state.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
