### PR TITLE
Update docs and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 Checklist for reviewer:
 
-- [ ] Commits should reference a bug or github issue, if relevant
+- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
 - [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
-- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.
+- [ ] Watch the results of the `integration` CI test and make sure the error rates do not increase without justification.
 
 For glean changes:
 - [ ] Update `include/glean/CHANGELOG.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Checklist for reviewer:
 
 - [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
 - [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
-- [ ] Watch the results of the `integration` CI test and make sure the error rates do not increase without justification.
+- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.
 
 For glean changes:
 - [ ] Update `include/glean/CHANGELOG.md`

--- a/README.md
+++ b/README.md
@@ -94,30 +94,6 @@ pytest -k telemetry/main.4
 pytest -k java
 ```
 
-If you would like to run validation against
-[`everit-org/json-schema`](https://github.com/everit-org/json-schema) used in
-[mozilla/ingestion-beam](https://mozilla.github.io/gcp-ingestion/ingestion-beam/),
-either run the docker container or install the java dependencies.
-
-```bash
-export JAVA_HOME=...
-
-# resolves and copies jars into `target/dependency`
-mvn dependency:copy-dependencies
-
-# check that tests are not skipped
-pytest -k java -n 8
-```
-
-The following docker command will generate a report against a sample of data from the ingestion system given proper credentials. Running this is recommended when making modifications to many schemas or during review.
-
-    docker run \
-        -e AWS_ACCESS_KEY_ID \
-        -e AWS_SECRET_ACCESS_KEY \
-        -v "$(pwd)":/app/mozilla-pipeline-schemas \
-        -it mozilla/edge-validator:latest \
-            make report
-
 Pushes to the main repo will trigger integration tests in CircleCI that directly
 compare the revision to the `master` branch. These tests do not run for forked PRs
 in order to protect data and credentials, but reviewers can trigger tests to run


### PR DESCRIPTION
Notably, no need to ask people to run the integration tests
manually since we now do this automatically. The instructions
were out of date and hard to follow so I just removed them, if
people really care to do this themselves they can always look at the
circle configuration.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
