### PR TITLE
Fix #505 - Ignore only build at root directory; add java ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 release/
-data/
 venv/
-build/
-target/
+/build/
+/data/
+/target/
 **/__pycache__/
 **/*.pyc
+.classpath
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 release/
-data/
 venv/
-build/
-target/
+/build/
+/data/
+/target/
 __pycache__/
 *.pyc
+.classpath
+.project


### PR DESCRIPTION
This fixes #505. It prefixes the path for `build` in the `.gitignore` with a forward slash to denote to ignore only at the root of the repository.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
