### PR TITLE
Bug 1625207 - Make device manufacturer and model optional

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -59,8 +59,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "device_manufacturer",
-        "device_model",
         "first_run_date",
         "os",
         "os_version",

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- `device_manufacturer` and `device_model` are now optional. See [Bug 1625207](https://bugzilla.mozilla.org/show_bug.cgi?id=1625207).
+
 - `extras` on an experiment may now be `null`.  See [Bug 1012940](https://bugzilla.mozilla.org/show_bug.cgi?id=1612940)
    
 - Added `locale` to `client_info` section. See [Bug 1601489](https://bugzilla.mozilla.org/show_bug.cgi?id=1601489).

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -36,8 +36,6 @@
         "app_build",
         "app_display_version",
         "architecture",
-        "device_manufacturer",
-        "device_model",
         "first_run_date",
         "os",
         "os_version",


### PR DESCRIPTION
These are less clear-cut on non-mobile.
More specific hardware identification might be necessary for Desktop use cases.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
