### PR TITLE
Add fissionEnabled to new uninstall ping

### DIFF
--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -574,6 +574,10 @@
               "description": "maximum number of processes that will be launched for regular web content",
               "type": "integer"
             },
+            "fissionEnabled": {
+              "description": "whether fission is enabled this session, and subframes can load in a different process",
+              "type": "boolean"
+            },
             "intl": {
               "properties": {
                 "acceptLanguages": {


### PR DESCRIPTION
I think this is a weird ordering problem where the tests succeeded on
https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/629
but after merging, it was out of date with the new fissionEnabled field.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
