### PR TITLE
Bug 1659750 Prepare account-ecosystem ping for probe injection

### DIFF
--- a/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -170,7 +170,7 @@
     "payload": {
       "properties": {
         "duration": {
-          "type": "number"
+          "type": "integer"
         },
         "ecosystemClientId": {
           "type": "string"

--- a/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -169,6 +169,9 @@
     },
     "payload": {
       "properties": {
+        "duration": {
+          "type": "number"
+        },
         "ecosystemClientId": {
           "type": "string"
         },
@@ -176,6 +179,98 @@
           "description": "Account Ecosystem Telemetry user identifier; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing ecosystemAnonId",
           "pattern": "[a-zA-z0-9]{64}",
           "type": "string"
+        },
+        "histograms": {
+          "properties": {
+            "parent": {
+              "additionalProperties": {
+                "type": [
+                  "integer",
+                  "string",
+                  "boolean"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "keyedHistograms": {
+          "properties": {
+            "parent": {
+              "additionalProperties": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "bucket_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "histogram_type": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "log_sum": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "log_sum_squares": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "range": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sum": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "sum_squares_hi": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "sum_squares_lo": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^[0-9]+$": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "object"
+              }
+            }
+          },
+          "type": "object"
+        },
+        "keyedScalars": {
+          "properties": {
+            "parent": {
+              "additionalProperties": {
+                "additionalProperties": {
+                  "type": [
+                    "integer",
+                    "string",
+                    "boolean"
+                  ]
+                },
+                "type": "object"
+              }
+            }
+          },
+          "type": "object"
         },
         "previousEcosystemUserIds": {
           "description": "Previous Account Ecosystem Telemetry identifiers associated with this user; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing previousEcosystemAnonIds",

--- a/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -49,7 +49,7 @@
           }
         },
         "duration": {
-          "type": "number"
+          "type": "integer"
         },
         "scalars": {
           "type": "object",

--- a/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -48,10 +48,40 @@
             @ACCOUNT-ECOSYSTEM_ECOSYSTEM_USER_ID_TYPE_1_JSON@
           }
         },
+        "duration": {
+          "type": "number"
+        },
         "scalars": {
           "type": "object",
           "properties": {
             "parent": @TELEMETRY_SCALARS_1_JSON@
+          }
+        },
+        "keyedScalars": {
+          "type": "object",
+          "properties": {
+            "parent": {
+              "additionalProperties": @TELEMETRY_SCALARS_1_JSON@
+            }
+          }
+        },
+        "histograms": {
+          "type": "object",
+          "properties": {
+            "parent": @TELEMETRY_SCALARS_1_JSON@
+          }
+        },
+        "keyedHistograms": {
+          "type": "object",
+          "properties": {
+            "parent": {
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  @TELEMETRY_HISTOGRAM_1_JSON@
+                }
+              }
+            }
           }
         }
       },

--- a/validation/telemetry/account-ecosystem.4.sample.pass.json
+++ b/validation/telemetry/account-ecosystem.4.sample.pass.json
@@ -18,10 +18,61 @@
     "ecosystemClientId": "5bdc7cec-0b1d-ac42-a369-610223b7869d",
     "ecosystemUserId": "abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh",
     "previousEcosystemUserIds": ["18cdefghabcdefghabcdefghabcdefgh1bcdefghabcdefghabcdefghabcdefg3"],
+    "duration": 8547,
     "scalars": {
       "parent": {
+        "browser.engagement.active_ticks": 12,
         "browser.engagement.total_uri_count": 3
       }
+    },
+    "keyedScalars": {
+      "key1": 12,
+      "key2": "foo"
+    },
+    "histograms": {
+      "content": {},
+      "dynamic": {},
+      "extension": {},
+      "gpu": {},
+      "parent": {},
+      "socket": {}
+    },
+    "keyedHistograms": {
+      "content": {},
+      "dynamic": {},
+      "extension": {},
+      "gpu": {},
+      "parent": {
+        "SEARCH_COUNTS": {
+          "google.in-content:sap:firefox-b-d": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "sum": 1,
+            "range": [
+              1,
+              2
+            ],
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          },
+          "google-b-d.urlbar": {
+            "bucket_count": 3,
+            "histogram_type": 4,
+            "sum": 1,
+            "range": [
+              1,
+              2
+            ],
+            "values": {
+              "0": 1,
+              "1": 0
+            }
+          }
+        }
+      },
+      "socket": {}
     }
   }
 }


### PR DESCRIPTION
Currently, the only probes saved into the "account-ecosystem" metrics store
are in process main, so this PR only adds "parent" placeholders for now.

Injection is happening in https://github.com/mozilla/mozilla-schema-generator/pull/140

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
