### PR TITLE
Add command for generating compact set of columns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="mozilla-pipeline-schemas",
-    version="0.1.0",
+    version="0.2.0",
     use_incremental=True,
     author="Mozilla Corporation",
     author_email="fx-data-dev@mozilla.org",

--- a/tests/test_mps_cli_bigquery.py
+++ b/tests/test_mps_cli_bigquery.py
@@ -1,13 +1,14 @@
 import os
+import json
 
 from click.testing import CliRunner
 
-from mozilla_pipeline_schemas.cli.bigquery import diff
+from mozilla_pipeline_schemas.cli.bigquery import diff, columns, transpile
 from utils import runif_cli_configured
 
 
 @runif_cli_configured
-def test_main(tmp_git):
+def test_bigquery_diff(tmp_git):
     # choose a base ref relative to HEAD, since the head ref may be master
     res = CliRunner().invoke(
         diff,
@@ -25,7 +26,7 @@ def test_main(tmp_git):
 
 
 @runif_cli_configured
-def test_main_duplicate(tmp_git):
+def test_bigquery_diff_duplicate(tmp_git):
     res = CliRunner().invoke(
         diff,
         [
@@ -44,3 +45,76 @@ def test_main_duplicate(tmp_git):
     assert (
         not next((tmp_git / "integration").glob("*.diff")).open().read()
     ), "diff should be empty"
+
+
+def test_bigquery_columns(tmp_path):
+    schema = [
+        {"name": "leaf", "mode": "NULLABLE", "type": "INT64"},
+        {"name": "repeated", "mode": "REPEATED", "type": "INT64"},
+        {
+            "name": "nested",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [{"name": "leaf", "type": "INT64", "mode": "NULLABLE"}],
+        },
+        {
+            "name": "repeated_nested",
+            "mode": "REPEATED",
+            "type": "RECORD",
+            "fields": [{"name": "leaf", "type": "INT64", "mode": "NULLABLE"}],
+        },
+    ]
+    expected = sorted(
+        [
+            "root.leaf INT64",
+            "root.nested.leaf INT64",
+            "root.repeated.[] INT64",
+            "root.repeated_nested.[].leaf INT64",
+        ]
+    )
+    path = tmp_path / "test"
+    with path.open("w") as fp:
+        json.dump(schema, fp)
+    res = CliRunner().invoke(columns, [str(path)], catch_exceptions=False)
+    assert res.exit_code == 0
+    output = res.output.strip().split("\n")
+    assert output == expected
+
+
+@runif_cli_configured
+def test_bigquery_columns_from_transpiled(tmp_path):
+    schema = {
+        "type": "object",
+        "properties": {
+            "leaf": {"type": "integer"},
+            "nested": {"type": "object", "properties": {"leaf": {"type": "integer"}}},
+            "repeated": {"type": "array", "items": {"type": "integer"}},
+            "repeated_nested": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"leaf": {"type": "integer"}},
+                },
+            },
+        },
+    }
+    expected = sorted(
+        [
+            "root.leaf INT64",
+            "root.nested.leaf INT64",
+            "root.repeated.[] INT64",
+            "root.repeated_nested.[].leaf INT64",
+        ]
+    )
+    path = tmp_path / "test"
+    with path.open("w") as fp:
+        json.dump(schema, fp)
+    res = CliRunner().invoke(transpile, [str(path)], catch_exceptions=False)
+    assert res.exit_code == 0
+
+    path = tmp_path / "transpiled"
+    with path.open("w") as fp:
+        fp.write(res.output)
+    res = CliRunner().invoke(columns, [str(path)], catch_exceptions=False)
+    output = res.output.strip().split("\n")
+    assert output == expected


### PR DESCRIPTION
This adds a `mps bigquery columns` command, which is intended to be used to make schema diffs a bit easier to read.

```bash
$ pip install .
$ git checkout generated-schemas
$ mps bigquery columns schemas/org-mozilla-reference-browser/baseline/baseline.1.bq 
root.additional_properties STRING
root.client_info.android_sdk_version STRING
root.client_info.app_build STRING
root.client_info.app_channel STRING
root.client_info.app_display_version STRING
root.client_info.architecture STRING
root.client_info.client_id STRING
root.client_info.device_manufacturer STRING
root.client_info.device_model STRING
root.client_info.first_run_date STRING
root.client_info.locale STRING
root.client_info.os STRING
root.client_info.os_version STRING
root.client_info.telemetry_sdk_build STRING
root.document_id STRING
root.events.[].category STRING
root.events.[].extra.[].key STRING
root.events.[].extra.[].value STRING
root.events.[].name STRING
root.events.[].timestamp INT64
root.metadata.geo.city STRING
root.metadata.geo.country STRING
root.metadata.geo.db_version STRING
root.metadata.geo.subdivision1 STRING
root.metadata.geo.subdivision2 STRING
root.metadata.header.date STRING
root.metadata.header.dnt STRING
root.metadata.header.x_debug_id STRING
root.metadata.header.x_pingsender_version STRING
root.metadata.user_agent.browser STRING
root.metadata.user_agent.os STRING
root.metadata.user_agent.version STRING
root.metrics.counter.glean_validation_metrics_ping_count INT64
root.metrics.labeled_counter.glean_error_invalid_label.[].key STRING
root.metrics.labeled_counter.glean_error_invalid_label.[].value INT64
root.metrics.labeled_counter.glean_error_invalid_overflow.[].key STRING
root.metrics.labeled_counter.glean_error_invalid_overflow.[].value INT64
root.metrics.labeled_counter.glean_error_invalid_state.[].key STRING
root.metrics.labeled_counter.glean_error_invalid_state.[].value INT64
root.metrics.labeled_counter.glean_error_invalid_value.[].key STRING
root.metrics.labeled_counter.glean_error_invalid_value.[].value INT64
root.metrics.string.glean_baseline_locale STRING
root.metrics.timespan.glean_baseline_duration.time_unit STRING
root.metrics.timespan.glean_baseline_duration.value INT64
root.normalized_app_name STRING
root.normalized_channel STRING
root.normalized_country_code STRING
root.normalized_os STRING
root.normalized_os_version STRING
root.ping_info.end_time STRING
root.ping_info.experiments.[].key STRING
root.ping_info.experiments.[].value.branch STRING
root.ping_info.experiments.[].value.extra.type STRING
root.ping_info.ping_type STRING
root.ping_info.reason STRING
root.ping_info.seq INT64
root.ping_info.start_time STRING
root.sample_id INT64
root.submission_timestamp TIMESTAMP
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
