### PR TITLE
Bug 1653654 Add oauth_client_id to firefox-accounts AET schema

### DIFF
--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -16,12 +16,12 @@
       "items": {
         "properties": {
           "action": {
+            "description": "An event identifier",
             "enum": [
               "impression",
               "click",
               "save"
             ],
-            "description": "An event identifier",
             "type": "string"
           },
           "position": {

--- a/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/schemas/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -44,6 +44,10 @@
       "description": "Value of the 'event' field in the source LogEntry payload",
       "type": "string"
     },
+    "oauth_client_id": {
+      "description": "Value of the 'clientId' field in the source LogEntry payload, indicating the OAuth client associated with the event",
+      "type": "string"
+    },
     "previous_ecosystem_user_ids": {
       "description": "Previous Account Ecosystem Telemetry identifiers associated with this user; this value is not present in the original payload sent by clients, but is instead inserted by the pipeline after decrypting and removing previous_ecosystem_anon_ids",
       "items": {

--- a/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
+++ b/templates/firefox-accounts/account-ecosystem/account-ecosystem.1.schema.json
@@ -33,6 +33,10 @@
       "type": "string",
       "description": "Value of the 'event' field in the source LogEntry payload"
     },
+    "oauth_client_id": {
+      "type": "string",
+      "description": "Value of the 'clientId' field in the source LogEntry payload, indicating the OAuth client associated with the event"
+    },
     "country": {
       "type": "string",
       "description": "Country name as extracted in the FxA pipeline; contains logical values like 'United States' and 'India' rather than 2-letter country codes"


### PR DESCRIPTION
Added to ingestion in https://github.com/mozilla/gcp-ingestion/pull/1404

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
