### PR TITLE
Bug 1624986 - Fix specification of sessionId, crashTime fields in crash schema

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1251,6 +1251,10 @@
           "description": "Optional, ID of the associated crash. Added to schema in bug 1604666.",
           "type": "string"
         },
+        "crashTime": {
+          "description": "<ISO Date>, time of crash. Per-hour resolution",
+          "type": "string"
+        },
         "hasCrashEnvironment": {
           "type": "boolean"
         },
@@ -1289,7 +1293,7 @@
               "type": "string"
             },
             "CrashTime": {
-              "description": "<time>, Seconds since the Epoch",
+              "description": "<time>, Seconds since the Epoch (see also: `payload.crashTime`)",
               "type": "string"
             },
             "EventLoopNestingLevel": {
@@ -1349,7 +1353,7 @@
               "type": "string"
             },
             "TelemetrySessionId": {
-              "description": "<id>, Active telemetry session ID when the crash was recorded",
+              "description": "Should not be in any pings, left in only for backwards compatibility - see `payload.sessionId` instead",
               "type": "string"
             },
             "TextureUsage": {
@@ -1396,6 +1400,13 @@
         },
         "processType": {
           "type": "string"
+        },
+        "sessionId": {
+          "description": "<uuid>, Telemetry ID of crashing session. May be missing for crashes that happen early in startup",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "stackTraces": {
           "properties": {

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -19,6 +19,14 @@
           "type": "string",
           "description": "Optional, ID of the associated crash. Added to schema in bug 1604666."
         },
+        "crashTime": {
+          "description": "<ISO Date>, time of crash. Per-hour resolution",
+          "type": "string"
+        },
+        "sessionId": {
+          "description": "<uuid>, Telemetry ID of crashing session. May be missing for crashes that happen early in startup",
+          "type": ["string", "null"]
+        },
         "hasCrashEnvironment": {
           "type": "boolean"
         },
@@ -58,7 +66,7 @@
               "type": "string"
             },
             "CrashTime": {
-              "description": "<time>, Seconds since the Epoch",
+              "description": "<time>, Seconds since the Epoch (see also: `payload.crashTime`)",
               "type": "string"
             },
             "EventLoopNestingLevel": {
@@ -122,7 +130,7 @@
               "type": "string"
             },
             "TelemetrySessionId": {
-              "description": "<id>, Active telemetry session ID when the crash was recorded",
+              "description": "Should not be in any pings, left in only for backwards compatibility - see `payload.sessionId` instead",
               "type": "string"
             },
             "TextureUsage": {


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
