### PR TITLE
[Bug 1625547] Sync payload allow default device ID (00000000000000000000000000000000)

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -69,7 +69,7 @@
             "additionalProperties": false,
             "properties": {
               "id": {
-                "pattern": "^[0-9a-f]{64}$",
+                "pattern": "^([0-9a-f]{64}|0{32})$",
                 "type": "string"
               },
               "os": {

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -83,7 +83,7 @@
             "additionalProperties": false,
             "properties": {
               "id": {
-                "pattern": "^[0-9a-f]{64}$",
+                "pattern": "^([0-9a-f]{64}|0{32})$",
                 "type": "string"
               },
               "os": {

--- a/templates/include/telemetry/syncPayload.1.schema.json
+++ b/templates/include/telemetry/syncPayload.1.schema.json
@@ -18,7 +18,7 @@
         "additionalProperties": false,
         "type": "object",
         "properties": {
-          "id": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "id": { "type": "string", "pattern": "^([0-9a-f]{64}|0{32})$" },
           "os": { "type": ["string", "null"] },
           "version": { "type": ["string", "null"] },
           "type": { "type": "string" },

--- a/validation/telemetry/sync.4.null_device_version.pass.json
+++ b/validation/telemetry/sync.4.null_device_version.pass.json
@@ -24,7 +24,7 @@
       {
         "os": null,
         "version": null,
-        "id": "f38b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba",
+        "id": "00000000000000000000000000000000",
         "type": "mobile",
         "syncID": "e21b5add46460b49c7373bac4c99f96bfda39af90ed01ce2b4b24957cd5bbeba"
       }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1625547

The default device ID for sync payloads is `00000000000000000000000000000000` and is currently not supported in the schema. This PR adds support for this default device ID.
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
