### PR TITLE
[Bug 1627840] Add openTabCount column to mobile events

### DIFF
--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -71,6 +71,9 @@
     "locale": {
       "type": "string"
     },
+    "openTabCount": {
+      "type": "integer"
+    },
     "os": {
       "type": "string"
     },

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -71,6 +71,9 @@
     "locale": {
       "type": "string"
     },
+    "openTabCount": {
+      "type": "integer"
+    },
     "os": {
       "type": "string"
     },

--- a/templates/include/telemetry/mobileEvent.1.schema.json
+++ b/templates/include/telemetry/mobileEvent.1.schema.json
@@ -15,5 +15,8 @@
   "events": {
     "type": "array",
     "items": @COMMON_EVENT_1_JSON@
+  },
+  "openTabCount": {
+    "type": "integer"
   }
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1627840

The `openTabCount` field [is coming for iOS](https://github.com/mozilla-mobile/firefox-ios/blob/1104a4fa58e43eb73eb8e02d3ec9b0505d830356/Docs/telemetry.md#core-ping)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
