### PR TITLE
Bug 1672763 - Add pocket-button ping.

### DIFF
--- a/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/schemas/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "This schema will be deprecated in favor of pocket-button as of FX84.",
   "mozPipelineMetadata": {
     "bq_dataset_family": "activity_stream",
     "bq_metadata_format": "structured",

--- a/schemas/activity-stream/pocket-button/pocket-button.1.schema.json
+++ b/schemas/activity-stream/pocket-button/pocket-button.1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "activity_stream",
+    "bq_metadata_format": "structured",
+    "bq_table": "pocket_button_v1",
+    "expiration_policy": {
+      "delete_after_days": 180
+    }
+  },
+  "properties": {
+    "events": {
+      "items": {
+        "properties": {
+          "action": {
+            "description": "An event identifier.",
+            "enum": [
+              "impression",
+              "click",
+              "save",
+              "remove"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "description": "An identifier for where the event occurred (e.g. what part of the Pocket button UI a click was performed on).",
+            "type": "string"
+          },
+          "position": {
+            "description": "A zero based integer indicating the position of this event.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "source"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "experiments": {
+      "additionalProperties": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "description": "An object to record all active experiments, experiments IDs are stored as keys, and the value object stores the branch information. Example: {\"experiment_1\": {\"branch\": \"control\"}, \"experiment_2\": {\"branch\": \"treatment\"}}. This deprecates the \"shield_id\" used in activity-stream and messaging-system.",
+      "type": "object"
+    },
+    "impression_id": {
+      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id.",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "model": {
+      "description": "(In the case of actions related to on-save recs) An identifier for the machine learning model used to generate the recommendations.",
+      "type": "string"
+    },
+    "pocket_logged_in_status":{
+      "description": "A boolean for whether the user was logged-in to the Pocket Firefox integration when they performed the indicated action(s). True = logged in.",
+       "type":"boolean"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "events",
+    "version",
+    "locale",
+    "pocket_logged_in_status"
+  ],
+  "title": "pocket-button",
+  "type": "object"
+}

--- a/schemas/activity-stream/pocket-button/pocket-button.1.schema.json
+++ b/schemas/activity-stream/pocket-button/pocket-button.1.schema.json
@@ -18,7 +18,7 @@
               "impression",
               "click",
               "save",
-              "remove"
+              "unpin"
             ],
             "type": "string"
           },

--- a/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
+++ b/templates/activity-stream/on-save-recs/on-save-recs.1.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "This schema will be deprecated in favor of pocket-button as of FX84.",
   "type": "object",
   "title": "on-save-recs",
   "properties": {

--- a/templates/activity-stream/pocket-button/pocket-button.1.schema.json
+++ b/templates/activity-stream/pocket-button/pocket-button.1.schema.json
@@ -15,7 +15,7 @@
               "impression",
               "click",
               "save",
-              "remove"
+              "unpin"
             ],
             "description": "An event identifier.",
             "type": "string"

--- a/templates/activity-stream/pocket-button/pocket-button.1.schema.json
+++ b/templates/activity-stream/pocket-button/pocket-button.1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "pocket-button",
+  "properties": {
+    @ACTIVITY-STREAM_IMPRESSIONID_1_JSON@,
+    @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "enum": [
+              "impression",
+              "click",
+              "save",
+              "remove"
+            ],
+            "description": "An event identifier.",
+            "type": "string"
+          },
+          "source": {
+            "description": "An identifier for where the event occurred (e.g. what part of the Pocket button UI a click was performed on).",
+            "type": "string"
+          },
+          "position": {
+            "description": "A zero based integer indicating the position of this event.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "source"
+        ]
+      }
+    },
+    "locale": {
+      "type": "string"
+    },
+    "model": {
+      "description": "(In the case of actions related to on-save recs) An identifier for the machine learning model used to generate the recommendations.",
+      "type": "string"
+    },
+    "pocket_logged_in_status": {
+      "description": "A boolean for whether the user was logged-in to the Pocket Firefox integration when they performed the indicated action(s). True = logged in.",
+      "type": "boolean"
+    },
+    "profile_creation_date": {
+      "type": "integer"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "impression_id",
+    "events",
+    "version",
+    "locale",
+    "pocket_logged_in_status"
+  ]
+}

--- a/validation/activity-stream/pocket-button.1.door_hanger_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.door_hanger_click.pass.json
@@ -1,0 +1,14 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "click",
+      "source": "learn_more"
+    },
+  ],
+  "profile_creation_date": 16587,
+  "pocket_logged_in_status": false
+}

--- a/validation/activity-stream/pocket-button.1.door_hanger_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.door_hanger_click.pass.json
@@ -7,7 +7,7 @@
     {
       "action": "click",
       "source": "learn_more"
-    },
+    }
   ],
   "profile_creation_date": 16587,
   "pocket_logged_in_status": false

