### PR TITLE
Bug 1674884 Remove NOT YET IMPLEMENTED for delete_after_days

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -38,7 +38,7 @@
               "type": "string"
             },
             "delete_after_days": {
-              "description": "NOT YET IMPLEMENTED: If present, a time_partitioning_expiration policy will be set on the destination stable table in BigQuery",
+              "description": "If present, a time_partitioning_expiration policy will be set on the destination stable table in BigQuery",
               "type": "integer"
             }
           },

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -33,7 +33,7 @@
           "properties": {
             "delete_after_days": {
               "type": "integer",
-              "description": "NOT YET IMPLEMENTED: If present, a time_partitioning_expiration policy will be set on the destination stable table in BigQuery"
+              "description": "If present, a time_partitioning_expiration policy will be set on the destination stable table in BigQuery"
             },
             "collect_through_date": {
               "type": "string",


### PR DESCRIPTION
`delete_after_days` is now used as source of truth for retention policies
in the ops logic per https://bugzilla.mozilla.org/show_bug.cgi?id=1674884

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
