### PR TITLE
Bug 1634520 - missing isFromTerminatorWatchdog in lateWrites telemetry…

### DIFF
--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1496,6 +1496,10 @@
         "lateWrites": {
           "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
           "properties": {
+            "isFromTerminatorWatchdog": {
+              "description": "True if the late writes began in nsTerminator, false otherwise",
+              "type": "boolean"
+            },
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1496,6 +1496,10 @@
         "lateWrites": {
           "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
           "properties": {
+            "isFromTerminatorWatchdog": {
+              "description": "True if the late writes began in nsTerminator, false otherwise",
+              "type": "boolean"
+            },
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1496,6 +1496,10 @@
         "lateWrites": {
           "description": "This sections reports writes to the file system that happen during shutdown. The reported data contains the stack and the file names of the loaded libraries at the time the writes happened.",
           "properties": {
+            "isFromTerminatorWatchdog": {
+              "description": "True if the late writes began in nsTerminator, false otherwise",
+              "type": "boolean"
+            },
             "memoryMap": {
               "description": "entries in the format [module name, breakpad identifier]",
               "items": {

--- a/templates/include/telemetry/mainPayload.1.schema.json
+++ b/templates/include/telemetry/mainPayload.1.schema.json
@@ -147,6 +147,10 @@
               "maxItems": 2
             }
           }
+        },
+        "isFromTerminatorWatchdog": {
+          "description": "True if the late writes began in nsTerminator, false otherwise",
+          "type": "boolean"
         }
       }
     },

--- a/validation/telemetry/main.4.latewrites.fail.json
+++ b/validation/telemetry/main.4.latewrites.fail.json
@@ -16204,7 +16204,8 @@
           [300, 10],
           [400, 20]
         ]
-      ]
+      ],
+      "isFromTerminatorWatchdog": 0
     },
     "log": [
       [

--- a/validation/telemetry/main.4.latewrites.pass.json
+++ b/validation/telemetry/main.4.latewrites.pass.json
@@ -16204,7 +16204,8 @@
           [300, 10],
           [400, 20]
         ]
-      ]
+      ],
+      "isFromTerminatorWatchdog": 0
     },
     "log": [
       [


### PR DESCRIPTION
… schema

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
