### PR TITLE
Add Schema for Custom Ping (Normandy login study Bug 1643383)

### DIFF
--- a/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -1,154 +1,219 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
-    "accounts_days_visited_per_month": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "activeAddons": {
-      "items": {
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
         },
-        "type": "object"
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
       },
-      "type": [
-        "array",
-        "null"
-      ]
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
     },
-    "browser_privatebrowsing_autostart": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
     },
-    "browser_startup_page": {
-      "type": [
-        "number",
-        "null"
-      ]
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
     },
-    "cookies_oldest_days_old": {
-      "type": [
-        "number",
-        "null"
-      ]
+    "payload": {
+      "properties": {
+        "accounts_days_visited_per_month": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "activeAddons": {
+          "items": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "browser_privatebrowsing_autostart": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "browser_startup_page": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "cookies_oldest_days_old": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "default_private_search_engine_is_google": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_search_engine_is_google": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "google_accounts_cookie_days_old": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "google_accounts_cookie_present": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "has_allow_cookie_exceptions": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "has_block_cookie_exceptions": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "has_browser_search_ad_clicks": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "has_browser_search_with_ads": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "history_oldest_days_old": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "logins_accounts": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "logins_accounts_uses_per_month": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "network_cookie_cookie_behavior": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "network_cookie_lifetime_policy": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "password_manager_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "privacy_clear_on_shutdown_cookies": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "privacy_sanitize_sanitize_on_shutdown": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "profile_days_old": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "session_days_old": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "default_private_search_engine_is_google": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "default_search_engine_is_google": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "google_accounts_cookie_days_old": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "google_accounts_cookie_present": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "has_allow_cookie_exceptions": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "has_block_cookie_exceptions": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "has_browser_search_ad_clicks": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "has_browser_search_with_ads": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "history_oldest_days_old": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "logins_accounts": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "logins_accounts_uses_per_month": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "network_cookie_cookie_behavior": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "network_cookie_lifetime_policy": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "password_manager_enabled": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "privacy_clear_on_shutdown_cookies": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "privacy_sanitize_sanitize_on_shutdown": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "profile_days_old": {
-      "type": [
-        "number",
-        "null"
-      ]
-    },
-    "session_days_old": {
-      "type": [
-        "number",
-        "null"
-      ]
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
     }
   },
   "title": "normandy-login-study",

--- a/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "accounts_days_visited_per_month": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "activeAddons": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "browser_privatebrowsing_autostart": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "browser_startup_page": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "cookies_oldest_days_old": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "default_private_search_engine_is_google": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "default_search_engine_is_google": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "google_accounts_cookie_days_old": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "google_accounts_cookie_present": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "has_allow_cookie_exceptions": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "has_block_cookie_exceptions": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "has_browser_search_ad_clicks": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "has_browser_search_with_ads": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "history_oldest_days_old": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "logins_accounts": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "logins_accounts_uses_per_month": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "network_cookie_cookie_behavior": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "network_cookie_lifetime_policy": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "password_manager_enabled": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "privacy_clear_on_shutdown_cookies": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "privacy_sanitize_sanitize_on_shutdown": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "profile_days_old": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "session_days_old": {
+      "type": [
+        "number",
+        "null"
+      ]
+    }
+  },
+  "title": "normandy-login-study",
+  "type": "object"
+}

--- a/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -147,6 +147,12 @@
             "null"
           ]
         },
