### PR TITLE
Add new fields for Firefox Voice:

### DIFF
--- a/schemas/telemetry/voice-feedback/voice-feedback.4.schema.json
+++ b/schemas/telemetry/voice-feedback/voice-feedback.4.schema.json
@@ -19,6 +19,10 @@
           "minimum": 0,
           "title": "Milliseconds-since-the-epoch when feedback was submitted",
           "type": "number"
+        },
+        "utterance": {
+          "title": "The utterance for which feedback is being provided",
+          "type": "string"
         }
       },
       "type": "object"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1268,6 +1268,14 @@
           "title": "Number of open tabs",
           "type": "integer"
         },
+        "optInAcceptanceTime": {
+          "title": "The timestamp when the user accepted the opt-in",
+          "type": "integer"
+        },
+        "optInAudio": {
+          "title": "Has the user opted in to audio?",
+          "type": "boolean"
+        },
         "serverErrorIntentParser": {
           "description": "Error with the server intent parser",
           "title": "DEPRECATED",
@@ -1334,6 +1342,14 @@
           "description": "Typically the slots found in the utterance",
           "title": "Parsed form of the utterance",
           "type": "object"
+        },
+        "wakewordEnabled": {
+          "title": "Has the user enabled the wakeword?",
+          "type": "boolean"
+        },
+        "wakewordUsed": {
+          "title": "Did the user start the intent with a wakeword, and what wakeword?",
+          "type": "string"
         }
       },
       "required": [

--- a/templates/telemetry/voice-feedback/voice-feedback.4.schema.json
+++ b/templates/telemetry/voice-feedback/voice-feedback.4.schema.json
@@ -18,6 +18,10 @@
           "title": "Any free-text feedback given by the user",
           "type": "string"
         },
+        "utterance": {
+          "title": "The utterance for which feedback is being provided",
+          "type": "string"
+        },
         "timestamp": {
           "title": "Milliseconds-since-the-epoch when feedback was submitted",
           "type": "number",

--- a/templates/telemetry/voice/voice.4.schema.json
+++ b/templates/telemetry/voice/voice.4.schema.json
@@ -208,6 +208,22 @@
           "title": "Number of open tabs",
           "description": "A count of the number of tabs in all windows, that are open when the tool is activated",
           "type": "integer"
+        },
+        "wakewordEnabled": {
+          "title": "Has the user enabled the wakeword?",
+          "type": "boolean"
+        },
+        "wakewordUsed": {
+          "title": "Did the user start the intent with a wakeword, and what wakeword?",
+          "type": "string"
+        },
+        "optInAcceptanceTime": {
+          "title": "The timestamp when the user accepted the opt-in",
+          "type": "integer"
+        },
+        "optInAudio": {
+          "title": "Has the user opted in to audio?",
+          "type": "boolean"
         }
       },
       "required": [

--- a/validation/telemetry/voice-feedback.4.normal.pass.json
+++ b/validation/telemetry/voice-feedback.4.normal.pass.json
@@ -6,6 +6,7 @@
     "intentId": "a9e83ff0",
     "rating": -1,
     "timestamp": 1567635589896,
-    "feedback": "Did not work as expected"
+    "feedback": "Did not work as expected",
+    "utterance": "turn off my lights"
   }
 }

--- a/validation/telemetry/voice.4.full.pass.json
+++ b/validation/telemetry/voice.4.full.pass.json
@@ -40,7 +40,11 @@
     "utteranceDeepSpeechChars": 20,
     "deepSpeechMatches": true,
     "deepSpeechServerTime": 2001,
-    "numberOfOpenTabs": 12
+    "numberOfOpenTabs": 12,
+    "wakewordEnabled": true,
+    "wakewordUsed": "hey firefox",
+    "optInAcceptanceTime": 1567635566896,
+    "optInAudio": false
   },
   "creationDate": "2019-02-16T17:23:29.850Z",
   "application": {


### PR DESCRIPTION
- Copy of utterance in the feedback, for users that haven't opted in to utterance recording
- Whether a user has enabled a wakeword
- If a user started Voice with a wakeword, and what wakeword
- The timestamp of opt-in for utterance storage
- Whether the user opted in to audio recording

Upstream bugs:

- https://github.com/mozilla/firefox-voice/issues/574
- https://github.com/mozilla/firefox-voice/issues/945
- https://github.com/mozilla/firefox-voice/issues/587
- https://github.com/mozilla/firefox-voice/issues/588

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
