### PR TITLE
Bug 1631506 - Add some more fields from crash annotations

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1272,6 +1272,10 @@
               "description": "<size>, Windows-only, available physical memory in bytes",
               "type": "string"
             },
+            "AvailableSwapMemory": {
+              "description": "Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
+              "type": "string"
+            },
             "AvailableVirtualMemory": {
               "description": "<size>, Windows-only, available virtual memory in bytes",
               "type": "string"
@@ -1296,16 +1300,32 @@
               "description": "<time>, Seconds since the Epoch (see also: `payload.crashTime`)",
               "type": "string"
             },
+            "DOMFissionEnabled": {
+              "description": "Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
+              "type": "boolean"
+            },
             "EventLoopNestingLevel": {
               "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
+              "type": "string"
+            },
+            "IndexedDBShutdownTimeout": {
+              "description": "This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "IsGarbageCollecting": {
               "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
               "type": "string"
             },
+            "LocalStorageShutdownTimeout": {
+              "description": "This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "type": "string"
+            },
             "LowCommitSpaceEvents": {
               "description": "<num>, Windows-only, present only if >0, number of low commit space events detected by the available memory tracker",
+              "type": "string"
+            },
+            "MainThreadRunnableName": {
+              "description": "Name of the currently executing nsIRunnable on the main thread.",
               "type": "string"
             },
             "MemoryErrorCorrection": {
@@ -1326,6 +1346,10 @@
             },
             "ProductName": {
               "description": "Firefox",
+              "type": "string"
+            },
+            "PurgeablePhysicalMemory": {
+              "description": "macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
               "type": "string"
             },
             "ReleaseChannel": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1273,7 +1273,7 @@
               "type": "string"
             },
             "AvailableSwapMemory": {
-              "description": "Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
+              "description": "<size>, Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
               "type": "string"
             },
             "AvailableVirtualMemory": {
@@ -1301,15 +1301,15 @@
               "type": "string"
             },
             "DOMFissionEnabled": {
-              "description": "Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
-              "type": "boolean"
+              "description": "<boolean>, Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
+              "type": "string"
             },
             "EventLoopNestingLevel": {
               "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
               "type": "string"
             },
             "IndexedDBShutdownTimeout": {
-              "description": "This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "description": "<json>, This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "IsGarbageCollecting": {
@@ -1317,7 +1317,7 @@
               "type": "string"
             },
             "LocalStorageShutdownTimeout": {
-              "description": "This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "description": "<json>, This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "LowCommitSpaceEvents": {
@@ -1325,7 +1325,7 @@
               "type": "string"
             },
             "MainThreadRunnableName": {
-              "description": "Name of the currently executing nsIRunnable on the main thread.",
+              "description": "<string>, Name of the currently executing nsIRunnable on the main thread.",
               "type": "string"
             },
             "MemoryErrorCorrection": {
@@ -1349,7 +1349,7 @@
               "type": "string"
             },
             "PurgeablePhysicalMemory": {
-              "description": "macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
+              "description": "<size>, macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
               "type": "string"
             },
             "ReleaseChannel": {

--- a/scripts/extract_crash_annotation_fields
+++ b/scripts/extract_crash_annotation_fields
@@ -39,10 +39,14 @@ for crash_annotation_name, crash_annotation_props in crash_annotations.items():
         and crash_annotation_name not in existing_payload_properties
     ):
         print(
-            '"%s": {\n  "description": %s,\n  "type": "%s"\n},'
+            '"%s": {\n  "description": %s,\n  "type": "string"\n},'
             % (
                 crash_annotation_name,
-                json.dumps(crash_annotation_props["description"].strip()),
-                crash_annotation_props["type"],
+                json.dumps(
+                    "<{}>, {}".format(
+                        crash_annotation_props["type"],
+                        crash_annotation_props["description"].strip(),
+                    ),
+                ),
             )
         )

--- a/scripts/extract_crash_annotation_fields
+++ b/scripts/extract_crash_annotation_fields
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Script to parse in-tree list of Crash Annotations, compare with what's currently in the
+schema-- outputting a list of *new* annotations (in JSON format) to add to the payload
+in templates/telemetry/crash. You will want to take the output of this script and copy
+paste it into this file.
+
+You should be able to get the latest set of crash annotations from:
+
+https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/crashreporter/CrashAnnotations.yaml
+
+"""
+
+import json
+import os
+import sys
+
+import yaml
+
+if len(sys.argv) != 2:
+    print("USAGE: {} <crash annotations file>")
+    sys.exit(1)
+
+existing_payload_properties = json.loads(
+    open(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "schemas/telemetry/crash/crash.4.schema.json",
+        )
+    ).read()
+)["properties"]["payload"]["properties"]["metadata"]["properties"].keys()
+
+crash_annotations = yaml.load(open(sys.argv[1]).read())
+for crash_annotation_name, crash_annotation_props in crash_annotations.items():
+    if (
+        crash_annotation_props.get("ping")
+        and crash_annotation_name not in existing_payload_properties
+    ):
+        print(
+            '"%s": {\n  "description": %s,\n  "type": "%s"\n},'
+            % (
+                crash_annotation_name,
+                json.dumps(crash_annotation_props["description"].strip()),
+                crash_annotation_props["type"],
+            )
+        )

--- a/scripts/extract_crash_annotation_fields
+++ b/scripts/extract_crash_annotation_fields
@@ -19,7 +19,7 @@ import sys
 import yaml
 
 if len(sys.argv) != 2:
-    print("USAGE: {} <crash annotations file>")
+    print(f"USAGE: {sys.argv[0]} <crash annotations file>")
     sys.exit(1)
 
 existing_payload_properties = json.loads(

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -34,7 +34,7 @@
           "type": "object",
           "properties": {
             "AvailableSwapMemory": {
-              "description": "Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
+              "description": "<size>, Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
               "type": "string"
             },
             "AsyncShutdownTimeout": {
@@ -74,15 +74,15 @@
               "type": "string"
             },
             "DOMFissionEnabled": {
-              "description": "Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
-              "type": "boolean"
+              "description": "<boolean>, Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
+              "type": "string"
             },
             "EventLoopNestingLevel": {
               "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
               "type": "string"
             },
             "IndexedDBShutdownTimeout": {
-              "description": "This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "description": "<json>, This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "ipc_channel_error": {
@@ -94,7 +94,7 @@
               "type": "string"
             },
             "LocalStorageShutdownTimeout": {
-              "description": "This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "description": "<json>, This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "LowCommitSpaceEvents": {
@@ -102,7 +102,7 @@
               "type": "string"
             },
             "MainThreadRunnableName": {
-              "description": "Name of the currently executing nsIRunnable on the main thread.",
+              "description": "<string>, Name of the currently executing nsIRunnable on the main thread.",
               "type": "string"
             },
             "MemoryErrorCorrection": {
@@ -118,7 +118,7 @@
               "type": "string"
             },
             "PurgeablePhysicalMemory": {
-              "description": "macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
+              "description": "<size>, macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
               "type": "string"
             },
             "ProductID": {

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -33,6 +33,10 @@
         "metadata": {
           "type": "object",
           "properties": {
+            "AvailableSwapMemory": {
+              "description": "Amount of free swap space in bytes. - Under macOS, populated with the contents of\n  sysctl \"vm.swapusage\" :: xsu_avail.\n- Under Linux, populated with /proc/meminfo's SwapFree. - Not available on other platforms.",
+              "type": "string"
+            },
             "AsyncShutdownTimeout": {
               "description": "<json>, Optional, present when a shutdown blocker failed to respond within a reasonable amount of time",
               "type": "string"
@@ -69,8 +73,16 @@
               "description": "<time>, Seconds since the Epoch (see also: `payload.crashTime`)",
               "type": "string"
             },
+            "DOMFissionEnabled": {
+              "description": "Set to 1 when DOM fission is enabled, and subframes are potentially loaded in a separate process.",
+              "type": "boolean"
+            },
             "EventLoopNestingLevel": {
               "description": "<levels>, Optional, present only if >0, indicates the nesting level of the event-loop",
+              "type": "string"
+            },
+            "IndexedDBShutdownTimeout": {
+              "description": "This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
             },
             "ipc_channel_error": {
@@ -81,8 +93,16 @@
               "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
               "type": "string"
             },
+            "LocalStorageShutdownTimeout": {
+              "description": "This annotation is present if LocalStorage shutdown was not finished in time and the browser was crashed instead of waiting for LocalStorage shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked LocalStorage shutdown. Objects are divided into three groups: PrepareDatastoreOperations, Datastores and LiveDatabases. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
+              "type": "string"
+            },
             "LowCommitSpaceEvents": {
               "description": "<num>, Windows-only, present only if >0, number of low commit space events detected by the available memory tracker",
+              "type": "string"
+            },
+            "MainThreadRunnableName": {
+              "description": "Name of the currently executing nsIRunnable on the main thread.",
               "type": "string"
             },
             "MemoryErrorCorrection": {
@@ -95,6 +115,10 @@
             },
             "OOMAllocationSize": {
               "description": "<size>, Size of the allocation that caused an OOM",
+              "type": "string"
+            },
+            "PurgeablePhysicalMemory": {
+              "description": "macOS only. Amount of physical memory currently allocated but which may be deallocated by the system in case of memory pressure. Populated from vm_statistics64_data_t::purgeable_count * vm_page_size.",
               "type": "string"
             },
             "ProductID": {


### PR DESCRIPTION
Also add a small script, extract_crash_annotation_fields for
automatically grabbing this type of information in the future.


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`