### PR TITLE
Bug 1630444 - Add process_type to the launcher process failure ping

### DIFF
--- a/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -98,6 +98,10 @@
       "description": "Windows version numnber in major.minor.build.UBR format (UBR is optional, only available on Win10)",
       "type": "string"
     },
+    "process_type": {
+      "description": "The type of the process which failed to start as a sandboxed process",
+      "type": "string"
+    },
     "security": {
       "description": "Information about the security applications registered with Windows on the host computer",
       "properties": {

--- a/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -48,6 +48,10 @@
       "description": "True if the process was launched with Administrator privileges but without User Account Control (= UAC)",
       "type": "boolean"
     },
+    "process_type": {
+      "description": "The type of the process which failed to start as a sandboxed process",
+      "type": "string"
+    },
     "xpcom_abi": {
       "description": "This build's XPCOM_ABI string",
       "type": "string"

--- a/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
+++ b/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
@@ -12,6 +12,7 @@
  "cpu_arch": 9,
  "num_logical_cpus": 8,
  "is_admin_without_uac": true,
+ "process_type": "gmplugin",
  "memory": {
   "total_phys": 16976711680,
   "avail_phys": 4024082432,


### PR DESCRIPTION
This patch adds a new optional string field `process_type` in the existing
launcher process failure ping.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
