### PR TITLE
Bug 1627843 - Missing iOS Core ping fields

### DIFF
--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -32,6 +32,20 @@
     "defaultBrowser": {
       "type": "boolean"
     },
+    "defaultMailClient": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaultNewTabExperience": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "defaultSearch": {
       "type": [
         "string",
@@ -359,6 +373,13 @@
     },
     "showTrackerStatsShare": {
       "type": "boolean"
+    },
+    "systemTheme": {
+      "description": "Sent from Firefox iOS. Added in bug 1627843",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "tz": {
       "type": "integer"

--- a/templates/include/telemetry/coreCommon.2.schema.json
+++ b/templates/include/telemetry/coreCommon.2.schema.json
@@ -164,4 +164,16 @@
 "enhancedSearchVersion": {
   "type": "string",
   "description": "Added in bug 1612935."
+},
+"defaultMailClient": {
+  "type": ["string", "null"],
+  "description": "Sent from Firefox iOS. Added in bug 1627843"
+},
+"defaultNewTabExperience": {
+  "type": ["string", "null"],
+  "description": "Sent from Firefox iOS. Added in bug 1627843"
+},
+"systemTheme": {
+  "type": ["string", "null"],
+  "description": "Sent from Firefox iOS. Added in bug 1627843"
 }

--- a/validation/telemetry/core.10.sample.pass.json
+++ b/validation/telemetry/core.10.sample.pass.json
@@ -30,5 +30,8 @@
     "com.google.android.marvin.talkback/.TalkBackService",
     "com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"
   ],
-  "bug_1501329_affected": true
+  "bug_1501329_affected": true,
+  "defaultMailClient": "googlegmail://",
+  "defaultNewTabExperience": "HomePage",
+  "systemTheme": null
 }


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