+        "history_average_days_per_month": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "history_oldest_days_old": {
           "type": [
             "number",

--- a/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -3,85 +3,98 @@
   "type": "object",
   "title": "normandy-login-study",
   "properties": {
-    "password_manager_enabled": {
-      "type": ["boolean", "null"]
+    @TELEMETRY_ID_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_APPLICATION_1_JSON@,
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
     },
-    "browser_privatebrowsing_autostart": {
-      "type": ["boolean", "null"]
-    },
-    "network_cookie_lifetime_policy": {
-      "type": ["number", "null"]
-    },
-    "privacy_sanitize_sanitize_on_shutdown": {
-      "type": ["boolean", "null"]
-    },
-    "privacy_clear_on_shutdown_cookies": {
-      "type": ["boolean", "null"]
-    },
-    "network_cookie_cookie_behavior": {
-      "type": ["number", "null"]
-    },
-    "browser_startup_page": {
-      "type": ["number", "null"]
-    },
-    "session_days_old": {
-      "type": ["number", "null"]
-    },
-    "profile_days_old": {
-      "type": ["number", "null"]
-    },
-    "logins_accounts": {
-      "type": ["boolean", "null"]
-    },
-    "logins_accounts_uses_per_month": {
-      "type": ["number", "null"]
-    },
-    "google_accounts_cookie_present": {
-      "type": ["boolean", "null"]
-    },
-    "google_accounts_cookie_days_old": {
-      "type": ["number", "null"]
-    },
-    "has_allow_cookie_exceptions": {
-      "type": ["boolean", "null"]
-    },
-    "has_block_cookie_exceptions": {
-      "type": ["boolean", "null"]
-    },
-    "cookies_oldest_days_old": {
-      "type": ["number", "null"]
-    },
-    "activeAddons": {
-      "type": ["array", "null"],
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
+    "payload" : {
+      "type": "object",
+      "properties": {
+        "password_manager_enabled": {
+          "type": ["boolean", "null"]
+        },
+        "browser_privatebrowsing_autostart": {
+          "type": ["boolean", "null"]
+        },
+        "network_cookie_lifetime_policy": {
+          "type": ["number", "null"]
+        },
+        "privacy_sanitize_sanitize_on_shutdown": {
+          "type": ["boolean", "null"]
+        },
+        "privacy_clear_on_shutdown_cookies": {
+          "type": ["boolean", "null"]
+        },
+        "network_cookie_cookie_behavior": {
+          "type": ["number", "null"]
+        },
+        "browser_startup_page": {
+          "type": ["number", "null"]
+        },
+        "session_days_old": {
+          "type": ["number", "null"]
+        },
+        "profile_days_old": {
+          "type": ["number", "null"]
+        },
+        "logins_accounts": {
+          "type": ["boolean", "null"]
+        },
+        "logins_accounts_uses_per_month": {
+          "type": ["number", "null"]
+        },
+        "google_accounts_cookie_present": {
+          "type": ["boolean", "null"]
+        },
+        "google_accounts_cookie_days_old": {
+          "type": ["number", "null"]
+        },
+        "has_allow_cookie_exceptions": {
+          "type": ["boolean", "null"]
+        },
+        "has_block_cookie_exceptions": {
+          "type": ["boolean", "null"]
+        },
+        "cookies_oldest_days_old": {
+          "type": ["number", "null"]
+        },
+        "activeAddons": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
           }
+        },
+        "default_search_engine_is_google": {
+          "type": ["boolean", "null"]
+        },
+        "default_private_search_engine_is_google": {
+          "type": ["boolean", "null"]
+        },
+        "accounts_days_visited_per_month": {
+          "type": ["number", "null"]
+        },
+        "has_browser_search_with_ads": {
+          "type": ["boolean", "null"]
+        },
+        "has_browser_search_ad_clicks": {
+          "type": ["boolean", "null"]
+        },
+        "history_oldest_days_old": {
+          "type": ["number", "null"]
         }
       }
-    },
-    "default_search_engine_is_google": {
-      "type": ["boolean", "null"]
-    },
-    "default_private_search_engine_is_google": {
-      "type": ["boolean", "null"]
-    },
-    "accounts_days_visited_per_month": {
-      "type": ["number", "null"]
-    },
-    "has_browser_search_with_ads": {
-      "type": ["boolean", "null"]
-    },
-    "has_browser_search_ad_clicks": {
-      "type": ["boolean", "null"]
-    },
-    "history_oldest_days_old": {
-      "type": ["number", "null"]
     }
   }
 }

