### PR TITLE
Remove ecosystem_device_id fields

### DIFF
--- a/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -4,9 +4,6 @@
     "ecosystem_client_id": {
       "type": "string"
     },
-    "ecosystem_device_id": {
-      "type": "string"
-    },
     "ecosystem_user_id": {
       "description": "Account Ecosystem Telemetry user identifier; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing ecosystem_anon_id",
       "pattern": "[a-zA-z0-9]{32}",

--- a/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -61,9 +61,6 @@
         "ecosystemClientId": {
           "type": "string"
         },
-        "ecosystemDeviceId": {
-          "type": "string"
-        },
         "ecosystemUserId": {
           "description": "Account Ecosystem Telemetry user identifier; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing ecosystemAnonId",
           "pattern": "[a-zA-z0-9]{32}",

--- a/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -6,9 +6,6 @@
     "ecosystem_client_id": {
       "type": "string"
     },
-    "ecosystem_device_id": {
-      "type": "string"
-    },
     "ecosystem_user_id": {
       "description": "Account Ecosystem Telemetry user identifier; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing ecosystem_anon_id",
       @ACCOUNT-ECOSYSTEM_ECOSYSTEM_USER_ID_TYPE_1_JSON@

--- a/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -21,9 +21,6 @@
         "ecosystemClientId": {
           "type": "string"
         },
-        "ecosystemDeviceId": {
-          "type": "string"
-        },
         "ecosystemUserId": {
           @ACCOUNT-ECOSYSTEM_ECOSYSTEM_USER_ID_TYPE_1_JSON@,
           "description": "Account Ecosystem Telemetry user identifier; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing ecosystemAnonId"


### PR DESCRIPTION
This is a schema-incompatible change. These tables are still being used only
for early stage testing of AET, so it is entirely reasonable to throw away
existing data and recreate them entirely.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
