### PR TITLE
Bug 1647825 - Add a schema for the new ping 'xfocsp-error=report'.

### DIFF
--- a/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
+  "properties": {
+    "payload": {
+      "maxProperties": 7,
+      "minProperties": 7,
+      "properties": {
+        "csp_header": {
+          "description": "The CSP: frame-ancestors value in the response HTTP header.",
+          "type": "string"
+        },
+        "error_type": {
+          "description": "The type of what error triggers this ping.",
+          "enum": [
+            "xfo",
+            "csp"
+          ],
+          "type": "string"
+        },
+        "frame_hostname": {
+          "description": "The hostname of the frame which triggers the error.",
+          "type": "string"
+        },
+        "frame_uri": {
+          "description": "The uri of the frame which triggers the error. This excludes the query strings.",
+          "type": "string"
+        },
+        "top_hostname": {
+          "description": "The hostname of the top-level page which loads the frame.",
+          "type": "string"
+        },
+        "top_uri": {
+          "description": "The uri of the top-level page which loads the frame. This excludes the query strings.",
+          "type": "string"
+        },
+        "xfo_header": {
+          "description": "The X-Frame-Options value in the response HTTP header.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_type",
+        "xfo_header",
+        "csp_header",
+        "frame_hostname",
+        "top_hostname",
+        "frame_uri",
+        "top_uri"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "payload"
+  ],
+  "title": "xfocsp-error-report",
+  "type": "object"
+}

--- a/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "xfocsp-error-report",
+  "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "minProperties": 7,
+      "maxProperties": 7,
+      "properties": {
+        "error_type": {
+          "description": "The type of what error triggers this ping.",
+          "type": "string",
+          "enum": ["xfo", "csp"]
+        },
+        "xfo_header": {
+          "description": "The X-Frame-Options value in the response HTTP header.",
+          "type": "string"
+        },
+        "csp_header": {
+          "description": "The CSP: frame-ancestors value in the response HTTP header.",
+          "type": "string"
+        },
+        "frame_hostname": {
+          "description": "The hostname of the frame which triggers the error.",
+          "type": "string"
+        },
+        "top_hostname": {
+          "description": "The hostname of the top-level page which loads the frame.",
+          "type": "string"
+        },
+        "frame_uri": {
+          "description": "The uri of the frame which triggers the error. This excludes the query strings.",
+          "type": "string"
+        },
+        "top_uri": {
+          "description": "The uri of the top-level page which loads the frame. This excludes the query strings.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_type",
+        "xfo_header",
+        "csp_header",
+        "frame_hostname",
+        "top_hostname",
+        "frame_uri",
+        "top_uri"
+      ]
+    }
+  },
+  "required": [
+    "payload"
+  ]
+}

--- a/validation/telemetry/xfocsp-error-report.4.sample.pass.json
+++ b/validation/telemetry/xfocsp-error-report.4.sample.pass.json
@@ -1,0 +1,26 @@
+{
+    "type": "xfocsp-error-report",
+    "id": "0cb9115c-471b-164b-9630-9fb75567eca8",
+    "creationDate": "2020-07-10T11:42:30.579Z",
+    "version": 4,
+    "application": {
+      "architecture": "x86-64",
+      "buildId": "20200710134107",
+      "name": "Firefox",
+      "version": "80.0a1",
+      "displayVersion": "80.0a1",
+      "vendor": "Mozilla",
+      "platformVersion": "80.0a1",
+      "xpcomAbi": "x86_64-gcc3",
+      "channel": "default"
+    },
+    "payload": {
+      "error_type": "xfo",
+      "xfo_header": "deny",
+      "csp_header": "",
+      "frame_hostname": "example.com",
+      "top_hostname": "example.com",
+      "frame_uri": "http://example.com/browser/dom/security/test/general/file_framing_error_pages.sjs",
+      "top_uri": "http//example.com/browser/dom/security/test/general/file_framing_error_pages_xfo.html"
+    }
+  }


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
