### PR TITLE
Bug 1603536 Add descriptions for environment from probe dictionary

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -65,9 +65,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -77,15 +79,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -93,30 +98,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -124,12 +136,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -210,6 +224,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -218,9 +233,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -230,18 +247,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -249,12 +270,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -262,9 +286,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -276,22 +302,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -302,23 +334,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -354,36 +391,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -395,6 +438,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -404,6 +448,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -423,14 +468,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -438,9 +486,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -455,6 +505,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -481,23 +532,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -507,6 +563,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -561,6 +618,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -576,11 +634,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -596,17 +656,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -629,6 +693,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -637,6 +702,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -645,53 +711,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -720,15 +795,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -822,6 +900,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -946,12 +1025,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -974,12 +1055,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1002,12 +1085,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1031,6 +1116,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1040,40 +1126,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1085,6 +1181,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1094,6 +1191,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1103,6 +1201,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1115,6 +1214,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -65,9 +65,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -77,15 +79,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -93,30 +98,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -124,12 +136,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -210,6 +224,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -218,9 +233,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -230,18 +247,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -249,12 +270,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -262,9 +286,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -276,22 +302,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -302,23 +334,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -354,36 +391,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -395,6 +438,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -404,6 +448,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -423,14 +468,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -438,9 +486,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -455,6 +505,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -481,23 +532,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -507,6 +563,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -561,6 +618,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -576,11 +634,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -596,17 +656,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -629,6 +693,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -637,6 +702,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -645,53 +711,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -720,15 +795,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -822,6 +900,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -946,12 +1025,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -974,12 +1055,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1002,12 +1085,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1031,6 +1116,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1040,40 +1126,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1085,6 +1181,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1094,6 +1191,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1103,6 +1201,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1115,6 +1214,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -65,9 +65,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -77,15 +79,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -93,30 +98,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -124,12 +136,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -210,6 +224,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -218,9 +233,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -230,18 +247,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -249,12 +270,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -262,9 +286,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -276,22 +302,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -302,23 +334,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -354,36 +391,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -395,6 +438,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -404,6 +448,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -423,14 +468,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -438,9 +486,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -455,6 +505,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -481,23 +532,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -507,6 +563,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -561,6 +618,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -576,11 +634,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -596,17 +656,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -629,6 +693,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -637,6 +702,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -645,53 +711,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -720,15 +795,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -822,6 +900,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -946,12 +1025,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -974,12 +1055,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1002,12 +1085,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1031,6 +1116,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1040,40 +1126,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1085,6 +1181,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1094,6 +1191,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1103,6 +1201,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1115,6 +1214,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -64,9 +64,11 @@
               "additionalProperties": {
                 "properties": {
                   "appDisabled": {
+                    "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "blocklisted": {
+                    "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "description": {
@@ -76,15 +78,18 @@
                     ]
                   },
                   "foreignInstall": {
+                    "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "integer",
                       "boolean"
                     ]
                   },
                   "hasBinaryComponents": {
+                    "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "boolean"
                   },
                   "installDay": {
+                    "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -92,30 +97,37 @@
                     ]
                   },
                   "isSystem": {
+                    "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "isWebExtension": {
+                    "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
                     "type": "boolean"
                   },
                   "multiprocessCompatible": {
+                    "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "string"
                   },
                   "scope": {
+                    "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
                     "type": [
                       "integer",
                       "null"
                     ]
                   },
                   "signedState": {
+                    "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": "integer"
                   },
                   "type": {
                     "type": "string"
                   },
                   "updateDay": {
+                    "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
                     "minimum": 0,
                     "type": [
                       "integer",
@@ -123,12 +135,14 @@
                     ]
                   },
                   "userDisabled": {
+                    "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
                     "type": [
                       "boolean",
                       "integer"
                     ]
                   },
                   "version": {
+                    "description": "The version of the add-on. This field is available at startup.",
                     "type": [
                       "string",
                       "number"
@@ -209,6 +223,7 @@
               "type": "array"
             },
             "persona": {
+              "description": "The id of the active persona (theme).",
               "type": [
                 "string",
                 "null"
@@ -217,9 +232,11 @@
             "theme": {
               "properties": {
                 "appDisabled": {
+                  "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
                   "type": "boolean"
                 },
                 "blocklisted": {
+                  "description": "Whether or not the theme appears in the blocklist.",
                   "type": "boolean"
                 },
                 "description": {
@@ -229,18 +246,22 @@
                   ]
                 },
                 "foreignInstall": {
+                  "description": "True or false depending on whether the theme is a third party theme installation or not.",
                   "type": [
                     "boolean",
                     "integer"
                   ]
                 },
                 "hasBinaryComponents": {
+                  "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
                   "type": "boolean"
                 },
                 "id": {
+                  "description": "The id of the theme.",
                   "type": "string"
                 },
                 "installDay": {
+                  "description": "The days since epoch that the theme was first installed.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -248,12 +269,15 @@
                   ]
                 },
                 "name": {
+                  "description": "The theme name, limited to 100 characters.",
                   "type": "string"
                 },
                 "scope": {
+                  "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
                   "type": "integer"
                 },
                 "updateDay": {
+                  "description": "The day the theme was last updated.",
                   "minimum": 0,
                   "type": [
                     "integer",
@@ -261,9 +285,11 @@
                   ]
                 },
                 "userDisabled": {
+                  "description": "Whether or not the user disabled the theme.",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "The version of the theme.",
                   "type": "string"
                 }
               },
@@ -275,22 +301,28 @@
         "build": {
           "properties": {
             "applicationId": {
+              "description": "The application UUID.",
               "type": "string"
             },
             "applicationName": {
+              "description": "The application name.",
               "type": "string"
             },
             "architecture": {
+              "description": "The build architecture for the active build.",
               "type": "string"
             },
             "architecturesInBinary": {
+              "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac.",
               "type": "string"
             },
             "buildId": {
+              "description": "The build ID/date of the application.",
               "pattern": "^[0-9]{10}",
               "type": "string"
             },
             "displayVersion": {
+              "description": "The display version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
@@ -301,23 +333,28 @@
               ]
             },
             "platformVersion": {
+              "description": "The version of the XULRunner platform.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "updaterAvailable": {
+              "description": "True if the application was built with the support for the updater component.",
               "type": "boolean"
             },
             "vendor": {
+              "description": "The application vendor.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "version": {
+              "description": "The version of the application.",
               "pattern": "^[0-9]{2,3}\\.",
               "type": "string"
             },
             "xpcomAbi": {
+              "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'.",
               "type": "string"
             }
           },
@@ -353,36 +390,42 @@
         "partner": {
           "properties": {
             "distributionId": {
+              "description": "The value of the `distribution.id` pref that identifies the Firefox distribution.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributionVersion": {
+              "description": "The value of the `distribution.version` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributor": {
+              "description": "The value of the `app.distributor` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "distributorChannel": {
+              "description": "The value of the `app.distributor.channel` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerId": {
+              "description": "The value of the `mozilla.partner.id` pref.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "partnerNames": {
+              "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`.",
               "items": {
                 "type": "string"
               },
@@ -394,6 +437,7 @@
         "profile": {
           "properties": {
             "creationDate": {
+              "description": "The creation date of the user profile as the integer number of days since UNIX epoch.",
               "type": "number"
             },
             "firstUseDate": {
@@ -403,6 +447,7 @@
               "type": "boolean"
             },
             "resetDate": {
+              "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional.",
               "type": "number"
             }
           },
@@ -422,14 +467,17 @@
         "settings": {
           "properties": {
             "addonCompatibilityCheckEnabled": {
+              "description": "Whether application compatibility is respected for add-ons.",
               "type": "boolean"
             },
             "attribution": {
               "properties": {
                 "campaign": {
+                  "description": "Identifier of the particular campaign that led to the download of the product.",
                   "type": "string"
                 },
                 "content": {
+                  "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
                 "experiment": {
@@ -437,9 +485,11 @@
                   "type": "string"
                 },
                 "medium": {
+                  "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
                 "source": {
+                  "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"
                 },
                 "ua": {
@@ -454,6 +504,7 @@
               "type": "object"
             },
             "blocklistEnabled": {
+              "description": "True if the blocklist is enabled.",
               "type": "boolean"
             },
             "defaultPrivateSearchEngine": {
@@ -480,23 +531,28 @@
               "type": "object"
             },
             "defaultSearchEngine": {
+              "description": "Contains the string identifier or name of the default search engine provider. Deprecated.",
               "type": "string"
             },
             "defaultSearchEngineData": {
               "properties": {
                 "loadPath": {
+                  "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID",
                   "type": [
                     "string",
                     "null"
                   ]
                 },
                 "name": {
+                  "description": "The name of the default search engine.",
                   "type": "string"
                 },
                 "origin": {
+                  "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes.",
                   "type": "string"
                 },
                 "submissionURL": {
+                  "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines.",
                   "type": "string"
                 }
               },
@@ -506,6 +562,7 @@
               "type": "string"
             },
             "e10sEnabled": {
+              "description": "True if the E10S is enabled.",
               "type": "boolean"
             },
             "e10sMultiProcesses": {
@@ -560,6 +617,7 @@
               "type": "object"
             },
             "isDefaultBrowser": {
+              "description": "Identifier to indicate the particular link within a campaign.",
               "type": [
                 "boolean",
                 "null"
@@ -575,11 +633,13 @@
               "type": "integer"
             },
             "locale": {
+              "description": "The best locale that the application should be localized to.",
               "type": "string"
             },
             "sandbox": {
               "properties": {
                 "effectiveContentProcessLevel": {
+                  "description": "The effective sandbox. The values are OS dependent.",
                   "type": [
                     "integer",
                     "null"
@@ -595,17 +655,21 @@
               ]
             },
             "telemetryEnabled": {
+              "description": "The state of the `toolkit.telemetry.enabled` pref.",
               "type": "boolean"
             },
             "update": {
               "properties": {
                 "autoDownload": {
+                  "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
                 "channel": {
+                  "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "The state of the `app.update.enabled` pref.",
                   "type": "boolean"
                 }
               },
@@ -628,6 +692,7 @@
         "system": {
           "properties": {
             "appleModelId": {
+              "description": "The model IDs for Apple desktop devices. This is Mac only.",
               "type": [
                 "string",
                 "null"
@@ -636,6 +701,7 @@
             "cpu": {
               "properties": {
                 "cores": {
+                  "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure.",
                   "maximum": 2048,
                   "minimum": 1,
                   "type": [
@@ -644,53 +710,62 @@
                   ]
                 },
                 "count": {
+                  "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure.",
                   "maximum": 1024,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "extensions": {
+                  "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "family": {
+                  "description": "The CPU family, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "l2cacheKB": {
+                  "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "l3cacheKB": {
+                  "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "model": {
+                  "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "speedMHz": {
+                  "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "stepping": {
+                  "description": "The CPU stepping, `null` on failure. Desktop only.",
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
                 "vendor": {
+                  "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
                     "null"
@@ -719,15 +794,18 @@
             "gfx": {
               "properties": {
                 "ContentBackend": {
+                  "description": "The name of the content backend.",
                   "type": "string"
                 },
                 "D2DEnabled": {
+                  "description": "Whether or not Direct2D is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
                   ]
                 },
                 "DWriteEnabled": {
+                  "description": "Whether or not DirectWrite is enabled. This is Windows only.",
                   "type": [
                     "boolean",
                     "null"
@@ -821,6 +899,7 @@
                       "type": "object"
                     },
                     "compositor": {
+                      "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
                       "type": [
                         "string",
                         "null"
@@ -945,12 +1024,14 @@
                 "binary": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the application binaries are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -973,12 +1054,14 @@
                 "profile": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the profile directory is located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1001,12 +1084,14 @@
                 "system": {
                   "properties": {
                     "model": {
+                      "description": "The model of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "revision": {
+                      "description": "The revision of the hdd where the system files are located. This is Windows only.",
                       "type": [
                         "string",
                         "null"
@@ -1030,6 +1115,7 @@
               "type": "object"
             },
             "isWow64": {
+              "description": "The availability of the WoW64 subsystem. This is Windows only.",
               "type": "boolean"
             },
             "isWowARM64": {
@@ -1039,40 +1125,50 @@
               ]
             },
             "memoryMB": {
+              "description": "The machines amount of RAM.",
               "type": "number"
             },
             "os": {
               "properties": {
                 "installYear": {
+                  "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
                   ]
                 },
                 "kernelVersion": {
+                  "description": "The kernel version of Android. This is Android only. `null` on failure.",
                   "type": "string"
                 },
                 "locale": {
+                  "description": "The locale of the OS, e.g. 'en'. This is `null` on failure.",
                   "type": "string"
                 },
                 "name": {
+                  "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure.",
                   "type": "string"
                 },
                 "servicePackMajor": {
+                  "description": "The Windows service pack major version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "servicePackMinor": {
+                  "description": "The Windows service pack minor version. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "version": {
+                  "description": "The version of the OS, e.g. '6.1'. This is `null` on failure.",
                   "type": [
                     "string"
                   ]
                 },
                 "windowsBuildNumber": {
+                  "description": "The Windows build number. This is Windows only. `null` on failure.",
                   "type": "number"
                 },
                 "windowsUBR": {
+                  "description": "The Windows UBR. This is Windows 10 only. `null` on failure.",
                   "type": [
                     "number",
                     "null"
@@ -1084,6 +1180,7 @@
             "sec": {
               "properties": {
                 "antispyware": {
+                  "description": "The name of the registered antispyware software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1093,6 +1190,7 @@
                   ]
                 },
                 "antivirus": {
+                  "description": "The name of the registered antivirus software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1102,6 +1200,7 @@
                   ]
                 },
                 "firewall": {
+                  "description": "The name of the registered firewall software. Windows only.",
                   "items": {
                     "type": "string"
                   },
@@ -1114,6 +1213,7 @@
               "type": "object"
             },
             "virtualMaxMB": {
+              "description": "Total virtual memory size in MB. This is Windows only. `null` on failure.",
               "type": [
                 "number",
                 "null"

--- a/scripts/extract_probe_dictionary_descriptions
+++ b/scripts/extract_probe_dictionary_descriptions
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+from collections import OrderedDict
+import json
+import os
+import sys
+
+"""
+Script to parse probe-dictionary json files for descriptions and add them to
+schemas if they don't already exist there.
+
+This was only used for extracting comments from environment.json
+(https://github.com/mozilla/probe-dictionary/blob/master/environment.json)
+"""
+
+
+parser = ArgumentParser(description=__doc__)
+parser.add_argument(
+    "--probe-input", help=("Input probe dictionary file"),
+)
+
+parser.add_argument(
+    "--schema-output", help=("Output JSON file descriptions should be added to"),
+)
+
+
+def dict_path_with_parent(input_dict, parent=None, path=None, paths=[]):
+    """
+    Returns all possible paths of the passed dictionary including
+    the parent element.
+
+    For example, for the dictionary:
+
+    {"env": 
+      {
+        "sys": "A", 
+        "settings:" {
+          "key": 1,
+          "a": false
+        }
+      }
+    }
+
+    the return values would be:
+
+    [
+      [["env"], None],
+      [["env", "sys"], <env dict>],
+      [["env", "settings"], <env dict>],
+      [["env", "settings", "key"], <settings dict>],
+      [["env", "settings", "a"], <settings dict>],
+    ]
+    """
+    if path is None:
+        path = []
+    for k, v in input_dict.items():
+        newpath = path + [k]
+        if isinstance(v, dict):
+            paths = dict_path_with_parent(v, v, newpath, paths)
+        else:
+            paths.append([newpath, parent])
+
+    return paths
+
+
+def main():
+    args = parser.parse_args()
+
+    with open(args.probe_input, "r") as probe_input:
+        # parse probe JSON file
+        probe_input_data = json.load(probe_input)
+
+        with open(args.schema_output, "r") as schema_output:
+            # parse JSON schema file; retain order of json elements
+            schema_output_data = json.load(schema_output, object_pairs_hook=OrderedDict)
+
+            all_paths = dict_path_with_parent(schema_output_data)
+
+            for [path, parent] in all_paths:
+                # convert path from schema to corresponding json path in probe file
+                probe_path = list(
+                    filter(
+                        lambda x: x != "properties"
+                        and x != "type"
+                        and x != "description"
+                        and x != "pattern"
+                        and x != "additionalProperties",
+                        path,
+                    )
+                )
+
+                # handle some exceptions; those are specific to environment.json
+                probe_path = [
+                    x if x != "activeAddons" else "activeAddons[addonId]"
+                    for x in probe_path
+                ]
+                probe_path = [
+                    x if x != "activePlugins" else "activePlugins[index]"
+                    for x in probe_path
+                ]
+
+                # create final json path for probe json file
+                probe_path = "{}/{}".format(probe_path[0], ".".join(probe_path[1:]))
+
+                print(probe_path)
+
+                if probe_path in probe_input_data:
+                    # extract description from probe json file
+                    entry = probe_input_data[probe_path]
+                    description = entry["history"]["release"][0]["description"]
+
+                    if "description" not in parent:
+                        # update entry in schema json file
+                        parent["description"] = description
+
+            with open(args.schema_output, "w") as f:
+                # write updated json schema to file
+                json.dump(schema_output_data, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -10,25 +10,43 @@
             "type": "object",
             "properties": {
               "blocklisted": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "description": {
-                "type": [ "string", "null" ]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
-                "type": "string"
+                "type": "string",
+                "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "userDisabled": {
-                "type": [ "boolean", "integer" ]
+                "type": [
+                  "boolean",
+                  "integer"
+                ],
+                "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "appDisabled": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "version": {
-                "type": [ "string", "number" ]
+                "type": [
+                  "string",
+                  "number"
+                ],
+                "description": "The version of the add-on. This field is available at startup."
               },
               "scope": {
-                "type": [ "integer", "null" ]
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup."
               },
               "type": {
                 "type": "string"
@@ -37,30 +55,44 @@
                 "type": [
                   "integer",
                   "boolean"
-                ]
+                ],
+                "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "hasBinaryComponents": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "installDay": {
-                "type": [ "integer", "null" ],
-                "minimum": 0
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0,
+                "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "updateDay": {
-                "type": [ "integer", "null" ],
-                "minimum": 0
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0,
+                "description": "The day the add-on was last updated. This field is optional, but available at startup if present."
               },
               "signedState": {
-                "type": "integer"
+                "type": "integer",
+                "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified."
               },
               "isSystem": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether or not the add-on is a system add-on. This field is available at startup."
               },
               "isWebExtension": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup."
               },
               "multiprocessCompatible": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup."
               }
             }
           }
@@ -82,7 +114,10 @@
             "type": "object",
             "properties": {
               "version": {
-                "type": [ "string", "null" ]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "userDisabled": {
                 "type": "boolean"
@@ -135,48 +170,72 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The id of the active persona (theme)."
         },
         "theme": {
           "type": "object",
           "properties": {
             "id": {
-              "type": "string"
+              "type": "string",
+              "description": "The id of the theme."
             },
             "blocklisted": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether or not the theme appears in the blocklist."
             },
             "description": {
-              "type": [ "string", "null" ]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The theme name, limited to 100 characters."
             },
             "userDisabled": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether or not the user disabled the theme."
             },
             "appDisabled": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting."
             },
             "version": {
-              "type": "string"
+              "type": "string",
+              "description": "The version of the theme."
             },
             "scope": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Indicates what scope the theme is installed in, per profile, user, system, or application."
             },
             "foreignInstall": {
-              "type": [ "boolean", "integer" ]
+              "type": [
+                "boolean",
+                "integer"
+              ],
+              "description": "True or false depending on whether the theme is a third party theme installation or not."
             },
             "hasBinaryComponents": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60."
             },
             "installDay": {
-              "type": [ "integer", "null" ],
-              "minimum": 0
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0,
+              "description": "The days since epoch that the theme was first installed."
             },
             "updateDay": {
-              "type": [ "integer", "null" ],
-              "minimum": 0
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0,
+              "description": "The day the theme was last updated."
             }
           }
         }
@@ -186,44 +245,61 @@
       "type": "object",
       "properties": {
         "applicationId": {
-          "type": "string"
+          "type": "string",
+          "description": "The application UUID."
         },
         "applicationName": {
-          "type": "string"
+          "type": "string",
+          "description": "The application name."
         },
         "architecture": {
-          "type": "string"
+          "type": "string",
+          "description": "The build architecture for the active build."
         },
         "architecturesInBinary": {
-          "type": "string"
+          "type": "string",
+          "description": "For Mac universal builds, this is a string containing a list of architectures delimited by '-'. Architecture sets are always in the same order: ppc > i386 > ppc64 > x86_64 > (future additions). This is only available on Mac."
         },
         "buildId": {
           "type": "string",
-          "pattern": "^[0-9]{10}"
+          "pattern": "^[0-9]{10}",
+          "description": "The build ID/date of the application."
         },
         "hotfixVersion": {
-          "type": [ "string", "null" ]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "version": {
           "type": "string",
-          "pattern": "^[0-9]{2,3}\\."
+          "pattern": "^[0-9]{2,3}\\.",
+          "description": "The version of the application."
         },
         "vendor": {
-          "type": [ "string", "null" ]
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The application vendor."
         },
         "displayVersion": {
           "type": "string",
-          "pattern": "^[0-9]{2,3}\\."
+          "pattern": "^[0-9]{2,3}\\.",
+          "description": "The display version of the application."
         },
         "platformVersion": {
           "type": "string",
-          "pattern": "^[0-9]{2,3}\\."
+          "pattern": "^[0-9]{2,3}\\.",
+          "description": "The version of the XULRunner platform."
         },
         "updaterAvailable": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "True if the application was built with the support for the updater component."
         },
         "xpcomAbi": {
-          "type": "string"
+          "type": "string",
+          "description": "A string tag identifying the binary ABI of the current processor and compiler vtable. This is taken from the TARGET_XPCOM_ABI configure variable. It may not be available on all platforms, especially unusual processor or compiler combinations. The result takes the form <processor>-<compilerABI>, for example: x86-msvc, ppc-gcc3, ... . This value should almost always be used in combination with  the 'OS'."
         }
       },
       "required": [
@@ -261,37 +337,43 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The value of the `distribution.id` pref that identifies the Firefox distribution."
         },
         "distributionVersion": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The value of the `distribution.version` pref."
         },
         "partnerId": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The value of the `mozilla.partner.id` pref."
         },
         "distributor": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The value of the `app.distributor` pref."
         },
         "distributorChannel": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "The value of the `app.distributor.channel` pref."
         },
         "partnerNames": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "The list of names from the `app.partner` children prefs, as `app.partner.<name>=<name>`."
         }
       }
     },
@@ -299,10 +381,12 @@
       "type": "object",
       "properties": {
         "creationDate": {
-          "type": "number"
+          "type": "number",
+          "description": "The creation date of the user profile as the integer number of days since UNIX epoch."
         },
         "resetDate": {
-          "type": "number"
+          "type": "number",
+          "description": "The date the user profile was reset, as the integer number of days since UNIX epoch. This is optional."
         },
         "firstUseDate": {
           "type": "number"
@@ -316,22 +400,27 @@
       "type": "object",
       "properties": {
         "addonCompatibilityCheckEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether application compatibility is respected for add-ons."
         },
         "attribution": {
           "type": "object",
           "properties": {
             "source": {
-              "type": "string"
+              "type": "string",
+              "description": "Referring partner domain, when install happens via a known partner."
             },
             "medium": {
-              "type": "string"
+              "type": "string",
+              "description": "Category of the source, such as 'organic' for a search engine."
             },
             "campaign": {
-              "type": "string"
+              "type": "string",
+              "description": "Identifier of the particular campaign that led to the download of the product."
             },
             "content": {
-              "type": "string"
+              "type": "string",
+              "description": "Identifier to indicate the particular link within a campaign."
             },
             "experiment": {
               "type": "string",
@@ -348,31 +437,47 @@
           }
         },
         "blocklistEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "True if the blocklist is enabled."
         },
         "isDefaultBrowser": {
-          "type": [ "boolean", "null" ]
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Identifier to indicate the particular link within a campaign."
         },
         "isInOptoutSample": {
-          "type": [ "boolean", "null" ]
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "defaultSearchEngine": {
-          "type": "string"
+          "type": "string",
+          "description": "Contains the string identifier or name of the default search engine provider. Deprecated."
         },
         "defaultSearchEngineData": {
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The name of the default search engine."
             },
             "loadPath": {
-              "type": [ "string", "null" ]
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The anonymized path of the engine xml file, e.g. e.g. jar:[app]/omni.ja!browser/engine.xml (where ‘browser’ is the name of the chrome package, not a folder) [profile]/searchplugins/engine.xml [distribution]/searchplugins/common/engine.xml [other]/engine.xml [other]/addEngineWithDetails [other]/addEngineWithDetails:extensionID [http/https]example.com/engine-name.xml [http/https]example.com/engine-name.xml:extensionID"
             },
             "submissionURL": {
-              "type": "string"
+              "type": "string",
+              "description": "The HTTP url we would use to search. For privacy, we don’t record this for user-installed engines."
             },
             "origin": {
-              "type": "string"
+              "type": "string",
+              "description": "The origin of the search engine: the value will be default for engines that are built-in or from distribution partners, verified for user-installed engines with valid verification hashes, unverified for non-default engines without verification hash, and invalid for engines with broken verification hashes."
             }
           }
         },
@@ -386,7 +491,10 @@
               "type": "string"
             },
             "loadPath": {
-              "type": [ "string", "null" ]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "submissionURL": {
               "type": "string"
@@ -397,13 +505,17 @@
           }
         },
         "searchCohort": {
-          "type": [ "string", "null" ]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "launcherProcessState": {
           "type": "integer"
         },
         "e10sEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "True if the E10S is enabled."
         },
         "e10sMultiProcesses": {
           "description": "maximum number of processes that will be launched for regular web content",
@@ -434,13 +546,19 @@
               }
             },
             "systemLocales": {
-              "type": [ "array", "null" ],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "type": "string"
               }
             },
             "regionalPrefsLocales": {
-              "type": [ "array", "null" ],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "type": "string"
               }
@@ -454,36 +572,50 @@
           }
         },
         "locale": {
-          "type": "string"
+          "type": "string",
+          "description": "The best locale that the application should be localized to."
         },
         "telemetryEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "The state of the `toolkit.telemetry.enabled` pref."
         },
         "update": {
           "type": "object",
           "properties": {
             "autoDownload": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "The state of the `app.update.auto` pref."
             },
             "channel": {
-              "type": "string"
+              "type": "string",
+              "description": "The update channel from the defaults only. Does not include the partner bits."
             },
             "enabled": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "The state of the `app.update.enabled` pref."
             }
           }
         },
         "userPrefs": {
           "type": "object",
           "additionalProperties": {
-            "type": ["boolean", "string", "number", "null"]
+            "type": [
+              "boolean",
+              "string",
+              "number",
+              "null"
+            ]
           }
         },
         "sandbox": {
           "type": "object",
           "properties": {
             "effectiveContentProcessLevel": {
-              "type": [ "integer", "null" ]
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "The effective sandbox. The values are OS dependent."
             }
           }
         }
@@ -504,47 +636,85 @@
       "type": "object",
       "properties": {
         "appleModelId": {
-          "type": [ "string", "null" ]
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The model IDs for Apple desktop devices. This is Mac only."
         },
         "cpu": {
           "type": "object",
           "properties": {
             "cores": {
-              "type": [ "integer", "null" ],
+              "type": [
+                "integer",
+                "null"
+              ],
               "minimum": 1,
-              "maximum": 2048
+              "maximum": 2048,
+              "description": "The number of physical CPU cores. Desktop only, e.g. 4, or `null` on failure."
             },
             "count": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1024
+              "maximum": 1024,
+              "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure."
             },
             "extensions": {
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'."
             },
             "family": {
-              "type": [ "integer", "null" ]
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "The CPU family, `null` on failure. Desktop only."
             },
             "l2cacheKB": {
-              "type": [ "number", "null" ]
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "The CPU L2 cache size in KB. `null` on failure. Desktop only."
             },
             "l3cacheKB": {
-              "type": [ "number", "null" ]
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only."
             },
             "model": {
-              "type": [ "integer", "null" ]
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "The CPU model, `null` on failure. Desktop only."
             },
             "speedMHz": {
-              "type": [ "number", "null" ]
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Only available on Firefox desktop. The CPU clock speed in MHz."
             },
             "stepping": {
-              "type": [ "integer", "null" ]
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "The CPU stepping, `null` on failure. Desktop only."
             },
             "vendor": {
-              "type": [ "string", "null" ]
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The CPU vendor, e.g. 'GenuineIntel', or `null` on failure. Desktop only."
             }
           }
         },
@@ -569,19 +739,22 @@
           "type": "object",
           "properties": {
             "ContentBackend": {
-              "type": "string"
+              "type": "string",
+              "description": "The name of the content backend."
             },
             "D2DEnabled": {
               "type": [
                 "boolean",
                 "null"
-              ]
+              ],
+              "description": "Whether or not Direct2D is enabled. This is Windows only."
             },
             "DWriteEnabled": {
               "type": [
                 "boolean",
                 "null"
-              ]
+              ],
+              "description": "Whether or not DirectWrite is enabled. This is Windows only."
             },
             "Headless": {
               "type": [
@@ -598,28 +771,52 @@
                 "type": "object",
                 "properties": {
                   "description": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "vendorID": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "deviceID": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "subsysID": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "RAM": {
-                    "type": [ "integer", "null" ]
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   },
                   "driver": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "driverVersion": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "driverDate": {
-                    "type": [ "string", "null" ]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "GPUActive": {
                     "type": "boolean"
@@ -654,25 +851,44 @@
               "type": "object",
               "properties": {
                 "compositor": {
-                  "type": [ "string", "null" ]
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created)."
                 },
                 "d3d11": {
                   "type": "object",
                   "properties": {
                     "status": {
-                      "type": [ "string", "null" ]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "version": {
-                      "type": [ "number", "null" ]
+                      "type": [
+                        "number",
+                        "null"
+                      ]
                     },
                     "warp": {
-                      "type": [ "boolean", "null" ]
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
                     },
                     "blacklisted": {
-                      "type": [ "boolean", "null" ]
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
                     },
                     "textureSharing": {
-                      "type": [ "boolean", "null" ]
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
                     }
                   }
                 },
@@ -680,10 +896,16 @@
                   "type": "object",
                   "properties": {
                     "status": {
-                      "type": [ "string", "null" ]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "version": {
-                      "type": [ "string", "null" ]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 },
@@ -691,31 +913,10 @@
                   "type": "object",
                   "properties": {
                     "status": {
-                      "type": [ "string", "null" ]
-                    }
-                  }
-                },
-                "advancedLayers": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": [ "string", "null" ]
-                    }
-                  }
-                },
-                "webrender": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": [ "string", "null" ]
-                    }
-                  }
-                },
-                "wrQualified": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": [ "string", "null" ]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 },
@@ -723,10 +924,38 @@
                   "type": "object",
                   "properties": {
                     "noConstantBufferOffsetting": {
-                      "type": ["boolean", "null"]
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
                     },
                     "status": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "webrender": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "wrQualified": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
@@ -744,13 +973,15 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The model of the hdd where the profile directory is located. This is Windows only."
                 },
                 "revision": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The revision of the hdd where the profile directory is located. This is Windows only."
                 },
                 "type": {
                   "type": [
@@ -772,13 +1003,15 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The model of the hdd where the application binaries are located. This is Windows only."
                 },
                 "revision": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The revision of the hdd where the application binaries are located. This is Windows only."
                 },
                 "type": {
                   "type": [
@@ -800,13 +1033,15 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The model of the hdd where the system files are located. This is Windows only."
                 },
                 "revision": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "The revision of the hdd where the system files are located. This is Windows only."
                 },
                 "type": {
                   "type": [
@@ -824,46 +1059,72 @@
           }
         },
         "isWow64": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "The availability of the WoW64 subsystem. This is Windows only."
         },
         "isWowARM64": {
-          "type": [ "boolean", "null" ]
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "memoryMB": {
-          "type": "number"
+          "type": "number",
+          "description": "The machines amount of RAM."
         },
         "virtualMaxMB": {
-          "type": [ "number", "null" ]
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Total virtual memory size in MB. This is Windows only. `null` on failure."
         },
         "os": {
           "type": "object",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "description": "The name of the OS, e.g. 'Windows_NT'. This is `null` on failure."
             },
             "version": {
-              "type": [ "string" ]
+              "type": [
+                "string"
+              ],
+              "description": "The version of the OS, e.g. '6.1'. This is `null` on failure."
             },
             "kernelVersion": {
-              "type": "string"
+              "type": "string",
+              "description": "The kernel version of Android. This is Android only. `null` on failure."
             },
             "servicePackMajor": {
-              "type": "number"
+              "type": "number",
+              "description": "The Windows service pack major version. This is Windows only. `null` on failure."
             },
             "servicePackMinor": {
-              "type": "number"
+              "type": "number",
+              "description": "The Windows service pack minor version. This is Windows only. `null` on failure."
             },
             "windowsBuildNumber": {
-              "type": "number"
+              "type": "number",
+              "description": "The Windows build number. This is Windows only. `null` on failure."
             },
             "windowsUBR": {
-              "type": [ "number", "null" ]
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "The Windows UBR. This is Windows 10 only. `null` on failure."
             },
             "installYear": {
-              "type": [ "number", "null" ]
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "The year Windows was installed. This is Windows only. `null` on failure."
             },
             "locale": {
-              "type": "string"
+              "type": "string",
+              "description": "The locale of the OS, e.g. 'en'. This is `null` on failure."
             }
           }
         },
@@ -871,22 +1132,34 @@
           "type": "object",
           "properties": {
             "antivirus": {
-              "type": [ "array", "null" ],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "The name of the registered antivirus software. Windows only."
             },
             "antispyware": {
-              "type": [ "array", "null" ],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "The name of the registered antispyware software. Windows only."
             },
             "firewall": {
-              "type": [ "array", "null" ],
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "The name of the registered firewall software. Windows only."
             }
           }
         }


### PR DESCRIPTION
I wrote a small script to extract descriptions from [probe-dictionary](https://github.com/mozilla/probe-dictionary/blob/master/environment.json) and add them to corresponding fields that were missing the description. 


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
