### PR TITLE
Make ecosystem_device_id an optional field

### DIFF
--- a/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -22,8 +22,7 @@
     }
   },
   "required": [
-    "ecosystem_client_id",
-    "ecosystem_device_id"
+    "ecosystem_client_id"
   ],
   "title": "account-ecosystem",
   "type": "object"

--- a/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -94,8 +94,7 @@
         }
       },
       "required": [
-        "ecosystemClientId",
-        "ecosystemDeviceId"
+        "ecosystemClientId"
       ],
       "type": "object"
     },

--- a/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -22,7 +22,6 @@
     }
   },
   "required": [
-    "ecosystem_client_id",
-    "ecosystem_device_id"
+    "ecosystem_client_id"
   ]
 }

--- a/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -43,8 +43,7 @@
         }
       },
       "required": [
-        "ecosystemClientId",
-        "ecosystemDeviceId"
+        "ecosystemClientId"
       ]
     }
   },


### PR DESCRIPTION
See discussion in
https://github.com/mozilla/gcp-ingestion/pull/1304#discussion_r443312441

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
