### PR TITLE
Require JSON Pointer format for jwe_mappings

### DIFF
--- a/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -18,12 +18,12 @@
     "bq_table": "account_ecosystem_v1",
     "jwe_mappings": [
       {
-        "decrypted_field_path": "ecosystem_user_id",
-        "source_field_path": "ecosystem_anon_id"
+        "decrypted_field_path": "/ecosystem_user_id",
+        "source_field_path": "/ecosystem_anon_id"
       },
       {
-        "decrypted_field_path": "previous_ecosystem_user_ids",
-        "source_field_path": "previous_ecosystem_anon_ids"
+        "decrypted_field_path": "/previous_ecosystem_user_ids",
+        "source_field_path": "/previous_ecosystem_anon_ids"
       }
     ]
   },

--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -41,13 +41,15 @@
           "type": "object"
         },
         "jwe_mappings": {
-          "description": "NOT YET IMPLEMENTED: Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; only planned initial use case is for Account Ecosystem Telemetry; paths may indicate nested fields with dots such as 'payload.ecosystemAnonId'",
+          "description": "NOT YET IMPLEMENTED: Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; only planned initial use case is for Account Ecosystem Telemetry; paths must be in [JSON Pointer format](https://tools.ietf.org/html/rfc6901) like '/payload/ecosystemAnonId'",
           "items": {
             "properties": {
               "decrypted_field_path": {
+                "pattern": "^/.*$",
                 "type": "string"
               },
               "source_field_path": {
+                "pattern": "^/.*$",
                 "type": "string"
               }
             },

--- a/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/schemas/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -6,12 +6,12 @@
     "bq_table": "account_ecosystem_v4",
     "jwe_mappings": [
       {
-        "decrypted_field_path": "payload.ecosystemUserId",
-        "source_field_path": "payload.ecosystemAnonId"
+        "decrypted_field_path": "/payload/ecosystemUserId",
+        "source_field_path": "/payload/ecosystemAnonId"
       },
       {
-        "decrypted_field_path": "payload.previousEcosystemUserIds",
-        "source_field_path": "payload.previousEcosystemAnonIds"
+        "decrypted_field_path": "/payload/previousEcosystemUserIds",
+        "source_field_path": "/payload/previousEcosystemAnonIds"
       }
     ]
   },

--- a/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -5,12 +5,12 @@
   "mozPipelineMetadata": {
     "jwe_mappings": [
       {
-        "source_field_path": "ecosystem_anon_id",
-        "decrypted_field_path": "ecosystem_user_id"
+        "source_field_path": "/ecosystem_anon_id",
+        "decrypted_field_path": "/ecosystem_user_id"
       },
       {
-        "source_field_path": "previous_ecosystem_anon_ids",
-        "decrypted_field_path": "previous_ecosystem_user_ids"
+        "source_field_path": "/previous_ecosystem_anon_ids",
+        "decrypted_field_path": "/previous_ecosystem_user_ids"
       }
     ]
   },

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -40,12 +40,18 @@
         },
         "jwe_mappings": {
           "type": "array",
-          "description": "NOT YET IMPLEMENTED: Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; only planned initial use case is for Account Ecosystem Telemetry; paths may indicate nested fields with dots such as 'payload.ecosystemAnonId'",
+          "description": "NOT YET IMPLEMENTED: Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; only planned initial use case is for Account Ecosystem Telemetry; paths must be in [JSON Pointer format](https://tools.ietf.org/html/rfc6901) like '/payload/ecosystemAnonId'",
           "items": {
             "type": "object",
             "properties": {
-              "source_field_path":{"type": "string"},
-              "decrypted_field_path":{"type": "string"}
+              "source_field_path":{
+                "type": "string",
+                "pattern": "^/.*$"
+              },
+              "decrypted_field_path":{
+                "type": "string",
+                "pattern": "^/.*$"
+              }
             }
           }
         }

--- a/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
+++ b/templates/telemetry/account-ecosystem/account-ecosystem.4.schema.json
@@ -5,12 +5,12 @@
   "mozPipelineMetadata": {
     "jwe_mappings": [
       {
-        "source_field_path": "payload.ecosystemAnonId",
-        "decrypted_field_path": "payload.ecosystemUserId"
+        "source_field_path": "/payload/ecosystemAnonId",
+        "decrypted_field_path": "/payload/ecosystemUserId"
       },
       {
-        "source_field_path": "payload.previousEcosystemAnonIds",
-        "decrypted_field_path": "payload.previousEcosystemUserIds"
+        "source_field_path": "/payload/previousEcosystemAnonIds",
+        "decrypted_field_path": "/payload/previousEcosystemUserIds"
       }
     ]
   },


### PR DESCRIPTION
This moves us from using an informal ad hoc format for specifying paths to
a proposed IETF standard.

I came across this standard as I was starting to draft a PR for relying on
jwe_mappings in the AET decoder. In particular, the Jackson library provides
an implementation of JSON Pointer that simplifies the AET logic.

See draft: https://github.com/mozilla/gcp-ingestion/pull/1374

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
