### PR TITLE
Introduce "pioneer" value for bq_metadata_format

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -15,7 +15,8 @@
           "description": "NOT YET IMPLEMENTED: The logical format for the metadata struct in the destination BigQuery table",
           "enum": [
             "structured",
-            "telemetry"
+            "telemetry",
+            "pioneer"
           ],
           "type": "string"
         },

--- a/schemas/pioneer-debug/debug/debug.1.schema.json
+++ b/schemas/pioneer-debug/debug/debug.1.schema.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "bq_dataset_family": "pioneer_debug",
-    "bq_metadata_format": "structured",
+    "bq_metadata_format": "pioneer",
     "bq_table": "debug_v1"
   },
   "properties": {

--- a/schemas/pioneer-debug/deletion-request/deletion-request.1.schema.json
+++ b/schemas/pioneer-debug/deletion-request/deletion-request.1.schema.json
@@ -4,7 +4,7 @@
   "additionalProperties": false,
   "mozPipelineMetadata": {
     "bq_dataset_family": "pioneer_debug",
-    "bq_metadata_format": "structured",
+    "bq_metadata_format": "pioneer",
     "bq_table": "deletion_request_v1"
   },
   "properties": {},

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -20,7 +20,7 @@
         "bq_metadata_format": {
           "type": "string",
           "description": "NOT YET IMPLEMENTED: The logical format for the metadata struct in the destination BigQuery table",
-          "enum": ["structured", "telemetry"]
+          "enum": ["structured", "telemetry", "pioneer"]
         },
         "expiration_policy": {
           "type": "object",

--- a/templates/pioneer-debug/defaults.schema.json
+++ b/templates/pioneer-debug/defaults.schema.json
@@ -1,0 +1,5 @@
+{
+  "mozPipelineMetadata": {
+    "bq_metadata_format": "pioneer"
+  }
+}

--- a/tests/test_metadata_defaults.py
+++ b/tests/test_metadata_defaults.py
@@ -1,3 +1,0 @@
-def test_metadata_defaults(schemas):
-    main = schemas["telemetry.account-ecosystem.4"]
-    assert main["mozPipelineMetadata"]["bq_metadata_format"] == "telemetry"

--- a/tests/test_pipeline_metadata.py
+++ b/tests/test_pipeline_metadata.py
@@ -1,0 +1,10 @@
+def test_metadata_defaults(schemas):
+    main = schemas["telemetry.account-ecosystem.4"]
+    assert main["mozPipelineMetadata"]["bq_metadata_format"] == "telemetry"
+
+def test_pioneer_defaults(schemas):
+    for name, schema in schemas.items():
+        if name.startswith("pioneer-"):
+            msg = (f"{name} is a pioneer ping and must have bq_metadata_format 'pioneer';"
+                   " see templates/pioneer-debug/defaults.schema.json")
+            assert schema["mozPipelineMetadata"]["bq_metadata_format"] == "pioneer", msg

--- a/tests/test_telemetry_version.py
+++ b/tests/test_telemetry_version.py
@@ -1,0 +1,26 @@
+TELEMETRY_VERSIONS = {
+    "mobile-event": [1],
+    "core": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "frecency-update": [1, 4],
+    "shield-study": [1, 3, 4],
+    "health": [2, 4, 9],
+    "focus-event": [1],
+    "crash": [2, 4],
+    "installation": [1],
+    "ftu": [3],
+    "shield-study-error": [3, 4],
+    "shield-study-addon": [3, 4],
+    "android-anr-report": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "sync": [4, 5],
+    "mobile-metrics": [1],
+    "block-autoplay": [1, 4],
+}
+
+
+def test_telemetry_version(schemas):
+    for name, schema in schemas.items():
+        namespace, doctype, version = name.split(".")
+        if namespace == "telemetry":
+            allowed_versions = TELEMETRY_VERSIONS.get(doctype, [4])
+            msg = f"{name} is under the telemetry namespace with an unexpected version"
+            assert int(version) in allowed_versions, msg


### PR DESCRIPTION
This should bring parity with the [regex logic on filepaths in m-s-g](https://github.com/mozilla/mozilla-schema-generator/blob/0bdc35a407b991c3cf6de591a4afee6a8d8ea61a/bin/schema_generator.sh#L76-L91) Once this and https://github.com/mozilla/mozilla-schema-generator/pull/139 are merged, it should be possible to update m-s-g's metadata_merge to look up the appropriate metadata schema based on bq_metadata_format and remove the regex logic.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
