### PR TITLE
Bug 1588245 - Add detour_orig_bytes to the launcher process failure ping

### DIFF
--- a/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -33,6 +33,10 @@
     "launcher_error": {
       "description": "The error that raised the launcher process failure",
       "properties": {
+        "detour_orig_bytes": {
+          "description": "First sixteen bytes of a function that we failed to hook (Nightly-only).  This field is added only on detour failures.",
+          "type": "string"
+        },
         "hresult": {
           "description": "The HRESULT error code from the launcher failure",
           "type": "integer"

--- a/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -101,6 +101,10 @@
         "hresult": {
           "description": "The HRESULT error code from the launcher failure",
           "type": "integer"
+        },
+        "detour_orig_bytes": {
+          "description": "First sixteen bytes of a function that we failed to hook (Nightly-only).  This field is added only on detour failures.",
+          "type": "string"
         }
       }
     },

--- a/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
+++ b/validation/firefox-launcher-process/launcher-process-failure.1.sample.pass.json
@@ -23,7 +23,8 @@
  "launcher_error": {
   "source_file": "LauncherProcessWin.cpp",
   "source_line": 195,
-  "hresult": -2147023609
+  "hresult": -2147023609,
+  "detour_orig_bytes": "4c8bd1b828000000f604250803000000"
  },
  "security": {
   "av": [


### PR DESCRIPTION
This patch adds a new optional string field `detour_orig_bytes` in the existing
launcher process failure ping.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
