### PR TITLE
Bug 1658787 - Add Pocket on-save recs ping

### DIFF
--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "activity_stream",
+    "bq_metadata_format": "structured",
+    "bq_table": "on_save_recs_v1",
+    "expiration_policy": {
+      "delete_after_days": 180
+    }
+  },
+  "properties": {
+    "action_position": {
+      "description": "A zero based integer indicating the position of this event",
+      "type": "integer"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "event": {
+      "enum": [
+        "impression",
+        "click",
+        "save"
+      ],
+      "description": "An event identifier",
+      "type": "string"
+    },
+    "experiments": {
+      "additionalProperties": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "description": "An object to record all active experiments, experiments IDs are stored as keys, and the value object stores the branch information. Example: {\"experiment_1\": {\"branch\": \"control\"}, \"experiment_2\": {\"branch\": \"treatment\"}}. This deprecates the \"shield_id\" used in activity-stream and messaging-system.",
+      "type": "object"
+    },
+    "impression_id": {
+      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "model": {
+      "description": "An identifier for the machine learning model used to generate the recommendations",
+      "type": "string"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "region": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "event",
+    "addon_version",
+    "version",
+    "locale"
+  ],
+  "title": "on-save-recs",
+  "type": "object"
+}

--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -9,21 +9,33 @@
     }
   },
   "properties": {
-    "action_position": {
-      "description": "A zero based integer indicating the position of this event",
-      "type": "integer"
-    },
     "addon_version": {
       "type": "string"
     },
-    "event": {
-      "enum": [
-        "impression",
-        "click",
-        "save"
-      ],
-      "description": "An event identifier",
-      "type": "string"
+    "events": {
+      "items": {
+        "properties": {
+          "action": {
+            "enum": [
+              "impression",
+              "click",
+              "save"
+            ],
+            "description": "An event identifier",
+            "type": "string"
+          },
+          "position": {
+            "description": "A zero based integer indicating the position of this event",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "position"
+        ],
+        "type": "object"
+      },
+      "type": "array"
     },
     "experiments": {
       "additionalProperties": {
@@ -64,7 +76,7 @@
   },
   "required": [
     "impression_id",
-    "event",
+    "events",
     "addon_version",
     "version",
     "locale"

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -5,21 +5,33 @@
   "properties": {
     @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
     @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
-    "action_position": {
-      "description": "A zero based integer indicating the position of this event",
-      "type": "integer"
-    },
     "addon_version": {
       "type": "string"
     },
-    "event": {
-      "enum": [
-        "impression",
-        "click",
-        "save"
-      ],
-      "description": "An event identifier",
-      "type": "string"
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "enum": [
+              "impression",
+              "click",
+              "save"
+            ],
+            "description": "An event identifier",
+            "type": "string"
+          },
+          "position": {
+            "description": "A zero based integer indicating the position of this event",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "position"
+        ],
+      }
     },
     "locale": {
       "type": "string"
@@ -43,7 +55,7 @@
   },
   "required": [
     "impression_id",
-    "event",
+    "events",
     "addon_version",
     "version",
     "locale"

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -30,7 +30,7 @@
         "required": [
           "action",
           "position"
-        ],
+        ]
       }
     },
     "locale": {

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "on-save-recs",
+  "properties": {
+    @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
+    @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
+    "action_position": {
+      "description": "A zero based integer indicating the position of this event",
+      "type": "integer"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "event": {
+      "enum": [
+        "impression",
+        "click",
+        "save"
+      ],
+      "description": "An event identifier",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "model": {
+      "description": "An identifier for the machine learning model used to generate the recommendations",
+      "type": "string"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "region": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "event",
+    "addon_version",
+    "version",
+    "locale"
+  ]
+}

--- a/validation/activity-stream/on-save-recs.1.sample.pass.json
+++ b/validation/activity-stream/on-save-recs.1.sample.pass.json
@@ -8,5 +8,5 @@
   "action_position": 0,
   "profile_creation_date": 16587,
   "region": "CA",
-  "model": "doc2vec",
+  "model": "doc2vec"
 }

--- a/validation/activity-stream/on-save-recs.1.sample.pass.json
+++ b/validation/activity-stream/on-save-recs.1.sample.pass.json
@@ -4,8 +4,20 @@
   "version": "72.0a1",
   "release_channel": "nightly",
   "addon_version": "20191119043902",
-  "event": "impression",
-  "action_position": 0,
+  "events": [
+    {
+      "action": "impression",
+      "position": 0
+    },
+    {
+      "action": "impression",
+      "position": 1
+    },
+    {
+      "action": "impression",
+      "position": 2
+    }
+  ],
   "profile_creation_date": 16587,
   "region": "CA",
   "model": "doc2vec"

--- a/validation/activity-stream/on-save-recs.1.sample.pass.json
+++ b/validation/activity-stream/on-save-recs.1.sample.pass.json
@@ -1,0 +1,12 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20191119043902",
+  "event": "impression",
+  "action_position": 0,
+  "profile_creation_date": 16587,
+  "region": "CA",
+  "model": "doc2vec",
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

This creates a new telemetry ping to track impressions, clicks, and saves of on-save recommendations shown to users when they save a webpage via the Pocket button in the address bar.

I have included most standard information that we track on AS pings and entered this ping into the `activity-stream` namespace, as per guidance from @ncloudioj . This ping does not have the FX `client_id`, but instead uses the Pocket `impression_id` as a user identifier.

The only new parameters of note are:
-`model` = name of the machine learning model that generated these recommendations