--- a/validation/activity-stream/pocket-button.1.on_save_rec_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.on_save_rec_click.pass.json
@@ -1,0 +1,16 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "click",
+      "source": "on_save_recs",
+      "position": 0
+    },
+  ],
+  "profile_creation_date": 16587,
+  "model": "doc2vec",
+  "pocket_logged_in_status": true
+}

--- a/validation/activity-stream/pocket-button.1.on_save_rec_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.on_save_rec_click.pass.json
@@ -8,7 +8,7 @@
       "action": "click",
       "source": "on_save_recs",
       "position": 0
-    },
+    }
   ],
   "profile_creation_date": 16587,
   "model": "doc2vec",

--- a/validation/activity-stream/pocket-button.1.on_save_rec_save.pass.json
+++ b/validation/activity-stream/pocket-button.1.on_save_rec_save.pass.json
@@ -1,0 +1,16 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "save",
+      "source": "on_save_recs",
+      "position": 0
+    }
+  ],
+  "profile_creation_date": 16587,
+  "model": "doc2vec",
+  "pocket_logged_in_status": true
+}

--- a/validation/activity-stream/pocket-button.1.pocket_button_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.pocket_button_click.pass.json
@@ -1,0 +1,14 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "click",
+      "source": "save_button"
+    },
+  ],
+  "profile_creation_date": 16587,
+  "pocket_logged_in_status": false
+}

--- a/validation/activity-stream/pocket-button.1.pocket_button_click.pass.json
+++ b/validation/activity-stream/pocket-button.1.pocket_button_click.pass.json
@@ -7,7 +7,7 @@
     {
       "action": "click",
       "source": "save_button"
-    },
+    }
   ],
   "profile_creation_date": 16587,
   "pocket_logged_in_status": false

--- a/validation/activity-stream/pocket-button.1.pocket_button_remove.pass.json
+++ b/validation/activity-stream/pocket-button.1.pocket_button_remove.pass.json
@@ -7,7 +7,7 @@
     {
       "action": "remove",
       "source": "save_button"
-    },
+    }
   ],
   "profile_creation_date": 16587,
   "pocket_logged_in_status": false

--- a/validation/activity-stream/pocket-button.1.pocket_button_remove.pass.json
+++ b/validation/activity-stream/pocket-button.1.pocket_button_remove.pass.json
@@ -1,0 +1,14 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "remove",
+      "source": "save_button"
+    },
+  ],
+  "profile_creation_date": 16587,
+  "pocket_logged_in_status": false
+}

--- a/validation/activity-stream/pocket-button.1.pocket_button_unpin.pass.json
+++ b/validation/activity-stream/pocket-button.1.pocket_button_unpin.pass.json
@@ -5,7 +5,7 @@
   "release_channel": "nightly",
   "events": [
     {
-      "action": "remove",
+      "action": "unpin",
       "source": "save_button"
     }
   ],

--- a/validation/activity-stream/pocket-button.1.sample.pass.json
+++ b/validation/activity-stream/pocket-button.1.sample.pass.json
@@ -1,0 +1,26 @@
+{
+  "locale": "en-US",
+  "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "version": "72.0a1",
+  "release_channel": "nightly",
+  "events": [
+    {
+      "action": "impression",
+      "source": "on_save_recs",
+      "position": 0
+    },
+    {
+      "action": "impression",
+      "source": "on_save_recs",
+      "position": 1
+    },
+    {
+      "action": "impression",
+      "source": "on_save_recs",
+      "position": 2
+    }
+  ],
+  "profile_creation_date": 16587,
+  "model": "doc2vec",
+  "pocket_logged_in_status": true
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`

This PR updates a ping introduced in an earlier [PR](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/608) and generalizes it to track all types of interactions with the Pocket button in the nav bar. This ping does not have the FX client_id, but instead uses the Pocket impression_id as a user identifier.

The possible events it can be used to track, as well as test events that I've included:
- [impressions](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-f8b701b9cdee099f01bfb9798ef670e013a8ab9bd5fa47d55ac7e339675116d7) of on-save recommendations
- [clicks](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-7a72508d2dbb9e53f6025e0645f87a4ee5473c07916860fb4fa58018e475dbcc) of on-save recommendations
- [saves](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-925ad8a1425502fdb980d9559bcfcf65036370931af31319080482a57de6e81a) of on-save recommendations
- [clicks](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-af4dc0c2f2f2c098459ee30bae91cf8d69f47c3a670402e09155fd2e92a621b3) of the Pocket button itself
- [removal](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-fb6c0f86274f3b3e03b75534cd3815f22cbad5ebc8217a0273bc2b44716a978a) of the Pocket button from the nav bar
- [clicks](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/638/files#diff-6347021187cf7301911f188fe23d0d8ad3efaa3f862c71535f31e2390451c0c6) on any of the buttons/links in the door hanger menu shown when a logged-out user clicks the Pocket button