--- a/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "normandy-login-study",
+  "properties": {
+    "password_manager_enabled": {
+      "type": ["boolean", "null"]
+    },
+    "browser_privatebrowsing_autostart": {
+      "type": ["boolean", "null"]
+    },
+    "network_cookie_lifetime_policy": {
+      "type": ["number", "null"]
+    },
+    "privacy_sanitize_sanitize_on_shutdown": {
+      "type": ["boolean", "null"]
+    },
+    "privacy_clear_on_shutdown_cookies": {
+      "type": ["boolean", "null"]
+    },
+    "network_cookie_cookie_behavior": {
+      "type": ["number", "null"]
+    },
+    "browser_startup_page": {
+      "type": ["number", "null"]
+    },
+    "session_days_old": {
+      "type": ["number", "null"]
+    },
+    "profile_days_old": {
+      "type": ["number", "null"]
+    },
+    "logins_accounts": {
+      "type": ["boolean", "null"]
+    },
+    "logins_accounts_uses_per_month": {
+      "type": ["number", "null"]
+    },
+    "google_accounts_cookie_present": {
+      "type": ["boolean", "null"]
+    },
+    "google_accounts_cookie_days_old": {
+      "type": ["number", "null"]
+    },
+    "has_allow_cookie_exceptions": {
+      "type": ["boolean", "null"]
+    },
+    "has_block_cookie_exceptions": {
+      "type": ["boolean", "null"]
+    },
+    "cookies_oldest_days_old": {
+      "type": ["number", "null"]
+    },
+    "activeAddons": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "default_search_engine_is_google": {
+      "type": ["boolean", "null"]
+    },
+    "default_private_search_engine_is_google": {
+      "type": ["boolean", "null"]
+    },
+    "accounts_days_visited_per_month": {
+      "type": ["number", "null"]
+    },
+    "has_browser_search_with_ads": {
+      "type": ["boolean", "null"]
+    },
+    "has_browser_search_ad_clicks": {
+      "type": ["boolean", "null"]
+    },
+    "history_oldest_days_old": {
+      "type": ["number", "null"]
+    }
+  }
+}

--- a/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -93,6 +93,9 @@
         },
         "history_oldest_days_old": {
           "type": ["number", "null"]
+        },
+        "history_average_days_per_month": {
+          "type": ["number", "null"]
         }
       }
     }

