### PR TITLE
Bug 1613225 Add descriptions to payload_bytes_* fields

### DIFF
--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -3,18 +3,22 @@
   "id": "http://jsonschema.net",
   "properties": {
     "args": {
+      "description": "query parameter part of the submission URI, i.e. \"v=4\"",
       "type": "string"
     },
     "client_id": {
       "type": "string"
     },
     "content_length": {
+      "description": "Content-Length header",
       "type": "string"
     },
     "date": {
+      "description": "Date header",
       "type": "string"
     },
     "dnt": {
+      "description": "DNT header",
       "type": "string"
     },
     "document_namespace": {
@@ -48,6 +52,7 @@
       "type": "string"
     },
     "host": {
+      "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\"",
       "type": "string"
     },
     "input": {
@@ -60,16 +65,20 @@
       "type": "string"
     },
     "method": {
+      "description": "HTTP method, i.e. \"POST\"",
       "type": "string"
     },
     "payload": {
+      "description": "Gzip-compressed JSON payload",
       "format": "bytes",
       "type": "string"
     },
     "protocol": {
+      "description": "i.e. \"HTTP/1.1\"",
       "type": "string"
     },
     "remote_addr": {
+      "description": "Deprecated; will always be null",
       "type": "string"
     },
     "stack_trace": {
@@ -91,13 +100,16 @@
       "type": "string"
     },
     "submission_timestamp": {
+      "description": "Time when the ingestion edge server in GCP accepted this message; format is ISO 8601 with microseconds and timezone \"Z\", example: \"2018-03-12T21:02:18.123456Z\"",
       "format": "date-time",
       "type": "string"
     },
     "uri": {
+      "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
       "type": "string"
     },
     "user_agent": {
+      "description": "User-Agent header",
       "type": "string"
     },
     "user_agent_browser": {
@@ -110,15 +122,19 @@
       "type": "string"
     },
     "x_debug_id": {
+      "description": "X-Debug-Id header",
       "type": "string"
     },
     "x_forwarded_for": {
+      "description": "Deprecated; will always be null",
       "type": "string"
     },
     "x_pingsender_version": {
+      "description": "X-Pingsender-Version header",
       "type": "string"
     },
     "x_pipeline_proxy": {
+      "description": "Deprecated; will always be null",
       "type": "string"
     }
   },

