### PR TITLE
Document default browser agent's client id field as deprecated

### DIFF
--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,6 +7,11 @@
     "build_version": {
       "type": "string"
     },
+    "client_id": {
+      "description": "Deprecated; This field will never be sent",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "default_browser": {
       "description": "The current default browser",
       "type": "string"

--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,11 +7,6 @@
     "build_version": {
       "type": "string"
     },
-    "client_id": {
-      "description": "A UUID, specific to the Windows user",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
-    },
     "default_browser": {
       "description": "The current default browser",
       "type": "string"

--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,8 +7,25 @@
     "build_version": {
       "type": "string"
     },
+    "client_id": {
+      "description": "A UUID, specific to the Windows user",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "default_browser": {
       "description": "The current default browser",
+      "type": "string"
+    },
+    "notification_action": {
+      "description": "What action was taken by the user then the toast notification was displayed",
+      "type": "string"
+    },
+    "notification_shown": {
+      "description": "Whether the notification was shown, not shown, or resulted in an error",
+      "type": "string"
+    },
+    "notification_type": {
+      "description": "Whether the notification shown was the initial notification, or the followup",
       "type": "string"
     },
     "os_locale": {

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,6 +7,11 @@
     "build_version": {
       "type": "string"
     },
+    "client_id": {
+      "description": "Deprecated; This field will never be sent",
+      @COMMON_PATTERN_UUID_1_JSON@,
+      "type": "string"
+    },
     "notification_action": {
       "description": "What action was taken by the user then the toast notification was displayed",
       "type": "string"

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,11 +7,6 @@
     "build_version": {
       "type": "string"
     },
-    "client_id": {
-      "description": "A UUID, specific to the Windows user",
-      @COMMON_PATTERN_UUID_1_JSON@,
-      "type": "string"
-    },
     "notification_action": {
       "description": "What action was taken by the user then the toast notification was displayed",
       "type": "string"

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -7,6 +7,23 @@
     "build_version": {
       "type": "string"
     },
+    "client_id": {
+      "description": "A UUID, specific to the Windows user",
+      @COMMON_PATTERN_UUID_1_JSON@,
+      "type": "string"
+    },
+    "notification_action": {
+      "description": "What action was taken by the user then the toast notification was displayed",
+      "type": "string"
+    },
+    "notification_shown": {
+      "description": "Whether the notification was shown, not shown, or resulted in an error",
+      "type": "string"
+    },
+    "notification_type": {
+      "description": "Whether the notification shown was the initial notification, or the followup",
+      "type": "string"
+    },
     "os_version": {
       "description": "Windows version numnber in major.minor.build.UBR format (UBR is optional, only available on Win10)",
       "type": "string"

--- a/validation/default-browser-agent/default-browser.1.sample_all_fields.pass.json
+++ b/validation/default-browser-agent/default-browser.1.sample_all_fields.pass.json
@@ -5,7 +5,6 @@
   "os_locale": "en-US",
   "default_browser": "firefox",
   "previous_default_browser": "edge",
-  "client_id": "98D8A499-DBA0-4340-A058-64CF35986FFB",
   "notification_type": "initial",
   "notification_shown": "shown",
   "notification_action": "dismissed-by-timeout"

--- a/validation/default-browser-agent/default-browser.1.sample_all_fields.pass.json
+++ b/validation/default-browser-agent/default-browser.1.sample_all_fields.pass.json
@@ -1,0 +1,12 @@
+{
+  "build_channel": "nightly",
+  "build_version": "74.0a1",
+  "os_version": "10.0.18363.592",
+  "os_locale": "en-US",
+  "default_browser": "firefox",
+  "previous_default_browser": "edge",
+  "client_id": "98D8A499-DBA0-4340-A058-64CF35986FFB",
+  "notification_type": "initial",
+  "notification_shown": "shown",
+  "notification_action": "dismissed-by-timeout"
+}


### PR DESCRIPTION
[Bug 1621703](https://bugzilla.mozilla.org/show_bug.cgi?id=1621703#c10)

Originally, we planned to have a client id in the default browser agent's ping. However, we eventually decided not to include it. We never merged the code that added the client id, so no pings have ever been sent with this field.