### PR TITLE
Add missing environement column and types

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -833,12 +833,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -858,6 +852,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -833,6 +833,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -833,12 +833,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -858,6 +852,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -833,6 +833,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",
@@ -1536,7 +1542,8 @@
               },
               "type": "object"
             }
-          ]
+          ],
+          "type": "object"
         },
         "reason": {
           "enum": [

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -833,12 +833,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -858,6 +852,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -833,6 +833,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -832,6 +832,12 @@
                           "null"
                         ]
                       },
+                      "adapterDriver": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
                       "description": {
                         "type": [
                           "string",

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -832,12 +832,6 @@
                           "null"
                         ]
                       },
-                      "adapterDriver": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
                       "description": {
                         "type": [
                           "string",
@@ -857,6 +851,12 @@
                         ]
                       },
                       "driverDate": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "driverVendor": {
                         "type": [
                           "string",
                           "null"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -820,6 +820,12 @@
                   },
                   "GPUActive": {
                     "type": "boolean"
+                  },
+                  "adapterDriver": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -821,7 +821,7 @@
                   "GPUActive": {
                     "type": "boolean"
                   },
-                  "adapterDriver": {
+                  "driverVendor": {
                     "type": [
                       "string",
                       "null"

--- a/templates/telemetry/new-profile/new-profile.4.schema.json
+++ b/templates/telemetry/new-profile/new-profile.4.schema.json
@@ -19,6 +19,7 @@
             ]
         },
         "processes": {
+          "type": "object",
           "$comment": "This use of 'allOf' is a terrible hack to force this section not to appear in BigQuery",
           "allOf": [{
             "type": "object",

--- a/templates/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/templates/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -9,6 +9,7 @@
     @TELEMETRY_ENVIRONMENT_1_JSON@,
     @TELEMETRY_ID_1_JSON@,
     "payload": {
+      "type": "object",
       "properties": {
         "reason": {
           "enum": [

--- a/validation/telemetry/event.4.sample.pass.json
+++ b/validation/telemetry/event.4.sample.pass.json
@@ -131,7 +131,8 @@
             "driver": null,
             "driverVersion": "4.5.0 NVIDIA 384.111",
             "driverDate": null,
-            "GPUActive": true
+            "GPUActive": true,
+            "driverVendor": "mesa/i965"
           }
         ],
         "monitors": [],


### PR DESCRIPTION
Add missing column `environment.system.gfx.adapters.adapterDriver` to environment and add missing types to schemas.

Fixes part of https://bugzilla.mozilla.org/show_bug.cgi?id=1614416

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
