### PR TITLE
Add initial Firefox Accounts metrics event schemas and templates

### DIFF
--- a/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "document_id": {
+      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "document_namespace": {
+      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "firefox-accounts"
+      ],
+      "type": "string"
+    },
+    "document_type": {
+      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "activity-flow-metrics"
+      ],
+      "type": "string"
+    },
+    "document_version": {
+      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "1"
+      ],
+      "type": "string"
+    },
+    "submission_timestamp": {
+      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "document_id",
+    "document_namespace",
+    "document_type",
+    "document_version",
+    "submission_timestamp"
+  ],
+  "title": "activity-flow-metrics",
+  "type": "object"
+}

--- a/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -1,45 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-    "document_id": {
-      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
-    },
-    "document_namespace": {
-      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "firefox-accounts"
-      ],
-      "type": "string"
-    },
-    "document_type": {
-      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "activity-flow-metrics"
-      ],
-      "type": "string"
-    },
-    "document_version": {
-      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "1"
-      ],
-      "type": "string"
-    },
-    "submission_timestamp": {
-      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
-      "format": "date-time",
-      "type": "string"
-    }
-  },
-  "required": [
-    "document_id",
-    "document_namespace",
-    "document_type",
-    "document_version",
-    "submission_timestamp"
-  ],
+  "properties": {},
   "title": "activity-flow-metrics",
   "type": "object"
 }

--- a/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -1,52 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
-    "document_id": {
-      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
-    },
-    "document_namespace": {
-      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "firefox-accounts"
-      ],
-      "type": "string"
-    },
-    "document_type": {
-      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "amplitude-event"
-      ],
-      "type": "string"
-    },
-    "document_version": {
-      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
-      "enum": [
-        "1"
-      ],
-      "type": "string"
-    },
     "op": {
       "description": "Pre-existing Firefox Accounts metrics field used to identify Amplitude metrics events.",
       "enum": [
         "amplitudeEvent"
       ],
       "type": "string"
-    },
-    "submission_timestamp": {
-      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
-      "format": "date-time",
-      "type": "string"
     }
   },
   "required": [
-    "document_id",
-    "document_namespace",
-    "document_type",
-    "document_version",
-    "op",
-    "submission_timestamp"
+    "op"
   ],
   "title": "amplitude-event",
   "type": "object"

--- a/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "document_id": {
+      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "document_namespace": {
+      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "firefox-accounts"
+      ],
+      "type": "string"
+    },
+    "document_type": {
+      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "amplitude-event"
+      ],
+      "type": "string"
+    },
+    "document_version": {
+      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
+      "enum": [
+        "1"
+      ],
+      "type": "string"
+    },
+    "op": {
+      "description": "Pre-existing Firefox Accounts metrics field used to identify Amplitude metrics events.",
+      "enum": [
+        "amplitudeEvent"
+      ],
+      "type": "string"
+    },
+    "submission_timestamp": {
+      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "document_id",
+    "document_namespace",
+    "document_type",
+    "document_version",
+    "op",
+    "submission_timestamp"
+  ],
+  "title": "amplitude-event",
+  "type": "object"
+}

--- a/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -3,37 +3,5 @@
   "type": "object",
   "title": "activity-flow-metrics",
   "properties": {
-    "document_id": {
-      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    },
-    "document_namespace": {
-      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "firefox-accounts" ]
-    },
-    "document_type": {
-      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "activity-flow-metrics" ]
-    },
-    "document_version": {
-      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "1" ]
-    },
-    "submission_timestamp": {
-      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
-      "type": "string",
-      "format": "date-time"
-    }
-  },
-  "required": [
-    "document_id",
-    "document_namespace",
-    "document_type",
-    "document_version",
-    "submission_timestamp"
-  ]
+  }
 }

--- a/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "activity-flow-metrics",
+  "properties": {
+    "document_id": {
+      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "document_namespace": {
+      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "firefox-accounts" ]
+    },
+    "document_type": {
+      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "activity-flow-metrics" ]
+    },
+    "document_version": {
+      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "1" ]
+    },
+    "submission_timestamp": {
+      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "document_id",
+    "document_namespace",
+    "document_type",
+    "document_version",
+    "submission_timestamp"
+  ]
+}

--- a/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -3,43 +3,13 @@
   "type": "object",
   "title": "amplitude-event",
   "properties": {
-    "document_id": {
-      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    },
-    "document_namespace": {
-      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "firefox-accounts" ]
-    },
-    "document_type": {
-      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "amplitude-event" ]
-    },
-    "document_version": {
-      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
-      "type": "string",
-      "enum": [ "1" ]
-    },
     "op": {
       "description": "Pre-existing Firefox Accounts metrics field used to identify Amplitude metrics events.",
       "type": "string",
       "enum": [ "amplitudeEvent" ]
-    },
-    "submission_timestamp": {
-      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
-      "type": "string",
-      "format": "date-time"
     }
   },
   "required": [
-    "document_id",
-    "document_namespace",
-    "document_type",
-    "document_version",
-    "op",
-    "submission_timestamp"
+    "op"
   ]
 }

--- a/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "amplitude-event",
+  "properties": {
+    "document_id": {
+      "description": "UUIDv4 message identifier, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "document_namespace": {
+      "description": "Per-project document namespace, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "firefox-accounts" ]
+    },
+    "document_type": {
+      "description": "Per-project document type, matching the schema title, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "amplitude-event" ]
+    },
+    "document_version": {
+      "description": "Document version number, normally parsed out of the uri by the ingestion edge service.",
+      "type": "string",
+      "enum": [ "1" ]
+    },
+    "op": {
+      "description": "Pre-existing Firefox Accounts metrics field used to identify Amplitude metrics events.",
+      "type": "string",
+      "enum": [ "amplitudeEvent" ]
+    },
+    "submission_timestamp": {
+      "description": "Time when the Firefox Accounts web server received this message, formatted as ISO time string.",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "document_id",
+    "document_namespace",
+    "document_type",
+    "document_version",
+    "op",
+    "submission_timestamp"
+  ]
+}

