### PR TITLE
[Bug 1612935] Move enhancedSearch out of fennec

### DIFF
--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -51,6 +51,18 @@
     "durations": {
       "type": "integer"
     },
+    "enhancedSearchReady": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchUsed": {
+      "description": "Added in bug 1612935.",
+      "type": "boolean"
+    },
+    "enhancedSearchVersion": {
+      "description": "Added in bug 1612935.",
+      "type": "string"
+    },
     "experiments": {
       "items": {
         "type": "string"
@@ -58,18 +70,6 @@
       "type": "array"
     },
     "fennec": {
-      "enhancedSearchReady": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchUsed": {
-        "description": "Added in bug 1612935.",
-        "type": "boolean"
-      },
-      "enhancedSearchVersion": {
-        "description": "Added in bug 1612935.",
-        "type": "string"
-      },
       "properties": {
         "addons": {
           "properties": {

--- a/templates/include/telemetry/coreCommon.2.schema.json
+++ b/templates/include/telemetry/coreCommon.2.schema.json
@@ -139,17 +139,17 @@
         "only_over_wifi": {"type": ["boolean", "null"]}
       }
     }
-  },
-  "enhancedSearchUsed": {
-    "type": "boolean",
-    "description": "Added in bug 1612935."
-  },
-  "enhancedSearchReady": {
-    "type": "boolean",
-    "description": "Added in bug 1612935."
-  },
-  "enhancedSearchVersion": {
-    "type": "string",
-    "description": "Added in bug 1612935."
   }
+},
+"enhancedSearchUsed": {
+  "type": "boolean",
+  "description": "Added in bug 1612935."
+},
+"enhancedSearchReady": {
+  "type": "boolean",
+  "description": "Added in bug 1612935."
+},
+"enhancedSearchVersion": {
+  "type": "string",
+  "description": "Added in bug 1612935."
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/ad837af24b81245c54be27de55a5e38e3aef7349

Looking at the ping payload, the `enhancedSearch[...]` fields do not appear inside of `fennec`. This PR moves them out of `fennec`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
