### PR TITLE
Bug 1658787 - Drop region field from on-sav-recs ping

### DIFF
--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -64,9 +64,6 @@
     "profile_creation_date": {
       "type": "integer"
     },
-    "region": {
-      "type": "string"
-    },
     "release_channel": {
       "type": "string"
     },

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -43,9 +43,6 @@
     "profile_creation_date": {
       "type": "integer"
     },
-    "region": {
-      "type": "string"
-    },
     "release_channel": {
       "type": "string"
     },

--- a/validation/activity-stream/on-save-recs.1.sample.pass.json
+++ b/validation/activity-stream/on-save-recs.1.sample.pass.json
@@ -19,6 +19,5 @@
     }
   ],
   "profile_creation_date": 16587,
-  "region": "CA",
   "model": "doc2vec"
 }


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

It turns out the data pipeline adds region information based on IP address to all events by default, so no need for the `region` parameter I had added to this ping [earlier](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/608).