### PR TITLE
Bug 1620118 - Add the isDependent field to the third-party-modules ping

### DIFF
--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1344,6 +1344,10 @@
                       "description": "The base address to which the loader mapped the module.",
                       "type": "string"
                     },
+                    "isDependent": {
+                      "description": "True if the module is included in the executable's Import Directory Table.",
+                      "type": "boolean"
+                    },
                     "loadDurationMS": {
                       "description": "Time spent loading this module, in milliseconds.",
                       "type": "number"

--- a/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -109,6 +109,10 @@
                       "description": "Index of the element in the modules array that contains details about the module that was loaded during this event.",
                       "type": "integer",
                       "minimum": 0
+                    },
+                    "isDependent": {
+                      "description": "True if the module is included in the executable's Import Directory Table.",
+                      "type": "boolean"
                     }
                   },
                   "required": [

--- a/validation/telemetry/third-party-modules.4.moduleindex.fail.json
+++ b/validation/telemetry/third-party-modules.4.moduleindex.fail.json
@@ -26,7 +26,8 @@
                         "threadID": 18264,
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
-                        "moduleIndex": -1
+                        "moduleIndex": -1,
+                        "isDependent": false
                     }
                 ]
             }

--- a/validation/telemetry/third-party-modules.4.sample.pass.json
+++ b/validation/telemetry/third-party-modules.4.sample.pass.json
@@ -411,7 +411,8 @@
                         "threadID": 18264,
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
-                        "moduleIndex": 0
+                        "moduleIndex": 0,
+                        "isDependent": false
                     }
                 ]
             }

--- a/validation/telemetry/third-party-modules.4.stackframe.fail.json
+++ b/validation/telemetry/third-party-modules.4.stackframe.fail.json
@@ -43,7 +43,8 @@
                         "threadID": 18264,
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
-                        "moduleIndex": 0
+                        "moduleIndex": 0,
+                        "isDependent": false
                     }
                 ]
             }

--- a/validation/telemetry/third-party-modules.4.trustflags.fail.json
+++ b/validation/telemetry/third-party-modules.4.trustflags.fail.json
@@ -26,7 +26,8 @@
                         "threadID": 18264,
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
-                        "moduleIndex": 0
+                        "moduleIndex": 0,
+                        "isDependent": false
                     }
                 ]
             }

--- a/validation/telemetry/third-party-modules.4.unknownmodule.pass.json
+++ b/validation/telemetry/third-party-modules.4.unknownmodule.pass.json
@@ -410,7 +410,8 @@
                         "threadID": 18264,
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
-                        "moduleIndex": 0
+                        "moduleIndex": 0,
+                        "isDependent": false
                     }
                 ]
             }


### PR DESCRIPTION
This patch adds a new optional field `isDependent` in the existing
third-party-module ping.

https://bugzilla.mozilla.org/show_bug.cgi?id=1620118

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