--- a/validation/firefox-accounts/activity-flow-metrics.1.sample.pass.json
+++ b/validation/firefox-accounts/activity-flow-metrics.1.sample.pass.json
@@ -1,0 +1,7 @@
+{
+  "document_id": "12345678-1234-5678-9abc-0123456789ab",
+  "document_namespace": "firefox-accounts",
+  "document_type": "activity-flow-metrics",
+  "document_version": "1",
+  "submission_timestamp": "2020-03-14T00:25:58.413Z"
+}

--- a/validation/firefox-accounts/amplitude-event.1.fxa-auth-server--fxa_login--success.pass.json
+++ b/validation/firefox-accounts/amplitude-event.1.fxa-auth-server--fxa_login--success.pass.json
@@ -1,0 +1,14 @@
+{
+  "event_type": "fxa_login - success",
+  "country": "United States",
+  "time": 1584635442022,
+  "os_name": "Windows",
+  "app_version": "162.3",
+  "language": "en",
+  "region": "Oregon",
+  "op": "amplitudeEvent",
+  "user_id": "4c86e262edbc48c6804c728a2e5711f0",
+  "user_properties": "{\"ua_browser\":\"Firefox\",\"ua_version\":\"76.0\"}",
+  "os_version": "8.1",
+  "event_properties": "{}"
+}

--- a/validation/firefox-accounts/amplitude-event.1.fxa-content-server--fxa_reg--view.pass.json
+++ b/validation/firefox-accounts/amplitude-event.1.fxa-content-server--fxa_reg--view.pass.json
@@ -1,0 +1,15 @@
+{
+  "session_id": 1584630379123,
+  "region": "Ontario",
+  "op": "amplitudeEvent",
+  "os_version": "10",
+  "user_properties": "{\"flow_id\":\"a2433a8201097b064cff25d1f08c62f9b47167e91994306a07eea0e6a5988123\",\"ua_browser\":\"Firefox\",\"ua_version\":\"74.0\",\"$append\":{\"fxa_services_used\":\"undefined_oauth\"}}",
+  "device_id": "33c6a63e28d64dae90c93609ff430900",
+  "event_properties": "{\"service\":\"undefined_oauth\",\"oauth_client_id\":\"e6eb0d1e856335fc\"}",
+  "event_type": "fxa_reg - view",
+  "country": "Canada",
+  "time": 1584630383466,
+  "os_name": "Windows",
+  "app_version": "162.1",
+  "language": "en"
+}

--- a/validation/firefox-accounts/amplitude-event.1.fxa-payments-server--fxa_pay_setup--engage.pass.json
+++ b/validation/firefox-accounts/amplitude-event.1.fxa-payments-server--fxa_pay_setup--engage.pass.json
@@ -1,0 +1,12 @@
+{
+  "op": "amplitudeEvent",
+  "event_type": "fxa_pay_setup - engage",
+  "time": 1584621762045,
+  "os_name": "Windows",
+  "app_version": "162.1",
+  "os_version": "10",
+  "user_properties": "{\"flow_id\":\"cdb4d564b76249355c8d9e8d0741db2b192f4cd7185ef5a1c197c2cf06d32610\",\"ua_browser\":\"Firefox\",\"ua_version\":\"72.0\"}",
+  "device_id": "61e8366b8d374ad08f49b59c79904bab",
+  "session_id": "1584261684526",
+  "event_properties": "{\"plan_id\":\"plan_FiJ55YK6UYftPa\",\"product_id\":\"prod_FiJ42WCzZNRSbS\"}"
+}

--- a/validation/firefox-accounts/amplitude-event.1.sample.pass.json
+++ b/validation/firefox-accounts/amplitude-event.1.sample.pass.json
@@ -1,8 +1,0 @@
-{
-  "document_id": "12345678-1234-5678-9abc-0123456789ab",
-  "document_namespace": "firefox-accounts",
-  "document_type": "amplitude-event",
-  "document_version": "1",
-  "op": "amplitudeEvent",
-  "submission_timestamp": "2020-03-14T00:25:58.413Z"
-}

--- a/validation/firefox-accounts/amplitude-event.1.sample.pass.json
+++ b/validation/firefox-accounts/amplitude-event.1.sample.pass.json
@@ -1,0 +1,8 @@
+{
+  "document_id": "12345678-1234-5678-9abc-0123456789ab",
+  "document_namespace": "firefox-accounts",
+  "document_type": "amplitude-event",
+  "document_version": "1",
+  "op": "amplitudeEvent",
+  "submission_timestamp": "2020-03-14T00:25:58.413Z"
+}


### PR DESCRIPTION
Opening early for feedback from @jklukas. Many optional fields to be added later. Things I'm particularly curious about:

* Should the parsed `uri` fields (`document_namespace` and so on) be grouped under a separate `metadata` property, as in the `metadata` schema templates?

* Should the `document_version` be specified, as I've done here, or left as just generic string type?

* Should I extract repeated fields into a template file, and/or borrow common fields (say, the UUID regex) from some common location?

Fixes https://github.com/mozilla/fxa/issues/4456.

-----

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
