### PR TITLE
Remove edge-validator from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@
 
 version: 2.1
 
-executors:
-  edge-validator:
-    docker:
-      - image: mozilla/edge-validator:v1.4.0
-
 jobs:
   test:
     docker:
@@ -44,57 +39,6 @@ jobs:
           root: /tmp
           paths:
             - integration
-  integrate:
-    executor: edge-validator
-    steps:
-      - checkout
-      - run:
-          <<: *checkout_upstream
-      - setup_remote_docker
-      - restore_cache:
-          key: mps-integration-data-v2
-      - run: &run_comparison
-          name: Run a comparison report
-          environment:
-            SOURCE_DATA_BUCKET: telemetry-parquet
-            SOURCE_DATA_PREFIX: sanitized-landfill-sample/v3
-          command: |
-            # Get the revisions for comparison. This will compare the tip of
-            # the PR against the upstream mozilla:master.
-            head_short_id=$(git rev-parse --short HEAD)
-            upstream_short_id=$(git rev-parse --short upstream/master)
-
-            # The `checkout` step defaults to $HOME/project (/app/project).
-            # Replace the container's submodule with the current state of this repo.
-            cd .. && rm -r mozilla-pipeline-schemas && mv project mozilla-pipeline-schemas
-
-            # Run the comparison report and store the artifacts for future viewing.
-            pipenv run \
-              python integration.py sync compare \
-                --report-path test-reports \
-                $upstream_short_id $head_short_id
-      - persist_to_workspace: &persist_artifacts
-          root: /app
-          paths:
-            - test-reports
-      - save_cache: &save_cache
-          paths:
-            - ~/resources
-          key: mps-integration-data-v2-{{ epoch }}
-  integrate-clean:
-    executor: edge-validator
-    steps:
-      - checkout
-      - run:
-          <<: *checkout_upstream
-      - setup_remote_docker
-      # We skip the restore_cache step so that the most recent cache is pristine once every day.
-      - run:
-          <<: *run_comparison
-      - persist_to_workspace:
-          <<: *persist_artifacts
-      - save_cache:
-          <<: *save_cache
   post-artifacts:
     docker:
       - image: circleci/node:8.10.0
@@ -121,23 +65,7 @@ workflows:
         - post-artifacts:
             requires:
               - test
-              - integrate
             filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-    nightly:
-      jobs:
-        - integrate-clean
-        - post-artifacts:
-            requires:
-              - integrate-clean
-      triggers:
-        - schedule:
-            # Run integration tests a little after midnight Pacific every day to pick up
-            # the latest data and ensure a clean cache for PRs the following day.
-            cron: "33 8 * * *"
-            filters:
-              branches:
-                only:
-                  - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,6 @@ workflows:
     build:
       jobs:
         - test
-        - integrate:
-            filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
         - post-artifacts:
             requires:
               - test

--- a/.circleci/post-artifact.js
+++ b/.circleci/post-artifact.js
@@ -7,43 +7,6 @@
 const fs = require("fs");
 const bot = require("circle-github-bot").create();
 
-function validation_report() {
-    let root = "/tmp/test-reports";
-    let files = fs.readdirSync(root);
-    console.log(files);
-
-    // An example listing of files. The diff is created by comparing differences
-    // between the upstream commit (mozilla-pipeline-schemas/master) and the report
-    // generated from the PR
-    //
-    // ["723350e.report.json", "c88ebe5.report.json", "c88ebe5-723350e.diff"]
-
-    let diff_file = files.find(x => x.endsWith(".diff"));
-    let diff_content = fs.readFileSync(root + "/" + diff_file, "utf8");
-    let [upstream, head] = diff_file.split(".")[0].split("-");
-
-    var body = "No content detected.";
-    if (diff_content) {
-        body = `<details>
-<summary>Click to expand!</summary>
-
-\`\`\`diff
-${diff_content}
-\`\`\`
-</details>
-`;
-    }
-
-    // Generate and post markdown
-    let content = `
-[Report for upstream](${bot.env.buildUrl}/artifacts/0/app/test-reports/${upstream}.report.json)
-[Report for latest commit](${bot.env.buildUrl}/artifacts/0/app/test-reports/${head}.report.json)
-
-#### \`${diff_file}\`
-${body}
-`;
-    return content;
-}
 
 function bigquery_diff() {
     let root = "/tmp/integration";
@@ -71,7 +34,6 @@ ${body}
 
 bot.comment(process.env.GH_AUTH_TOKEN, `
 ### Integration report for "${bot.env.commitMessage}"
-${validation_report()}
 
 ${bigquery_diff()}
 `);


### PR DESCRIPTION
This addresses failing nightly jobs that have occurred over the last few months since AWS buckets were deleted.  See #625

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
