### PR TITLE
Pin Centos image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM centos:centos8.1.1911
 LABEL maintainer="Firefox Data Platform"
 
 # Install the appropriate software


### PR DESCRIPTION
We're seeing all test runs currently fail (see [example failure](https://app.circleci.com/pipelines/github/mozilla-services/mozilla-pipeline-schemas/1666/workflows/2af886d5-3764-4da0-9d51-bab9ff994611/jobs/3706/steps)).

This looks to be due to "diff" not being available in the centos8 image
published last week.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
