### PR TITLE
Bug 1614418 allow null for syncs device versions

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -269,7 +269,10 @@
                       ]
                     },
                     "version": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   },
                   "type": "object"

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -283,7 +283,10 @@
                       ]
                     },
                     "version": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   },
                   "type": "object"

--- a/templates/include/telemetry/syncItem.1.schema.json
+++ b/templates/include/telemetry/syncItem.1.schema.json
@@ -11,7 +11,7 @@
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "os": { "type": ["string", "null"] },
-          "version": { "type": "string" }
+          "version": { "type": ["string", "null"] }
         }
       }
     },

--- a/validation/telemetry/sync.4.null_device_version.pass.json
+++ b/validation/telemetry/sync.4.null_device_version.pass.json
@@ -72,6 +72,11 @@
             "os": "Android",
             "version": "65.0.1",
             "id": "f38b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba"
+          },
+          {
+            "os": null,
+            "version": null,
+            "id": "a38b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbebf"
           }
         ],
         "why": "schedule",


### PR DESCRIPTION
This issue is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1614418 and was previously reported in https://bugzilla.mozilla.org/show_bug.cgi?id=1611168

There was already a PR trying to fix this issue a while ago: https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/490

However, I believe the previous PR didn't address the right part of the schema to be changed.

If the fix here looks right, I guess also the validation tests introduced in https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/490 should be changed?

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