--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -3,7 +3,7 @@
   "id": "http://jsonschema.net",
   "properties": {
     "args": {
-      "description": "query parameter part of the submission URI, i.e. \"v=4\"",
+      "description": "query parameter part of the submission URI, e.g. \"v=4\"",
       "type": "string"
     },
     "client_id": {
@@ -52,7 +52,7 @@
       "type": "string"
     },
     "host": {
-      "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\"",
+      "description": "Usually populated with the hostname part of the submission URI, e.g. \"incoming.telemetry.mozilla.org\"",
       "type": "string"
     },
     "input": {
@@ -65,7 +65,7 @@
       "type": "string"
     },
     "method": {
-      "description": "HTTP method, i.e. \"POST\"",
+      "description": "HTTP method, e.g. \"POST\"",
       "type": "string"
     },
     "payload": {
@@ -74,7 +74,7 @@
       "type": "string"
     },
     "protocol": {
-      "description": "i.e. \"HTTP/1.1\"",
+      "description": "e.g. \"HTTP/1.1\"",
       "type": "string"
     },
     "remote_addr": {
@@ -105,7 +105,7 @@
       "type": "string"
     },
     "uri": {
-      "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
+      "description": "e.g. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
       "type": "string"
     },
     "user_agent": {

--- a/schemas/metadata/raw/raw.1.schema.json
+++ b/schemas/metadata/raw/raw.1.schema.json
@@ -3,7 +3,7 @@
   "id": "http://jsonschema.net",
   "properties": {
     "args": {
-      "description": "query parameter part of the submission URI, i.e. \"v=4\"",
+      "description": "query parameter part of the submission URI, e.g. \"v=4\"",
       "type": "string"
     },
     "content_length": {
@@ -19,11 +19,11 @@
       "type": "string"
     },
     "host": {
-      "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\"",
+      "description": "Usually populated with the hostname part of the submission URI, e.g. \"incoming.telemetry.mozilla.org\"",
       "type": "string"
     },
     "method": {
-      "description": "HTTP method, i.e. \"POST\"",
+      "description": "HTTP method, e.g. \"POST\"",
       "type": "string"
     },
     "payload": {
@@ -32,7 +32,7 @@
       "type": "string"
     },
     "protocol": {
-      "description": "i.e. \"HTTP/1.1\"",
+      "description": "e.g. \"HTTP/1.1\"",
       "type": "string"
     },
     "remote_addr": {
@@ -45,7 +45,7 @@
       "type": "string"
     },
     "uri": {
-      "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
+      "description": "e.g. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
       "type": "string"
     },
     "user_agent": {
@@ -65,7 +65,7 @@
       "type": "string"
     },
     "x_pipeline_proxy": {
-      "description": "Time that the AWS to GCP tee service received the message",
+      "description": "Any non-null value indicates that this message was proxied from AWS",
       "type": "string"
     }
   },

--- a/schemas/metadata/raw/raw.1.schema.json
+++ b/schemas/metadata/raw/raw.1.schema.json
@@ -3,53 +3,69 @@
   "id": "http://jsonschema.net",
   "properties": {
     "args": {
+      "description": "query parameter part of the submission URI, i.e. \"v=4\"",
       "type": "string"
     },
     "content_length": {
+      "description": "Content-Length header",
       "type": "string"
     },
     "date": {
+      "description": "Date header",
       "type": "string"
     },
     "dnt": {
+      "description": "DNT header",
       "type": "string"
     },
     "host": {
+      "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\"",
       "type": "string"
     },
     "method": {
+      "description": "HTTP method, i.e. \"POST\"",
       "type": "string"
     },
     "payload": {
+      "description": "Gzip-compressed JSON payload",
       "format": "bytes",
       "type": "string"
     },
     "protocol": {
+      "description": "i.e. \"HTTP/1.1\"",
       "type": "string"
     },
     "remote_addr": {
+      "description": "Source IP address, usually a load balancer",
       "type": "string"
     },
     "submission_timestamp": {
+      "description": "Time when the ingestion edge server in GCP accepted this message; format is ISO 8601 with microseconds and timezone \"Z\", example: \"2018-03-12T21:02:18.123456Z\"",
       "format": "date-time",
       "type": "string"
     },
     "uri": {
+      "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\"",
       "type": "string"
     },
     "user_agent": {
+      "description": "User-Agent header",
       "type": "string"
     },
     "x_debug_id": {
+      "description": "X-Debug-Id header",
       "type": "string"
     },
     "x_forwarded_for": {
+      "description": "X-Forwarded-For header containing intermediate IP addresses",
       "type": "string"
     },
     "x_pingsender_version": {
+      "description": "X-Pingsender-Version header",
       "type": "string"
     },
     "x_pipeline_proxy": {
+      "description": "Time that the AWS to GCP tee service received the message",
       "type": "string"
     }
   },

--- a/templates/include/metadata/raw.1.schema.json
+++ b/templates/include/metadata/raw.1.schema.json
@@ -1,6 +1,6 @@
 "args": {
   "type": "string",
-  "description": "query parameter part of the submission URI, i.e. \"v=4\""
+  "description": "query parameter part of the submission URI, e.g. \"v=4\""
 },
 "content_length": {
   "type": "string",
@@ -16,11 +16,11 @@
 },
 "host": {
   "type": "string",
-  "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\""
+  "description": "Usually populated with the hostname part of the submission URI, e.g. \"incoming.telemetry.mozilla.org\""
 },
 "method": {
   "type": "string",
-  "description": "HTTP method, i.e. \"POST\""
+  "description": "HTTP method, e.g. \"POST\""
 },
 "payload": {
   "format": "bytes",
@@ -29,7 +29,7 @@
 },
 "protocol": {
   "type": "string",
-  "description": "i.e. \"HTTP/1.1\""
+  "description": "e.g. \"HTTP/1.1\""
 },
 "submission_timestamp": {
   "format": "date-time",
@@ -38,7 +38,7 @@
 },
 "uri": {
   "type": "string",
-  "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\""
+  "description": "e.g. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\""
 },
 "user_agent": {
   "type": "string",

--- a/templates/include/metadata/raw.1.schema.json
+++ b/templates/include/metadata/raw.1.schema.json
@@ -1,50 +1,54 @@
 "args": {
-  "type": "string"
+  "type": "string",
+  "description": "query parameter part of the submission URI, i.e. \"v=4\""
 },
 "content_length": {
-  "type": "string"
+  "type": "string",
+  "description": "Content-Length header"
 },
 "date": {
-  "type": "string"
+  "type": "string",
+  "description": "Date header"
 },
 "dnt": {
-  "type": "string"
+  "type": "string",
+  "description": "DNT header"
 },
 "host": {
-  "type": "string"
+  "type": "string",
+  "description": "Hostname part of the submission URI, i.e. \"incoming.telemetry.mozilla.org\""
 },
 "method": {
-  "type": "string"
+  "type": "string",
+  "description": "HTTP method, i.e. \"POST\""
 },
 "payload": {
   "format": "bytes",
-  "type": "string"
+  "type": "string",
+  "description": "Gzip-compressed JSON payload"
 },
 "protocol": {
-  "type": "string"
-},
-"remote_addr": {
-  "type": "string"
+  "type": "string",
+  "description": "i.e. \"HTTP/1.1\""
 },
 "submission_timestamp": {
   "format": "date-time",
-  "type": "string"
+  "type": "string",
+  "description": "Time when the ingestion edge server in GCP accepted this message; format is ISO 8601 with microseconds and timezone \"Z\", example: \"2018-03-12T21:02:18.123456Z\""
 },
 "uri": {
-  "type": "string"
+  "type": "string",
+  "description": "i.e. \"/submit/telemetry/6c49ec73-4350-45a0-9c8a-6c8f5aded0cf/main/Firefox/58.0.2/release/20180206200532\""
 },
 "user_agent": {
-  "type": "string"
+  "type": "string",
+  "description": "User-Agent header"
 },
 "x_debug_id": {
-  "type": "string"
-},
-"x_forwarded_for": {
-  "type": "string"
+  "type": "string",
+  "description": "X-Debug-Id header"
 },
 "x_pingsender_version": {
-  "type": "string"
-},
-"x_pipeline_proxy": {
-  "type": "string"
+  "type": "string",
+  "description": "X-Pingsender-Version header"
 }

--- a/templates/metadata/error/error.1.schema.json
+++ b/templates/metadata/error/error.1.schema.json
@@ -4,6 +4,18 @@
   "type": "object",
   "properties": {
     @METADATA_RAW_1_JSON@,
+    "remote_addr": {
+      "type": "string",
+      "description": "Deprecated; will always be null"
+    },
+    "x_forwarded_for": {
+      "type": "string",
+      "description": "Deprecated; will always be null"
+    },
+    "x_pipeline_proxy": {
+      "type": "string",
+      "description": "Deprecated; will always be null"
+    },
     "input": {
       "type": "string"
     },

--- a/templates/metadata/raw/raw.1.schema.json
+++ b/templates/metadata/raw/raw.1.schema.json
@@ -14,7 +14,7 @@
     },
     "x_pipeline_proxy": {
       "type": "string",
-      "description": "Time that the AWS to GCP tee service received the message"
+      "description": "Any non-null value indicates that this message was proxied from AWS"
     }
   },
   "required": ["submission_timestamp"]

--- a/templates/metadata/raw/raw.1.schema.json
+++ b/templates/metadata/raw/raw.1.schema.json
@@ -3,7 +3,19 @@
   "id": "http://jsonschema.net",
   "type": "object",
   "properties": {
-    @METADATA_RAW_1_JSON@
+    @METADATA_RAW_1_JSON@,
+    "remote_addr": {
+      "type": "string",
+      "description": "Source IP address, usually a load balancer"
+    },
+    "x_forwarded_for": {
+      "type": "string",
+      "description": "X-Forwarded-For header containing intermediate IP addresses"
+    },
+    "x_pipeline_proxy": {
+      "type": "string",
+      "description": "Time that the AWS to GCP tee service received the message"
+    }
   },
   "required": ["submission_timestamp"]
 }


### PR DESCRIPTION
In particular, we draw attention to the fact that IP address fields
in error tables will always be null.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
