### PR TITLE
Specify yaml loader in extract_crash_annotation_fields script

### DIFF
--- a/scripts/extract_crash_annotation_fields
+++ b/scripts/extract_crash_annotation_fields
@@ -32,7 +32,7 @@ existing_payload_properties = json.loads(
     ).read()
 )["properties"]["payload"]["properties"]["metadata"]["properties"].keys()
 
-crash_annotations = yaml.load(open(sys.argv[1]).read())
+crash_annotations = yaml.load(open(sys.argv[1]).read(), Loader=yaml.SafeLoader)
 for crash_annotation_name, crash_annotation_props in crash_annotations.items():
     if (
         crash_annotation_props.get("ping")


### PR DESCRIPTION
Avoids a scary warning when run


Checklist for reviewer:

(none applicable to this one)

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`