### PR TITLE
Add hasPrefetch and hasSuperfetch

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1193,6 +1193,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -1200,6 +1200,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1193,6 +1193,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1193,6 +1193,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
+++ b/schemas/telemetry/untrustedModules/untrustedModules.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1192,6 +1192,20 @@
             },
             "os": {
               "properties": {
+                "hasPrefetch": {
+                  "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "hasSuperfetch": {
+                  "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
                 "installYear": {
                   "description": "The year Windows was installed. This is Windows only. `null` on failure.",
                   "type": [

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -1172,6 +1172,14 @@
               ],
               "description": "The Windows UBR. This is Windows 10 only. `null` on failure."
             },
+            "hasPrefetch": {
+              "type": ["boolean", "null"],
+              "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure."
+            },
+            "hasSuperfetch": {
+              "type": ["boolean", "null"],
+              "description": "Whether or not the OS-based superfetch application start-up optimization service is running and using the default settings. This is Windows-only. `null` on failure."
+            },
             "installYear": {
               "type": [
                 "number",


### PR DESCRIPTION
The new "account-ecosystem" telemetry ping includes a minimal environment with only a subset of the fields included in most pings following the common ping format. The existing logic in mozilla-schema-generator injects some fields we don't want into the environment, and it's unclear to me why these don't exist in the json schemas directly. There is some discussion of the preference for defining the fields in the raw json schemas (see https://bugzilla.mozilla.org/show_bug.cgi?id=1614416#c3).

If we are able to add the fields at this level, then we can simplify the logic in mozilla-schema-generator as part of https://github.com/mozilla/mozilla-schema-generator/pull/140.

By merging this, we would be adding hasPrefetch to a few tables that currently do _not_ have it. This should be the set of doctypes that are defined with the telemetry environment include, but which aren't defined as common pings in m-s-g, such as dnssec-study (and I've spot checked that there are indeed some records we're getting to that doctype that include hasPrefetch in additional_properties). See the results of schema generation in https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/e5070de98ee119f54bd58b3eedbefcdb60002ffd

So, the only real danger I can see here is if there are any applications sending hasPrefetch with a non-boolean type, which could cause an increase in rejected documents. This seems unlikely, given these fields are likely all filled by an identical code path in desktop telemetry.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
