### PR TITLE
[Bug 1629695] Add missing sync ping payload.os fields

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -230,14 +230,44 @@
         },
         "os": {
           "properties": {
+            "hasPrefetch": {
+              "type": "boolean"
+            },
+            "hasSuperfetch": {
+              "type": "boolean"
+            },
+            "installYear": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "kernelVersion": {
+              "type": "string"
+            },
             "locale": {
               "type": "string"
             },
             "name": {
               "type": "string"
             },
+            "servicePackMajor": {
+              "type": "number"
+            },
+            "servicePackMinor": {
+              "type": "number"
+            },
             "version": {
               "type": "string"
+            },
+            "windowsBuildNumber": {
+              "type": "number"
+            },
+            "windowsUBR": {
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -244,14 +244,44 @@
         },
         "os": {
           "properties": {
+            "hasPrefetch": {
+              "type": "boolean"
+            },
+            "hasSuperfetch": {
+              "type": "boolean"
+            },
+            "installYear": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "kernelVersion": {
+              "type": "string"
+            },
             "locale": {
               "type": "string"
             },
             "name": {
               "type": "string"
             },
+            "servicePackMajor": {
+              "type": "number"
+            },
+            "servicePackMinor": {
+              "type": "number"
+            },
             "version": {
               "type": "string"
+            },
+            "windowsBuildNumber": {
+              "type": "number"
+            },
+            "windowsUBR": {
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/templates/include/telemetry/syncPayload.1.schema.json
+++ b/templates/include/telemetry/syncPayload.1.schema.json
@@ -9,7 +9,34 @@
       "properties": {
         "name": { "type": "string" },
         "version": { "type": "string" },
-        "locale": { "type": "string" }
+        "locale": { "type": "string" },
+        "kernelVersion": {
+          "type": "string"
+        },
+        "servicePackMajor": {
+          "type": "number"
+        },
+        "servicePackMinor": {
+          "type": "number"
+        },
+        "windowsBuildNumber": {
+          "type": "number"
+        },
+        "windowsUBR": {
+          "type": [ "number", "null" ]
+        },
+        "installYear": {
+          "type": [ "number", "null" ]
+        },
+        "locale": {
+          "type": "string"
+        },
+        "hasPrefetch": {
+          "type": "boolean"
+        },
+        "hasSuperfetch": {
+          "type": "boolean"
+        }
       }
     },
     "devices": {

--- a/validation/telemetry/sync.4.null_device_version.pass.json
+++ b/validation/telemetry/sync.4.null_device_version.pass.json
@@ -18,7 +18,14 @@
     "os": {
       "name": "Darwin",
       "version": "18.0.0",
-      "locale": "en-CA"
+      "locale": "en-CA",
+      "hasSuperfetch": true,
+      "windowsUBR": 778,
+      "hasPrefetch": true,
+      "windowsBuildNumber": 18363,
+      "installYear": 2019,
+      "servicePackMajor": 0,
+      "servicePackMinor": 0
     },
     "devices": [
       {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1629695

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
