### PR TITLE
Add ingestion sink transforms via jnius

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:centos8.1.1911
-LABEL maintainer="Firefox Data Platform"
+LABEL maintainer="Mozilla Data Platform"
 
 # Install the appropriate software
 RUN dnf -y update && \
@@ -29,6 +29,8 @@ RUN git config --global user.email "mozilla-pipeline-schemas@mozilla.com"
 RUN git config --global user.name "Mozilla Pipeline Schemas"
 
 WORKDIR /app
+
+COPY --from=mozilla/ingestion-sink:latest /app/ingestion-sink/target /app/target
 
 # Install python dependencies
 COPY requirements.txt requirements-dev.txt ./

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ Note that Pioneer studies have a [slightly amended](README.pioneer.md) process.
 
 ### Prerequisites
 
-* [`CMake` (3.0+)](http://cmake.org/cmake/resources/software.html)
-* [`jq` (1.5+)](https://github.com/stedolan/jq)
-* `python` (3.6+)
-* Optional: `java 8`, `maven`
-* Optional: [Docker](https://www.docker.com/get-started)
+- [`CMake` (3.0+)](http://cmake.org/cmake/resources/software.html)
+- [`jq` (1.5+)](https://github.com/stedolan/jq)
+- `python` (3.6+)
+- Optional: `java 8`, `maven`
+- Optional: [Docker](https://www.docker.com/get-started)
 
 On MacOS, these prerequisites can be installed using [homebrew](https://brew.sh/):
+
 ```bash
 brew install cmake
 brew install jq
@@ -142,6 +143,42 @@ by pushing the PR's revisions to a branch of the main repo. We provide a script 
 
 For details on how to compare two arbitrary revisions, refer to the `integration` job in `.circleci/config.yml`. For more documentation, see [mozilla-services/edge-validator](https://github.com/mozilla-services/edge-validator).
 
+### `mps` command-line tool
+
+The repository has an `mps` command-line tool for checking on the output of
+schema transformations used for BigQuery. Enter the shell using
+`scripts/mps-shell`.
+
+To transpile a schema for Bigquery:
+
+```bash
+schema=schemas/glean/glean/glean.1.schema.json
+mps bigquery transpile $schema
+```
+
+It may be useful to look at a compact version of the output:
+
+```bash
+schema=schemas/glean/glean/glean.1.schema.json
+mps bigquery transpile $schema | mps bigquery columns /dev/stdin
+```
+
+The output of the ingestion sink can be viewed for validation documents.
+
+```bash
+validation=validation/glean/glean.1.baseline.pass.json
+mps bigquery transform $validation | jq
+```
+
+Any value that is not captured in the schema is put into `additional_properties`.
+
+```bash
+validation=validation/glean/glean.1.baseline.pass.json
+mps bigquery transform $validation | jq '.additional_properties'
+"{\"$schema\":\"moz://mozilla.org/schemas/glean/ping/1\"}"
+```
+
+
 ## Releases
 
 There is a daily series of tasks run by Airflow (see the
@@ -154,16 +191,16 @@ deployed to production BigQuery tables several times a week.
 
 ## Contributions
 
-* All non trivial contributions should start with a bug or issue being filed (if it is
+- All non trivial contributions should start with a bug or issue being filed (if it is
   a new feature please propose your design/approach before doing any work as not
   all feature requests are accepted).
-* If updating the glean schemas, be sure to update the changelog in
+- If updating the glean schemas, be sure to update the changelog in
   `include/glean/CHANGELOG.md`.
-* This repository is configured to auto-assign a reviewer on PR submission. If you
+- This repository is configured to auto-assign a reviewer on PR submission. If you
   do not receive a response within a few business days (or your request is
   urgent), please followup in the
   [#fx-metrics slack channel](https://mozilla.slack.com/messages/fx-metrics/).
-* If your PR is associated with a bugzilla bug, please title it `Bug XXX - Description of change`, that way the [Bugzilla PR Linker](https://github.com/mozilla/github-bugzilla-pr-linker) will automatically add an attachment with your PR to bugzilla, for future reference.
+- If your PR is associated with a bugzilla bug, please title it `Bug XXX - Description of change`, that way the [Bugzilla PR Linker](https://github.com/mozilla/github-bugzilla-pr-linker) will automatically add an attachment with your PR to bugzilla, for future reference.
 
 ### Notes
 

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -103,7 +103,12 @@ def transform(validation_source_path, jars):
     """Convert the validation document into a format for insertion into
     BigQuery.
 
-    This function relies on the java libraries for gcp-ingestion/ingestion-sink.
+    This command relies on the java libraries for gcp-ingestion/ingestion-sink.
+    Update these using `scripts/download-java-dependencies`.
+    
+    This command also requires jnius. See installation instructions here:
+    https://pyjnius.readthedocs.io/en/stable/installation.html#installation
+    
     The documents will be transformed according to the shape of the transpiled
     schemas. If field is not captured by the schemas, it will go into
     additional_properties.

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -96,4 +96,4 @@ def diff(base_ref, head_ref, input_directory, output_directory):
     default=str(ROOT / "target"),
 )
 def transform(validation_source_path, jars):
-    transform_sink(validation_source_path, jars)
+    click.echo(json.dumps(transform_sink(validation_source_path, jars), indent=2))

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -1,17 +1,13 @@
+import click
 import json
 from pathlib import Path
-
-import click
-
-from mozilla_pipeline_schemas.bigquery import checkout_transpile_schemas
-from mozilla_pipeline_schemas.bigquery import transpile as transpile_path
-from mozilla_pipeline_schemas.bigquery import write_schema_diff
-from mozilla_pipeline_schemas.sink import transform_sink
-from mozilla_pipeline_schemas.utils import (
-    compute_compact_columns,
-    get_repository_root,
-    run,
+from mozilla_pipeline_schemas.utils import run, get_repository_root
+from mozilla_pipeline_schemas.bigquery import (
+    transpile as transpile_path,
+    checkout_transpile_schemas,
+    write_schema_diff,
 )
+from mozilla_pipeline_schemas.sink import transform_sink
 
 ROOT = get_repository_root()
 

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -6,6 +6,7 @@ import click
 from mozilla_pipeline_schemas.bigquery import checkout_transpile_schemas
 from mozilla_pipeline_schemas.bigquery import transpile as transpile_path
 from mozilla_pipeline_schemas.bigquery import write_schema_diff
+from mozilla_pipeline_schemas.sink import transform_sink
 from mozilla_pipeline_schemas.utils import (
     compute_compact_columns,
     get_repository_root,
@@ -89,3 +90,14 @@ def diff(base_ref, head_ref, input_directory, output_directory):
         prefix="compact_schema",
         options="--new-file --exclude *.bq",
     )
+
+
+@bigquery.command()
+@click.argument("validation_source_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--jars",
+    type=click.Path(exists=True, file_okay=False),
+    default=str(ROOT / "target"),
+)
+def transform(validation_source_path, jars):
+    transform_sink(validation_source_path, jars)

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -1,13 +1,17 @@
-import click
 import json
 from pathlib import Path
-from mozilla_pipeline_schemas.utils import run, get_repository_root
-from mozilla_pipeline_schemas.bigquery import (
-    transpile as transpile_path,
-    checkout_transpile_schemas,
-    write_schema_diff,
-)
+
+import click
+
+from mozilla_pipeline_schemas.bigquery import checkout_transpile_schemas
+from mozilla_pipeline_schemas.bigquery import transpile as transpile_path
+from mozilla_pipeline_schemas.bigquery import write_schema_diff
 from mozilla_pipeline_schemas.sink import transform_sink
+from mozilla_pipeline_schemas.utils import (
+    compute_compact_columns,
+    get_repository_root,
+    run,
+)
 
 ROOT = get_repository_root()
 

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -96,4 +96,12 @@ def diff(base_ref, head_ref, input_directory, output_directory):
     default=str(ROOT / "target"),
 )
 def transform(validation_source_path, jars):
+    """Convert the validation document into a format for insertion into
+    BigQuery.
+
+    This function relies on the java libraries for gcp-ingestion/ingestion-sink.
+    The documents will be transformed according to the shape of the transpiled
+    schemas. If field is not captured by the schemas, it will go into
+    additional_properties.
+    """
     click.echo(json.dumps(transform_sink(validation_source_path, jars), indent=2))

--- a/mozilla_pipeline_schemas/cli/bigquery.py
+++ b/mozilla_pipeline_schemas/cli/bigquery.py
@@ -105,10 +105,10 @@ def transform(validation_source_path, jars):
 
     This command relies on the java libraries for gcp-ingestion/ingestion-sink.
     Update these using `scripts/download-java-dependencies`.
-    
+
     This command also requires jnius. See installation instructions here:
     https://pyjnius.readthedocs.io/en/stable/installation.html#installation
-    
+
     The documents will be transformed according to the shape of the transpiled
     schemas. If field is not captured by the schemas, it will go into
     additional_properties.

--- a/mozilla_pipeline_schemas/sink.py
+++ b/mozilla_pipeline_schemas/sink.py
@@ -96,16 +96,21 @@ def _transform_sink(queue, validation_source_path, jars):
 
 
 def transform_sink(validation_source_path, jars):
-    # The tests do not play well with jnius for some reason (likely involving
-    # subprocesses internals). Instead, we can run this function inside of a
-    # process which has the nice side-effect of limiting the environment
-    # changes. This seems to work well enough for command-line use (and is not
-    # much slower than without the process call). See some of the following
-    # links for using multiprocessing and why pytest might deadlock without the
-    # spawn context.
-    # https://stackoverflow.com/a/2046630
-    # https://pythonspeed.com/articles/python-multiprocessing/
-    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+"""
+Transform a single payload at ` validation_source_path` into a format for insertion into BigQuery.
+
+The tests do not play well with jnius for some reason (likely involving
+subprocesses internals). Instead, we run this function inside of a
+process which has the nice side-effect of limiting the environment
+changes. This seems to work well enough for command-line use (and is not
+much slower than without the process call). See some of the following
+links for using multiprocessing and why pytest might deadlock without the
+spawn context:
+
+https://stackoverflow.com/a/2046630
+https://pythonspeed.com/articles/python-multiprocessing/
+https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+"""
     ctx = mp.get_context("spawn")
     q = ctx.Queue()
     p = ctx.Process(target=_transform_sink, args=(q, validation_source_path, jars))

--- a/mozilla_pipeline_schemas/sink.py
+++ b/mozilla_pipeline_schemas/sink.py
@@ -1,0 +1,101 @@
+import json
+import os
+import tarfile
+import tempfile
+from base64 import b64encode
+from pathlib import Path
+
+import click
+
+from .bigquery import transpile
+
+ROOT = Path(__file__).parent.parent
+
+
+def temp_pubsub_message(validation_path: Path) -> Path:
+    """Write a document as a base64 encoded message into a temporary path."""
+    output = Path(tempfile.mkdtemp()) / "pubsub.json"
+    namespace = validation_path.parent.name
+    doctype, version = validation_path.name.split(".")[:2]
+    data = json.dumps(
+        dict(
+            attributeMap=dict(
+                zip(
+                    ["document_namespace", "document_type", "document_version"],
+                    [namespace, doctype, version],
+                )
+            ),
+            payload=b64encode(validation_path.read_bytes()).decode(),
+        )
+    ).encode("utf-8")
+    output.write_bytes(data)
+    return output
+
+
+def temp_schema_artifact(validation_path: Path) -> Path:
+    """Creates a schema artifact given the name of a validation document.
+    
+    in: validation/telemetry/telemetry.main.4.pass.json
+    in: schemas/telemetry/main/main.4.schema.json
+    out: {tmp_path}/schema.tar.gz
+    """
+    namespace = validation_path.parent.name
+    doctype, version = validation_path.name.split(".")[:2]
+
+    # schema relative to the validation path
+    root = validation_path.parent.parent.parent
+    schema_path = (
+        root / "schemas" / namespace / doctype / f"{doctype}.{version}.schema.json"
+    )
+    if not schema_path.exists():
+        raise ValueError(f"Schema not found in {schema_path.relative_to(root)}")
+
+    tmp_path = Path(tempfile.mkdtemp())
+
+    # generate the bigquery schema
+    prefix = str(schema_path.relative_to(root)).replace("schema.json", "bq")
+    transpile_path = tmp_path / prefix
+    transpile_path.parent.mkdir(parents=True)
+    transpile_path.write_text(json.dumps(transpile(schema_path)))
+
+    # add it to a tarball
+    artifact_path = tmp_path / "schema.tar.gz"
+    with tarfile.open(str(artifact_path), "w:gz") as tar:
+        tar.add(transpile_path, arcname=f"mozilla-pipeline-schemas/{prefix}")
+
+    return artifact_path
+
+
+@click.command()
+@click.argument("source_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--jars",
+    type=click.Path(exists=True, file_okay=False),
+    default=str(ROOT / "target"),
+)
+def transform_sink(source_path, jars):
+    os.environ["CLASSPATH"] = ":".join(
+        [str(p.resolve()) for p in Path(jars).glob("**/*.jar")]
+    )
+    # now we can import Java with the classpath set
+    from jnius import autoclass
+
+    SinkConfig = autoclass("com.mozilla.telemetry.ingestion.sink.config.SinkConfig")
+
+    schema_location = temp_schema_artifact(Path(source_path))
+    intermediate_path = temp_pubsub_message(Path(source_path))
+
+    config = dict(
+        SCHEMAS_LOCATION=str(schema_location),
+        INPUT_PIPE=str(intermediate_path),
+        OUTPUT_PIPE="-",
+        OUTPUT_FORMAT="payload",
+    )
+    print(config)
+    os.environ.update(config)
+
+    SinkConfig.getInput(SinkConfig.getOutput()).run()
+
+
+if __name__ == "__main__":
+    transform_sink()

--- a/scripts/download-java-dependencies
+++ b/scripts/download-java-dependencies
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Download relevant java dependencies for schema validation and document
+# transformations
+
+set -ex
+cd "$(dirname "$0")/.."
+
+image=mozilla/ingestion-sink:latest
+
+# https://stackoverflow.com/a/31316636
+container_id=$(docker create $image)
+
+# default behavior is inconsistent when copying a directory from the container
+# https://docs.docker.com/engine/reference/commandline/cp/
+mkdir -p target
+docker cp "$container_id":/app/ingestion-sink/target ./.
+docker rm -v "$container_id"
+
+# now fetch dependencies from maven
+mvn dependency:copy-dependencies

--- a/scripts/mps-shell
+++ b/scripts/mps-shell
@@ -7,5 +7,6 @@ cd "$(dirname "$0")/.."
 docker run \
     --rm \
     --volume "$(pwd)":/app \
+    --volume /app/target \
     -it mozilla-pipeline-schemas:latest \
     bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,22 @@ from mozilla_pipeline_schemas.utils import get_repository_root, run
 ROOT = get_repository_root()
 SCHEMAS_ROOT = ROOT / "schemas"
 VALIDATION_ROOT = ROOT / "validation"
+JARS_ROOT = ROOT / "target"
+
+
+@pytest.fixture()
+def schemas_root():
+    return SCHEMAS_ROOT
+
+
+@pytest.fixture()
+def validation_root():
+    return VALIDATION_ROOT
+
+
+@pytest.fixture()
+def jars_root():
+    return JARS_ROOT
 
 
 def load_schemas():

--- a/tests/test_mps_sink.py
+++ b/tests/test_mps_sink.py
@@ -1,0 +1,15 @@
+from mozilla_pipeline_schemas.sink import transform_sink
+from utils import runif_sink_configured
+import json
+
+
+@runif_sink_configured
+def test_transform_sink_main_min(tmp_path, validation_root, jars_root):
+    path = validation_root / "telemetry/main.4.min.pass.json"
+    transformed = transform_sink(path, jars_root)
+    original = json.loads(path.read_text())
+
+    # additional properties is added
+    assert transformed["additional_properties"] == "{}"
+    # fields are snake cased
+    assert transformed["client_id"] == original["clientId"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,15 +1,28 @@
 from mozilla_pipeline_schemas.utils import run
+from mozilla_pipeline_schemas.sink import transform_sink
+from pathlib import Path
+import tempfile
 
-
+# Only run these relatively expensive checks once per test run
 ENABLE_MPS_BIGQUERY_TESTS = False
-MISCONFIGURED_REASON = "failed to configure mps bigquery"
+BIGQUERY_MISCONFIGURED_REASON = "failed to configure mps bigquery"
 try:
     run("diff --version")
     run("git --version")
     run("jsonschema-transpiler --version")
     ENABLE_MPS_BIGQUERY_TESTS = True
 except Exception as ex:
-    MISCONFIGURED_REASON = f"{MISCONFIGURED_REASON}: {str(ex)}"
+    BIGQUERY_MISCONFIGURED_REASON = f"{BIGQUERY_MISCONFIGURED_REASON}: {str(ex)}"
+
+# the target directory is relative to this module
+ENABLE_MPS_SINK_TESTS = False
+SINK_MISCONFIGURED_REASON = "failed to configure mps bigquery sink"
+root = Path(__file__).parent.parent
+try:
+    transform_sink(root / "validation/telemetry/main.4.min.pass.json", root / "target")
+    ENABLE_MPS_SINK_TESTS = True
+except Exception as ex:
+    SINK_MISCONFIGURED_REASON = f"{SINK_MISCONFIGURED_REASON}: {str(ex)}"
 
 
 def runif_cli_configured(func):
@@ -17,5 +30,14 @@ def runif_cli_configured(func):
     import pytest
 
     return pytest.mark.skipif(
-        not ENABLE_MPS_BIGQUERY_TESTS, reason=MISCONFIGURED_REASON
+        not ENABLE_MPS_BIGQUERY_TESTS, reason=BIGQUERY_MISCONFIGURED_REASON
+    )(func)
+
+
+def runif_sink_configured(func):
+    import pytest
+
+    # sink and bigquery tests must be configured
+    return pytest.mark.skipif(
+        not ENABLE_MPS_SINK_TESTS, reason=SINK_MISCONFIGURED_REASON
     )(func)


### PR DESCRIPTION
This uses ingestion-sink to transform a validation document into a document that can be inserted into a BigQuery table.

This can be used in a few ways. 

```bash
# check what a transformed document might look like
python -m mozilla_pipeline_schemas.sink validation/pioneer-citp-news-disinfo/measurements.1.sample.pass.json | jq

# check the results of additional properties
python -m mozilla_pipeline_schemas.sink validation/telemetry/main.4.sample.pass.json | jq '.additional_properties | fromjson'
```

This will probably the base of more sophisticated testing for schema coverage i.e. [bug 1450290](https://bugzilla.mozilla.org/show_bug.cgi?id=1450290). An uber jar containing the class definition `com.mozilla.telemetry.ingestion.sink.config.SinkConfig` should be in the `CLASSPATH`. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
