### PR TITLE
[Bug 1640713] Fix sync engines.outgoing field type

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -402,10 +402,7 @@
                         "type": "object"
                       },
                       "minItems": 1,
-                      "type": [
-                        "array",
-                        "object"
-                      ]
+                      "type": "array"
                     },
                     "status": {
                       "type": "string"

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -416,10 +416,7 @@
                         "type": "object"
                       },
                       "minItems": 1,
-                      "type": [
-                        "array",
-                        "object"
-                      ]
+                      "type": "array"
                     },
                     "status": {
                       "type": "string"

--- a/templates/include/telemetry/syncItem.1.schema.json
+++ b/templates/include/telemetry/syncItem.1.schema.json
@@ -59,7 +59,7 @@
             }
           },
           "outgoing": {
-            "type": ["array", "object"],
+            "type": "array",
             "minItems": 1,
             "items": {
               "type": "object",


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1640713

Defining the outgoing field type as both array and object, it seems like the jsonschema-transpiler removed that field when generating the BQ schema.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