--- a/validation/telemetry/normandy-login-study.4.sample.pass.json
+++ b/validation/telemetry/normandy-login-study.4.sample.pass.json
@@ -1,90 +1,148 @@
 {
-  "password_manager_enabled": false,
-  "browser_privatebrowsing_autostart": false,
-  "network_cookie_lifetime_policy": 0,
-  "privacy_sanitize_sanitize_on_shutdown": false,
-  "privacy_clear_on_shutdown_cookies": true,
-  "network_cookie_cookie_behavior": 4,
-  "browser_startup_page": 0,
-  "session_days_old": 0,
-  "profile_days_old": 0,
-  "logins_accounts": false,
-  "logins_accounts_uses_per_month": 0,
-  "google_accounts_cookie_present": false,
-  "google_accounts_cookie_days_old": null,
-  "has_allow_cookie_exceptions": false,
-  "has_block_cookie_exceptions": false,
-  "cookies_oldest_days_old": 0,
-  "activeAddons": [
-    {
-      "id": "doh-rollout@mozilla.org",
-      "name": "DoH Roll-Out"
-    },
-    {
-      "id": "formautofill@mozilla.org",
-      "name": "Form Autofill"
-    },
-    {
-      "id": "screenshots@mozilla.org",
-      "name": "Firefox Screenshots"
-    },
-    {
-      "id": "webcompat-reporter@mozilla.org",
-      "name": "WebCompat Reporter"
-    },
-    {
-      "id": "webcompat@mozilla.org",
-      "name": "Web Compat"
-    },
-    {
-      "id": "firefox-compact-dark@mozilla.org",
-      "name": "Dark"
-    },
-    {
-      "id": "login-telemetry-study-a@mozilla.org",
-      "name": "Login Telemetry Study"
-    },
-    {
-      "id": "google@search.mozilla.org",
-      "name": "Google"
-    },
-    {
-      "id": "amazon@search.mozilla.org",
-      "name": "Amazon.co.uk"
-    },
-    {
-      "id": "bing@search.mozilla.org",
-      "name": "Bing"
-    },
-    {
-      "id": "ddg@search.mozilla.org",
-      "name": "DuckDuckGo"
-    },
-    {
-      "id": "ebay@search.mozilla.org",
-      "name": "eBay"
-    },
-    {
-      "id": "twitter@search.mozilla.org",
-      "name": "Twitter"
-    },
-    {
-      "id": "wikipedia@search.mozilla.org",
-      "name": "Wikipedia (en)"
-    },
-    {
-      "id": "gmp-gmpopenh264",
-      "name": "OpenH264 Video Codec provided by Cisco Systems, Inc."
-    },
-    {
-      "id": "gmp-widevinecdm",
-      "name": "Widevine Content Decryption Module provided by Google Inc."
-    }
-  ],
-  "default_search_engine_is_google": true,
-  "default_private_search_engine_is_google": true,
-  "accounts_days_visited_per_month": 0,
-  "has_browser_search_with_ads": false,
-  "has_browser_search_ad_clicks": false,
-  "history_oldest_days_old": null
+  "type": "normandy-login-study",
+  "id": "0714c230-13ec-e04b-85cf-8fd3fc381b91",
+  "creationDate": "2020-06-19T03:32:47.518Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200617215206",
+    "name": "Firefox",
+    "version": "79.0a1",
+    "displayVersion": "79.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "79.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "nightly"
+  },
+  "payload": {
+    "password_manager_enabled": true,
+    "browser_privatebrowsing_autostart": false,
+    "network_cookie_lifetime_policy": 0,
+    "privacy_sanitize_sanitize_on_shutdown": false,
+    "privacy_clear_on_shutdown_cookies": false,
+    "network_cookie_cookie_behavior": 3,
+    "browser_startup_page": 3,
+    "session_days_old": 1,
+    "profile_days_old": 3123,
+    "logins_accounts": true,
+    "logins_accounts_uses_per_month": 0.1,
+    "google_accounts_cookie_present": true,
+    "google_accounts_cookie_days_old": 878,
+    "has_allow_cookie_exceptions": false,
+    "has_block_cookie_exceptions": false,
+    "cookies_oldest_days_old": 1243,
+    "activeAddons": [
+      {
+        "id": "{bb682c45-3136-4213-bf29-5f5833080bf4}",
+        "name": "Context Plus"
+      },
+      {
+        "id": "adb@mozilla.org",
+        "name": "Firefox DevTools ADB Extension"
+      },
+      {
+        "id": "{09420bd6-3c35-444d-b85c-74d51fe3df4f}",
+        "name": "Discard Tab"
+      },
+      {
+        "id": "aboutsync@mhammond.github.com",
+        "name": "About Sync"
+      },
+      {
+        "id": "{91aa5abe-9de4-4347-b7b5-322c38dd9271}",
+        "name": "Clippings"
+      },
+      {
+        "id": "redirector@einaregilsson.com",
+        "name": "Redirector"
+      },
+      {
+        "id": "@testpilot-containers",
+        "name": "Firefox Multi-Account Containers"
+      },
+      {
+        "id": "@contain-facebook",
+        "name": "Facebook Container"
+      },
+      {
+        "id": "https-everywhere-eff@eff.org",
+        "name": "HTTPS Everywhere"
+      },
+      {
+        "id": "default-theme@mozilla.org",
+        "name": "Default"
+      },
+      {
+        "id": "amazondotcom@search.mozilla.org",
+        "name": "Amazon.com"
+      },
+      {
+        "id": "ebay@search.mozilla.org",
+        "name": "eBay"
+      },
+      {
+        "id": "google@search.mozilla.org",
+        "name": "Google"
+      },
+      {
+        "id": "wikipedia@search.mozilla.org",
+        "name": "Wikipedia (en)"
+      },
+      {
+        "id": "ddg@search.mozilla.org",
+        "name": "DuckDuckGo"
+      },
+      {
+        "id": "bing@search.mozilla.org",
+        "name": "Bing"
+      },
+      {
+        "id": "secure-proxy@mozilla.com",
+        "name": "Firefox Private Network"
+      },
+      {
+        "id": "{bf855ead-d7c3-4c7b-9f88-9a7e75c0efdf}",
+        "name": "Zoom Scheduler"
+      },
+      {
+        "id": "screenshots@mozilla.org",
+        "name": "Firefox Screenshots"
+      },
+      {
+        "id": "webcompat-reporter@mozilla.org",
+        "name": "WebCompat Reporter"
+      },
+      {
+        "id": "formautofill@mozilla.org",
+        "name": "Form Autofill"
+      },
+      {
+        "id": "webcompat@mozilla.org",
+        "name": "Web Compat"
+      },
+      {
+        "id": "login-study@mozilla.org",
+        "name": "Google Accounts Login Check"
+      },
+      {
+        "id": "Shockwave FlashShockwave Flash 32.0 r0",
+        "name": "Shockwave Flash"
+      },
+      {
+        "id": "gmp-gmpopenh264",
+        "name": "OpenH264 Video Codec provided by Cisco Systems, Inc."
+      },
+      {
+        "id": "gmp-widevinecdm",
+        "name": "Widevine Content Decryption Module provided by Google Inc."
+      }
+    ],
+    "default_search_engine_is_google": false,
+    "default_private_search_engine_is_google": false,
+    "accounts_days_visited_per_month": 5.61,
+    "has_browser_search_with_ads": true,
+    "has_browser_search_ad_clicks": true,
+    "history_oldest_days_old": 453,
+    "history_average_days_per_month": 25.72
+  }
 }

