### PR TITLE
Add common ping fields to xfocsp-error-report

### DIFF
--- a/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -2,6 +2,61 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
   "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "payload": {
       "maxProperties": 7,
       "minProperties": 7,
@@ -49,6 +104,17 @@
         "top_uri"
       ],
       "type": "object"
+    },
+    "type": {
+      "enum": [
+        "xfocsp-error-report"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
     }
   },
   "required": [

--- a/schemas/xfocsp-error-report/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/schemas/xfocsp-error-report/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -2,6 +2,61 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
   "properties": {
+    "application": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "buildId": {
+          "pattern": "^[0-9]{10}",
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "displayVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platformVersion": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^[0-9]{2,3}\\.",
+          "type": "string"
+        },
+        "xpcomAbi": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "buildId",
+        "channel",
+        "name",
+        "platformVersion",
+        "version",
+        "vendor",
+        "xpcomAbi"
+      ],
+      "type": "object"
+    },
+    "creationDate": {
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "payload": {
       "maxProperties": 7,
       "minProperties": 7,
@@ -49,6 +104,17 @@
         "top_uri"
       ],
       "type": "object"
+    },
+    "type": {
+      "enum": [
+        "xfocsp-error-report"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "maximum": 4,
+      "minimum": 4,
+      "type": "number"
     }
   },
   "required": [

--- a/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -4,6 +4,18 @@
   "title": "xfocsp-error-report",
   "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
   "properties": {
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_ID_1_JSON@,
+    "type": {
+      "type": "string",
+      "enum": [ "xfocsp-error-report" ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
+    },
     "payload": {
       "type": "object",
       "minProperties": 7,

--- a/templates/xfocsp-error-report/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/templates/xfocsp-error-report/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -4,6 +4,18 @@
   "title": "xfocsp-error-report",
   "description": "Schema for xfocsp-error-report pings as documented at https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/xfocsp-error-report-ping.html",
   "properties": {
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_ID_1_JSON@,
+    "type": {
+      "type": "string",
+      "enum": [ "xfocsp-error-report" ]
+    },
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
+    },
     "payload": {
       "type": "object",
       "minProperties": 7,

--- a/validation/telemetry/xfocsp-error-report.4.sample.pass.json
+++ b/validation/telemetry/xfocsp-error-report.4.sample.pass.json
@@ -1,25 +1,26 @@
 {
-    "type": "xfocsp-error-report",
-    "creationDate": "2020-07-10T11:42:30.579Z",
-    "version": 4,
-    "application": {
-      "architecture": "x86-64",
-      "buildId": "20200710134107",
-      "name": "Firefox",
-      "version": "80.0a1",
-      "displayVersion": "80.0a1",
-      "vendor": "Mozilla",
-      "platformVersion": "80.0a1",
-      "xpcomAbi": "x86_64-gcc3",
-      "channel": "default"
-    },
-    "payload": {
-      "error_type": "xfo",
-      "xfo_header": "deny",
-      "csp_header": "",
-      "frame_hostname": "example.com",
-      "top_hostname": "example.com",
-      "frame_uri": "http://example.com/browser/dom/security/test/general/file_framing_error_pages.sjs",
-      "top_uri": "http//example.com/browser/dom/security/test/general/file_framing_error_pages_xfo.html"
-    }
+  "type": "xfocsp-error-report",
+  "id": "0cb9115c-471b-164b-9630-9fb75567eca8",
+  "creationDate": "2020-07-10T11:42:30.579Z",
+  "version": 4,
+  "application": {
+    "architecture": "x86-64",
+    "buildId": "20200710134107",
+    "name": "Firefox",
+    "version": "80.0a1",
+    "displayVersion": "80.0a1",
+    "vendor": "Mozilla",
+    "platformVersion": "80.0a1",
+    "xpcomAbi": "x86_64-gcc3",
+    "channel": "default"
+  },
+  "payload": {
+    "error_type": "xfo",
+    "xfo_header": "deny",
+    "csp_header": "",
+    "frame_hostname": "example.com",
+    "top_hostname": "example.com",
+    "frame_uri": "http://example.com/browser/dom/security/test/general/file_framing_error_pages.sjs",
+    "top_uri": "http//example.com/browser/dom/security/test/general/file_framing_error_pages_xfo.html"
   }
+}


### PR DESCRIPTION
In testing, we found several top-level fields included in the validation
document were going to additional_properties. We add them here.

Of note, we do not add client_id or environment, which are part of the common
ping format but specifically excluded here for user privacy.

Reverts https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/582

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`
