### PR TITLE
Bug 1623626 - Add crash stacks to crash schema

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1391,6 +1391,90 @@
         "processType": {
           "type": "string"
         },
+        "stackTraces": {
+          "properties": {
+            "crash_info": {
+              "properties": {
+                "address": {
+                  "pattern": "^(0x[a-fA-F0-9]+|0)$",
+                  "type": "string"
+                },
+                "crashing_thread": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "main_module": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "modules": {
+              "items": {
+                "properties": {
+                  "base_addr": {
+                    "pattern": "^(0x[a-fA-F0-9]+|0)$",
+                    "type": "string"
+                  },
+                  "code_id": {
+                    "type": "string"
+                  },
+                  "debug_file": {
+                    "type": "string"
+                  },
+                  "debug_id": {
+                    "type": "string"
+                  },
+                  "end_addr": {
+                    "pattern": "^(0x[a-fA-F0-9]+|0)$",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "threads": {
+              "items": {
+                "properties": {
+                  "ip": {
+                    "pattern": "^(0x[a-fA-F0-9]+|0)$",
+                    "type": "string"
+                  },
+                  "module_index": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "version": {
           "maximum": 1,
           "minimum": 1,

--- a/templates/include/telemetry/hexAddress.1.schema.json
+++ b/templates/include/telemetry/hexAddress.1.schema.json
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "pattern": "^(0x[a-fA-F0-9]+|0)$"
+}

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -162,6 +162,72 @@
         "processType": {
           "type": "string"
         },
+        "stackTraces": {
+          "type": ["object", "null"],
+          "properties": {
+            "crash_info": {
+              "type": "object",
+              "properties": {
+                "address": @TELEMETRY_HEXADDRESS_1_JSON@,
+                "crashing_thread": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "type": {
+                  "type": ["string", "null"]
+                }
+              }
+            },
+            "main_module": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "modules": {
+              "type": "array",
+              "items" : {
+                "type" : "object",
+                "properties": {
+                  "base_addr": @TELEMETRY_HEXADDRESS_1_JSON@,
+                  "end_addr": @TELEMETRY_HEXADDRESS_1_JSON@,
+                  "code_id": {
+                    "type": "string"
+                  },
+                  "debug_file": {
+                    "type": "string"
+                  },
+                  "debug_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "status": {
+              "type": "string"
+            },
+            "threads": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ip": @TELEMETRY_HEXADDRESS_1_JSON@,
+                  "module_index": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "version": {
           "type": "integer",
           "minimum": 1,

--- a/validation/telemetry/crash.4.null_stackTraces.pass.json
+++ b/validation/telemetry/crash.4.null_stackTraces.pass.json
@@ -1,0 +1,192 @@
+{
+  "clientId": "a136763f-3b9a-492d-8964-bfe783b68dc6",
+  "id": "89ba9d98-b041-46f3-8b1a-36dfeb5e1b15",
+  "environment": {
+    "settings": {
+      "blocklistEnabled": true,
+      "attribution": {
+        "content": "%2528not%2Bset%2529",
+        "source": "www.google.com",
+        "medium": "referral",
+        "campaign": "%2528not%2Bset%2529"
+      },
+      "isDefaultBrowser": true,
+      "addonCompatibilityCheckEnabled": true,
+      "locale": "en-US",
+      "e10sMultiProcesses": 4,
+      "defaultSearchEngineData": {
+        "origin": "default",
+        "loadPath": "jar:[app]/omni.ja!browser/google.xml",
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b",
+        "name": "Google"
+      },
+      "update": {
+        "enabled": true,
+        "autoDownload": true,
+        "channel": "nightly"
+      },
+      "e10sEnabled": true,
+      "sandbox": {
+        "effectiveContentProcessLevel": 5
+      },
+      "userPrefs": {
+        "browser.startup.homepage": "<user-set>",
+        "browser.search.region": "KE",
+        "browser.cache.disk.capacity": 358400,
+        "browser.search.widget.inNavBar": false
+      },
+      "defaultSearchEngine": "google",
+      "telemetryEnabled": true
+    },
+    "system": {
+      "gfx": {
+        "features": {
+          "compositor": "d3d11",
+          "advancedLayers": {
+            "status": "available"
+          },
+          "gpuProcess": {
+            "status": "unavailable"
+          },
+          "d3d11": {
+            "status": "available",
+            "textureSharing": true,
+            "version": 40960,
+            "blacklisted": false,
+            "warp": false
+          },
+          "d2d": {
+            "status": "blacklisted",
+            "version": "1.1"
+          }
+        },
+        "DWriteEnabled": true,
+        "D2DEnabled": false,
+        "ContentBackend": "Skia",
+        "adapters": [
+          {
+            "vendorID": "0x8086",
+            "driverVersion": "8.15.10.2302",
+            "driverDate": "2-11-2011",
+            "description": "Intel(R) Q45/Q43 Express Chipset",
+            "GPUActive": true,
+            "RAM": null,
+            "driver": "igdumdx32 igd10umd32",
+            "deviceID": "0x2e12",
+            "subsysID": "3034103c"
+          }
+        ],
+        "monitors": [
+          {
+            "refreshRate": 60,
+            "screenHeight": 1024,
+            "screenWidth": 1280,
+            "pseudoDisplay": false
+          }
+        ]
+      },
+      "os": {
+        "name": "Windows_NT",
+        "locale": "en-US",
+        "installYear": 2016,
+        "version": "6.1",
+        "servicePackMajor": 0,
+        "windowsBuildNumber": 7600,
+        "servicePackMinor": 0
+      },
+      "memoryMB": 1993,
+      "hdd": {
+        "profile": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "binary": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "system": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        }
+      },
+      "virtualMaxMB": 2048,
+      "appleModelId": null,
+      "isWow64": false,
+      "cpu": {
+        "count": 2,
+        "l3cacheKB": null,
+        "vendor": "GenuineIntel",
+        "family": 6,
+        "extensions": [
+          "hasMMX",
+          "hasSSE",
+          "hasSSE2",
+          "hasSSE3",
+          "hasSSSE3",
+          "hasSSE4_1"
+        ],
+        "stepping": 10,
+        "cores": 2,
+        "model": 23,
+        "speedMHz": 2926,
+        "l2cacheKB": 3072
+      }
+    },
+    "build": {
+      "applicationName": "Firefox",
+      "vendor": "Mozilla",
+      "buildId": "20180409100035",
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "version": "61.0a1",
+      "architecture": "x86",
+      "platformVersion": "61.0a1",
+      "xpcomAbi": "x86-msvc",
+      "updaterAvailable": true
+    },
+    "partner": {
+      "distributionId": null,
+      "distributorChannel": null,
+      "partnerId": null,
+      "distributor": null,
+      "distributionVersion": null,
+      "partnerNames": []
+    }
+  },
+  "application": {
+    "vendor": "Mozilla",
+    "name": "Firefox",
+    "buildId": "20180409100035",
+    "displayVersion": "61.0a1",
+    "version": "61.0a1",
+    "architecture": "x86",
+    "platformVersion": "61.0a1",
+    "xpcomAbi": "x86-msvc",
+    "channel": "nightly"
+  },
+  "version": 4,
+  "creationDate": "2018-04-10T07:25:01.155Z",
+  "type": "crash",
+  "payload": {
+    "sessionId": null,
+    "stackTraces": null,
+    "version": 1,
+    "minidumpSha256Hash": "5f95d0abb0104fa7d13378a47b799b489b6c321febbe1cd9a7b921207708526b",
+    "crashTime": "2018-04-10T07:00:00.000Z",
+    "crashDate": "2018-04-10",
+    "metadata": {
+      "Version": "61.0a1",
+      "StartupCrash": "0",
+      "ipc_channel_error": "ShutDownKill",
+      "ProductName": "Firefox",
+      "StartupCrash": "0",
+      "BuildID": "20180409100035",
+      "UptimeTS": "56.8150704",
+      "CrashTime": "1523345096",
+      "ReleaseChannel": "nightly",
+      "ProductID": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
+    },
+    "processType": "content",
+    "crashId": "f6ecb3b9-bcb7-4c65-ae77-255d79836cc6",
+    "hasCrashEnvironment": true
+  }
+}

--- a/validation/telemetry/crash.4.stackTraces.pass.json
+++ b/validation/telemetry/crash.4.stackTraces.pass.json
@@ -1,0 +1,236 @@
+{
+  "clientId": "a136763f-3b9a-492d-8964-bfe783b68dc6",
+  "id": "89ba9d98-b041-46f3-8b1a-36dfeb5e1b15",
+  "environment": {
+    "settings": {
+      "blocklistEnabled": true,
+      "attribution": {
+        "content": "%2528not%2Bset%2529",
+        "source": "www.google.com",
+        "medium": "referral",
+        "campaign": "%2528not%2Bset%2529"
+      },
+      "isDefaultBrowser": true,
+      "addonCompatibilityCheckEnabled": true,
+      "locale": "en-US",
+      "e10sMultiProcesses": 4,
+      "defaultSearchEngineData": {
+        "origin": "default",
+        "loadPath": "jar:[app]/omni.ja!browser/google.xml",
+        "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b",
+        "name": "Google"
+      },
+      "update": {
+        "enabled": true,
+        "autoDownload": true,
+        "channel": "nightly"
+      },
+      "e10sEnabled": true,
+      "sandbox": {
+        "effectiveContentProcessLevel": 5
+      },
+      "userPrefs": {
+        "browser.startup.homepage": "<user-set>",
+        "browser.search.region": "KE",
+        "browser.cache.disk.capacity": 358400,
+        "browser.search.widget.inNavBar": false
+      },
+      "defaultSearchEngine": "google",
+      "telemetryEnabled": true
+    },
+    "system": {
+      "gfx": {
+        "features": {
+          "compositor": "d3d11",
+          "advancedLayers": {
+            "status": "available"
+          },
+          "gpuProcess": {
+            "status": "unavailable"
+          },
+          "d3d11": {
+            "status": "available",
+            "textureSharing": true,
+            "version": 40960,
+            "blacklisted": false,
+            "warp": false
+          },
+          "d2d": {
+            "status": "blacklisted",
+            "version": "1.1"
+          }
+        },
+        "DWriteEnabled": true,
+        "D2DEnabled": false,
+        "ContentBackend": "Skia",
+        "adapters": [
+          {
+            "vendorID": "0x8086",
+            "driverVersion": "8.15.10.2302",
+            "driverDate": "2-11-2011",
+            "description": "Intel(R) Q45/Q43 Express Chipset",
+            "GPUActive": true,
+            "RAM": null,
+            "driver": "igdumdx32 igd10umd32",
+            "deviceID": "0x2e12",
+            "subsysID": "3034103c"
+          }
+        ],
+        "monitors": [
+          {
+            "refreshRate": 60,
+            "screenHeight": 1024,
+            "screenWidth": 1280,
+            "pseudoDisplay": false
+          }
+        ]
+      },
+      "os": {
+        "name": "Windows_NT",
+        "locale": "en-US",
+        "installYear": 2016,
+        "version": "6.1",
+        "servicePackMajor": 0,
+        "windowsBuildNumber": 7600,
+        "servicePackMinor": 0
+      },
+      "memoryMB": 1993,
+      "hdd": {
+        "profile": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "binary": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        },
+        "system": {
+          "model": "ST3160316CS",
+          "revision": "SC13"
+        }
+      },
+      "virtualMaxMB": 2048,
+      "appleModelId": null,
+      "isWow64": false,
+      "cpu": {
+        "count": 2,
+        "l3cacheKB": null,
+        "vendor": "GenuineIntel",
+        "family": 6,
+        "extensions": [
+          "hasMMX",
+          "hasSSE",
+          "hasSSE2",
+          "hasSSE3",
+          "hasSSSE3",
+          "hasSSE4_1"
+        ],
+        "stepping": 10,
+        "cores": 2,
+        "model": 23,
+        "speedMHz": 2926,
+        "l2cacheKB": 3072
+      }
+    },
+    "build": {
+      "applicationName": "Firefox",
+      "vendor": "Mozilla",
+      "buildId": "20180409100035",
+      "applicationId": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
+      "version": "61.0a1",
+      "architecture": "x86",
+      "platformVersion": "61.0a1",
+      "xpcomAbi": "x86-msvc",
+      "updaterAvailable": true
+    },
+    "partner": {
+      "distributionId": null,
+      "distributorChannel": null,
+      "partnerId": null,
+      "distributor": null,
+      "distributionVersion": null,
+      "partnerNames": []
+    }
+  },
+  "application": {
+    "vendor": "Mozilla",
+    "name": "Firefox",
+    "buildId": "20180409100035",
+    "displayVersion": "61.0a1",
+    "version": "61.0a1",
+    "architecture": "x86",
+    "platformVersion": "61.0a1",
+    "xpcomAbi": "x86-msvc",
+    "channel": "nightly"
+  },
+  "version": 4,
+  "creationDate": "2018-04-10T07:25:01.155Z",
+  "type": "crash",
+  "payload": {
+    "sessionId": null,
+    "stackTraces": {
+      "crash_info": {
+        "address": "0x0",
+        "crashing_thread": 0,
+        "type": "SIGABRT"
+      },
+      "main_module": 0,
+      "modules": [
+        {
+          "base_addr": "0x0",
+          "code_id": "00000000000000000000000000000000",
+          "debug_file": "libc.mo",
+          "debug_id": "000000000000000000000000000000000",
+          "end_addr": "0x76fd0000",
+          "filename": "libc.mo",
+          "version": ""
+        },
+        {
+          "base_addr": "0x0",
+          "code_id": "00000000000000000000000000000000",
+          "debug_file": "gconv-modules.cache",
+          "debug_id": "000000000000000000000000000000000",
+          "end_addr": "0x76fd7000",
+          "filename": "gconv-modules.cache",
+          "version": ""
+        }
+      ],
+      "status": "OK",
+      "threads": [
+        {
+          "frames": [
+            {
+              "ip": "0x0",
+              "module_index": 1,
+              "trust": "context"
+            },
+            {
+              "ip": "0x0",
+              "module_index": 2,
+              "trust": "scan"
+            }
+          ]
+        }
+      ]
+    },
+    "version": 1,
+    "minidumpSha256Hash": "5f95d0abb0104fa7d13378a47b799b489b6c321febbe1cd9a7b921207708526b",
+    "crashTime": "2018-04-10T07:00:00.000Z",
+    "crashDate": "2018-04-10",
+    "metadata": {
+      "Version": "61.0a1",
+      "StartupCrash": "0",
+      "ipc_channel_error": "ShutDownKill",
+      "ProductName": "Firefox",
+      "StartupCrash": "0",
+      "BuildID": "20180409100035",
+      "UptimeTS": "56.8150704",
+      "CrashTime": "1523345096",
+      "ReleaseChannel": "nightly",
+      "ProductID": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
+    },
+    "processType": "content",
+    "crashId": "f6ecb3b9-bcb7-4c65-ae77-255d79836cc6",
+    "hasCrashEnvironment": true
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