--- a/validation/telemetry/normandy-login-study.4.sample.pass.json
+++ b/validation/telemetry/normandy-login-study.4.sample.pass.json
@@ -1,0 +1,90 @@
+{
+  "password_manager_enabled": false,
+  "browser_privatebrowsing_autostart": false,
+  "network_cookie_lifetime_policy": 0,
+  "privacy_sanitize_sanitize_on_shutdown": false,
+  "privacy_clear_on_shutdown_cookies": true,
+  "network_cookie_cookie_behavior": 4,
+  "browser_startup_page": 0,
+  "session_days_old": 0,
+  "profile_days_old": 0,
+  "logins_accounts": false,
+  "logins_accounts_uses_per_month": 0,
+  "google_accounts_cookie_present": false,
+  "google_accounts_cookie_days_old": null,
+  "has_allow_cookie_exceptions": false,
+  "has_block_cookie_exceptions": false,
+  "cookies_oldest_days_old": 0,
+  "activeAddons": [
+    {
+      "id": "doh-rollout@mozilla.org",
+      "name": "DoH Roll-Out"
+    },
+    {
+      "id": "formautofill@mozilla.org",
+      "name": "Form Autofill"
+    },
+    {
+      "id": "screenshots@mozilla.org",
+      "name": "Firefox Screenshots"
+    },
+    {
+      "id": "webcompat-reporter@mozilla.org",
+      "name": "WebCompat Reporter"
+    },
+    {
+      "id": "webcompat@mozilla.org",
+      "name": "Web Compat"
+    },
+    {
+      "id": "firefox-compact-dark@mozilla.org",
+      "name": "Dark"
+    },
+    {
+      "id": "login-telemetry-study-a@mozilla.org",
+      "name": "Login Telemetry Study"
+    },
+    {
+      "id": "google@search.mozilla.org",
+      "name": "Google"
+    },
+    {
+      "id": "amazon@search.mozilla.org",
+      "name": "Amazon.co.uk"
+    },
+    {
+      "id": "bing@search.mozilla.org",
+      "name": "Bing"
+    },
+    {
+      "id": "ddg@search.mozilla.org",
+      "name": "DuckDuckGo"
+    },
+    {
+      "id": "ebay@search.mozilla.org",
+      "name": "eBay"
+    },
+    {
+      "id": "twitter@search.mozilla.org",
+      "name": "Twitter"
+    },
+    {
+      "id": "wikipedia@search.mozilla.org",
+      "name": "Wikipedia (en)"
+    },
+    {
+      "id": "gmp-gmpopenh264",
+      "name": "OpenH264 Video Codec provided by Cisco Systems, Inc."
+    },
+    {
+      "id": "gmp-widevinecdm",
+      "name": "Widevine Content Decryption Module provided by Google Inc."
+    }
+  ],
+  "default_search_engine_is_google": true,
+  "default_private_search_engine_is_google": true,
+  "accounts_days_visited_per_month": 0,
+  "has_browser_search_with_ads": false,
+  "has_browser_search_ad_clicks": false,
+  "history_oldest_days_old": null
+}


### PR DESCRIPTION
This is the schema for a custom addon-based ping that will be coming from a normandy-installed addon. 

A few things I'm unsure on:
1. was `telemetry` the right namespace here?
2. In addition to this, do I need to open any PRs on bigquery ETL if I want the data to end up in a table?
3. this is my first time opening a PR in this repo. tests are passing but I still may have done something wrong

CC

Further reading:
https://bugzilla.mozilla.org/show_bug.cgi?id=1643383
https://bugzilla.mozilla.org/show_bug.cgi?id=1646821
https://experimenter.services.mozilla.com/experiments/google-login-cookie-check/


Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `include/glean/CHANGELOG.md`
