### PR TITLE
[Bug 1659517] #/payload/syncs/0/engines/1/outgoing/0/failed set minimum to 0

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -432,7 +432,7 @@
                         "additionalProperties": false,
                         "properties": {
                           "failed": {
-                            "minimum": 1,
+                            "minimum": 0,
                             "type": "integer"
                           },
                           "sent": {

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -446,7 +446,7 @@
                         "additionalProperties": false,
                         "properties": {
                           "failed": {
-                            "minimum": 1,
+                            "minimum": 0,
                             "type": "integer"
                           },
                           "sent": {

--- a/templates/include/telemetry/syncItem.1.schema.json
+++ b/templates/include/telemetry/syncItem.1.schema.json
@@ -66,7 +66,7 @@
               "additionalProperties": false,
               "properties": {
                 "sent": { "type": "integer", "minimum": 1 },
-                "failed": { "type": "integer", "minimum": 1 }
+                "failed": { "type": "integer", "minimum": 0 }
               }
             }
           },

--- a/validation/telemetry/sync.4.sample.pass.json
+++ b/validation/telemetry/sync.4.sample.pass.json
@@ -58,6 +58,7 @@
             "took": 394,
             "outgoing": [
               {
+                "failed": 0,
                 "sent": 8
               }
             ]


### PR DESCRIPTION
Firefox for iOS is sending `"...outgoing":[{"failed":0,"sent":3}],..."`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
