### PR TITLE
Bug 1635212 - Handle frames property of threads in crash pings

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1470,6 +1470,25 @@
             "threads": {
               "items": {
                 "properties": {
+                  "frames": {
+                    "items": {
+                      "properties": {
+                        "ip": {
+                          "pattern": "^(0x[a-fA-F0-9]+|0)$",
+                          "type": "string"
+                        },
+                        "module_index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "trust": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "ip": {
                     "pattern": "^(0x[a-fA-F0-9]+|0)$",
                     "type": "string"

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -230,6 +230,22 @@
                   },
                   "trust": {
                     "type": "string"
+                  },
+                  "frames": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ip": @TELEMETRY_HEXADDRESS_1_JSON@,
+                        "module_index": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "trust": {
+                          "type": "string"
+                        }
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
This also makes the schema slightly more strict to make sure that
we're actually seeing what we expect to see.


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`