### PR TITLE
Bug 1505491 Add ISP information to metadata

### DIFF
--- a/schemas/metadata/decoded/decoded.1.schema.json
+++ b/schemas/metadata/decoded/decoded.1.schema.json
@@ -68,6 +68,28 @@
           },
           "type": "object"
         },
+        "isp": {
+          "description": "Results of ISP lookup based on the client's IP address",
+          "properties": {
+            "asn": {
+              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
+              "type": "string"
+            },
+            "db_version": {
+              "description": "The specific geo ISP database version used for this lookup",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the ISP associated with the client's IP address",
+              "type": "string"
+            },
+            "organization": {
+              "description": "The name of the organization associated with the client's IP address",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "uri": {
           "description": "Components of the URI to which this ping was sent",
           "properties": {

--- a/schemas/metadata/decoded/decoded.1.schema.json
+++ b/schemas/metadata/decoded/decoded.1.schema.json
@@ -71,10 +71,6 @@
         "isp": {
           "description": "Results of ISP lookup based on the client's IP address",
           "properties": {
-            "asn": {
-              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
-              "type": "string"
-            },
             "db_version": {
               "description": "The specific geo ISP database version used for this lookup",
               "type": "string"

--- a/schemas/metadata/decoded/decoded.1.schema.json
+++ b/schemas/metadata/decoded/decoded.1.schema.json
@@ -84,7 +84,7 @@
               "type": "string"
             },
             "organization": {
-              "description": "The name of the organization associated with the client's IP address",
+              "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
               "type": "string"
             }
           },

--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -61,6 +61,12 @@
     "input_type": {
       "type": "string"
     },
+    "isp_name": {
+      "type": "string"
+    },
+    "isp_organization": {
+      "type": "string"
+    },
     "job_name": {
       "type": "string"
     },

--- a/schemas/metadata/pioneer-ingestion/pioneer-ingestion.1.schema.json
+++ b/schemas/metadata/pioneer-ingestion/pioneer-ingestion.1.schema.json
@@ -60,6 +60,24 @@
           },
           "type": "object"
         },
+        "isp": {
+          "description": "Results of ISP lookup based on the client's IP address",
+          "properties": {
+            "db_version": {
+              "description": "The specific geo ISP database version used for this lookup",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the ISP associated with the client's IP address",
+              "type": "string"
+            },
+            "organization": {
+              "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "user_agent": {
           "description": "Parsed components of the client's user agent string",
           "properties": {

--- a/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -62,10 +62,6 @@
         "isp": {
           "description": "Results of ISP lookup based on the client's IP address",
           "properties": {
-            "asn": {
-              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
-              "type": "string"
-            },
             "db_version": {
               "description": "The specific geo ISP database version used for this lookup",
               "type": "string"

--- a/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -75,7 +75,7 @@
               "type": "string"
             },
             "organization": {
-              "description": "The name of the organization associated with the client's IP address",
+              "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
               "type": "string"
             }
           },

--- a/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -59,6 +59,28 @@
           },
           "type": "object"
         },
+        "isp": {
+          "description": "Results of ISP lookup based on the client's IP address",
+          "properties": {
+            "asn": {
+              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
+              "type": "string"
+            },
+            "db_version": {
+              "description": "The specific geo ISP database version used for this lookup",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the ISP associated with the client's IP address",
+              "type": "string"
+            },
+            "organization": {
+              "description": "The name of the organization associated with the client's IP address",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "user_agent": {
           "description": "Parsed components of the client's user agent string",
           "properties": {

--- a/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -62,10 +62,6 @@
         "isp": {
           "description": "Results of ISP lookup based on the client's IP address",
           "properties": {
-            "asn": {
-              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
-              "type": "string"
-            },
             "db_version": {
               "description": "The specific geo ISP database version used for this lookup",
               "type": "string"

--- a/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -75,7 +75,7 @@
               "type": "string"
             },
             "organization": {
-              "description": "The name of the organization associated with the client's IP address",
+              "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
               "type": "string"
             }
           },

--- a/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -59,6 +59,28 @@
           },
           "type": "object"
         },
+        "isp": {
+          "description": "Results of ISP lookup based on the client's IP address",
+          "properties": {
+            "asn": {
+              "description": "The autonomous system number (ASN) assigned to the ISP for routing",
+              "type": "string"
+            },
+            "db_version": {
+              "description": "The specific geo ISP database version used for this lookup",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the ISP associated with the client's IP address",
+              "type": "string"
+            },
+            "organization": {
+              "description": "The name of the organization associated with the client's IP address",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "uri": {
           "description": "Components of the URI to which this ping was sent",
           "properties": {

--- a/templates/include/metadata/ingestionCommonMetadata.1.schema.json
+++ b/templates/include/metadata/ingestionCommonMetadata.1.schema.json
@@ -75,10 +75,6 @@
     "organization": {
       "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
       "type": "string"
-    },
-    "asn": {
-      "description": "The autonomous system number (ASN) assigned to the ISP for routing",
-      "type": "string"
     }
   }
 }

--- a/templates/include/metadata/ingestionCommonMetadata.1.schema.json
+++ b/templates/include/metadata/ingestionCommonMetadata.1.schema.json
@@ -59,4 +59,26 @@
       "type": "string"
     }
   }
+},
+"isp": {
+  "type": "object",
+  "description": "Results of ISP lookup based on the client's IP address",
+  "properties": {
+    "db_version": {
+      "description": "The specific geo ISP database version used for this lookup",
+      "type": "string"
+    },
+    "name": {
+      "description": "The name of the ISP associated with the client's IP address",
+      "type": "string"
+    },
+    "organization": {
+      "description": "The name of the organization associated with the client's IP address",
+      "type": "string"
+    },
+    "asn": {
+      "description": "The autonomous system number (ASN) assigned to the ISP for routing",
+      "type": "string"
+    }
+  }
 }

--- a/templates/include/metadata/ingestionCommonMetadata.1.schema.json
+++ b/templates/include/metadata/ingestionCommonMetadata.1.schema.json
@@ -73,7 +73,7 @@
       "type": "string"
     },
     "organization": {
-      "description": "The name of the organization associated with the client's IP address",
+      "description": "The name of a specific business entity associated with the client's IP address when available; otherwise the ISP name",
       "type": "string"
     },
     "asn": {

--- a/templates/metadata/error/error.1.schema.json
+++ b/templates/metadata/error/error.1.schema.json
@@ -58,6 +58,12 @@
     "geo_subdivision2": {
       "type": "string"
     },
+    "isp_name": {
+      "type": "string"
+    },
+    "isp_organization": {
+      "type": "string"
+    },
     "stack_trace": {
       "type": "string"
     },


### PR DESCRIPTION
This adds ISP information to the metadata as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1505491 and https://github.com/mozilla/gcp-ingestion/pull/1117.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
