### PR TITLE
Bug 1658787 - Drop addon_version field from on-save-recs ping

### DIFF
--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -9,9 +9,6 @@
     }
   },
   "properties": {
-    "addon_version": {
-      "type": "string"
-    },
     "events": {
       "items": {
         "properties": {
@@ -74,7 +71,6 @@
   "required": [
     "impression_id",
     "events",
-    "addon_version",
     "version",
     "locale"
   ],

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -5,9 +5,6 @@
   "properties": {
     @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
     @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
-    "addon_version": {
-      "type": "string"
-    },
     "events": {
       "type": "array",
       "items": {
@@ -53,7 +50,6 @@
   "required": [
     "impression_id",
     "events",
-    "addon_version",
     "version",
     "locale"
   ]

--- a/validation/activity-stream/on-save-recs.1.sample.pass.json
+++ b/validation/activity-stream/on-save-recs.1.sample.pass.json
@@ -3,7 +3,6 @@
   "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
   "version": "72.0a1",
   "release_channel": "nightly",
-  "addon_version": "20191119043902",
   "events": [
     {
       "action": "impression",


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

Scott and I figured out that the `addon_version` field is irrelevant to this new ping (it was carried over from some Activity Stream pings), so no need for the `addon_version` parameter I had added to this ping [earlier](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/608).