### PR TITLE
Mark bq_metadata_format as implemented

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -12,7 +12,7 @@
           "type": "string"
         },
         "bq_metadata_format": {
-          "description": "NOT YET IMPLEMENTED: The logical format for the metadata struct in the destination BigQuery table",
+          "description": "The logical format for the metadata struct in the destination BigQuery table",
           "enum": [
             "structured",
             "telemetry",

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -19,7 +19,7 @@
         },
         "bq_metadata_format": {
           "type": "string",
-          "description": "NOT YET IMPLEMENTED: The logical format for the metadata struct in the destination BigQuery table",
+          "description": "The logical format for the metadata struct in the destination BigQuery table",
           "enum": ["structured", "telemetry", "pioneer"]
         },
         "expiration_policy": {


### PR DESCRIPTION
`bq_metadata_format` actually affects schema generation behavior as of https://github.com/mozilla/mozilla-schema-generator/pull/141

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
