### PR TITLE
Add a schema for the Ion/Rally demographics ping

### DIFF
--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,0 +1,169 @@
+{
+  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "pioneer_core",
+    "bq_metadata_format": "pioneer",
+    "bq_table": "demographic_survey_v1"
+  },
+  "properties": {
+    "age": {
+      "additionalProperties": false,
+      "properties": {
+        "19_24": {
+          "type": "boolean"
+        },
+        "25_34": {
+          "type": "boolean"
+        },
+        "35_44": {
+          "type": "boolean"
+        },
+        "45_54": {
+          "type": "boolean"
+        },
+        "55_64": {
+          "type": "boolean"
+        },
+        "over_65": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "education": {
+      "additionalProperties": false,
+      "properties": {
+        "associates_degree": {
+          "type": "boolean"
+        },
+        "bachelors_degree": {
+          "type": "boolean"
+        },
+        "graduate_degree": {
+          "type": "boolean"
+        },
+        "high_school_graduate_or_equivalent": {
+          "type": "boolean"
+        },
+        "less_than_high_school": {
+          "type": "boolean"
+        },
+        "some_college_but_no_degree_or_in_progress": {
+          "type": "boolean"
+        },
+        "some_high_school": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "gender": {
+      "additionalProperties": false,
+      "properties": {
+        "decline": {
+          "type": "boolean"
+        },
+        "female": {
+          "type": "boolean"
+        },
+        "male": {
+          "type": "boolean"
+        },
+        "neither": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "income": {
+      "additionalProperties": false,
+      "properties": {
+        "0_24999": {
+          "type": "boolean"
+        },
+        "100000_149999": {
+          "type": "boolean"
+        },
+        "25000_49999": {
+          "type": "boolean"
+        },
+        "50000_74999": {
+          "type": "boolean"
+        },
+        "75000_99999": {
+          "type": "boolean"
+        },
+        "ge_150000": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "origin": {
+      "additionalProperties": false,
+      "properties": {
+        "hispanicLatinoSpanish": {
+          "type": "boolean"
+        },
+        "other": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "races": {
+      "additionalProperties": false,
+      "properties": {
+        "american_indian_or_alaska_native": {
+          "type": "boolean"
+        },
+        "asian_indian": {
+          "type": "boolean"
+        },
+        "black_or_african_american": {
+          "type": "boolean"
+        },
+        "chamorro": {
+          "type": "boolean"
+        },
+        "chinese": {
+          "type": "boolean"
+        },
+        "filipino": {
+          "type": "boolean"
+        },
+        "japanese": {
+          "type": "boolean"
+        },
+        "korean": {
+          "type": "boolean"
+        },
+        "native_hawaiian": {
+          "type": "boolean"
+        },
+        "other_pacific_islander": {
+          "type": "boolean"
+        },
+        "samoan": {
+          "type": "boolean"
+        },
+        "some_other_race": {
+          "type": "boolean"
+        },
+        "vietnamese": {
+          "type": "boolean"
+        },
+        "white": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "zipCode": {
+      "type": "string"
+    }
+  },
+  "title": "demographic-survey",
+  "type": "object"
+}

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "demographic-survey",
+  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
+  "properties": {
+    "age": {
+      "type": "object",
+      "properties": {
+        "19_24": {
+          "type": "boolean"
+        },
+        "25_34": {
+          "type": "boolean"
+        },
+        "35_44": {
+          "type": "boolean"
+        },
+        "45_54": {
+          "type": "boolean"
+        },
+        "55_64": {
+          "type": "boolean"
+        },
+        "over_65": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "gender": {
+      "type": "object",
+      "properties": {
+        "male": {
+          "type": "boolean"
+        },
+        "female": {
+          "type": "boolean"
+        },
+        "neither": {
+          "type": "boolean"
+        },
+        "decline": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "origin": {
+      "type": "object",
+      "properties": {
+        "hispanicLatinoSpanish": {
+          "type": "boolean"
+        },
+        "other": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "education": {
+      "type": "object",
+      "properties": {
+        "less_than_high_school": {
+          "type": "boolean"
+        },
+        "some_high_school": {
+          "type": "boolean"
+        },
+        "high_school_graduate_or_equivalent": {
+          "type": "boolean"
+        },
+        "some_college_but_no_degree_or_in_progress": {
+          "type": "boolean"
+        },
+        "associates_degree": {
+          "type": "boolean"
+        },
+        "bachelors_degree": {
+          "type": "boolean"
+        },
+        "graduate_degree": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "income": {
+      "type": "object",
+      "properties": {
+        "0_24999": {
+          "type": "boolean"
+        },
+        "25000_49999": {
+          "type": "boolean"
+        },
+        "50000_74999": {
+          "type": "boolean"
+        },
+        "75000_99999": {
+          "type": "boolean"
+        },
+        "100000_149999": {
+          "type": "boolean"
+        },
+        "ge_150000": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "races": {
+      "type": "object",
+      "properties": {
+        "white": {
+          "type": "boolean"
+        },
+        "american_indian_or_alaska_native": {
+          "type": "boolean"
+        },
+        "chinese": {
+          "type": "boolean"
+        },
+        "filipino": {
+          "type": "boolean"
+        },
+        "asian_indian": {
+          "type": "boolean"
+        },
+        "vietnamese": {
+          "type": "boolean"
+        },
+        "korean": {
+          "type": "boolean"
+        },
+        "japanese": {
+          "type": "boolean"
+        },
+        "black_or_african_american": {
+          "type": "boolean"
+        },
+        "native_hawaiian": {
+          "type": "boolean"
+        },
+        "samoan": {
+          "type": "boolean"
+        },
+        "chamorro": {
+          "type": "boolean"
+        },
+        "other_pacific_islander": {
+          "type": "boolean"
+        },
+        "some_other_race": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "zipCode": {
+      "type": "string"
+    }
+  }
+}

--- a/validation/pioneer-core/demographic-survey.1.full.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.full.pass.json
@@ -1,0 +1,21 @@
+{
+    "age": {
+        "25_34": true
+    },
+    "gender": {
+        "decline": true
+    },
+    "origin": {
+        "other": true
+    },
+    "education": {
+        "high_school_graduate_or_equivalent": true
+    },
+    "income": {
+        "25000_49999": true
+    },
+    "races": {
+        "black_or_african_american": true,
+        "native_hawaiian": true
+    }
+}

--- a/validation/pioneer-core/demographic-survey.1.partial.fail.json
+++ b/validation/pioneer-core/demographic-survey.1.partial.fail.json
@@ -1,0 +1,9 @@
+{
+    "age": {
+        "25_34": true
+    },
+    "races": {
+        "native_hawaiian": true,
+		"not_listed_unknown_valie": true
+    }
+}

--- a/validation/pioneer-core/demographic-survey.1.partial.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.partial.pass.json
@@ -1,0 +1,9 @@
+{
+    "age": {
+        "25_34": true
+    },
+    "races": {
+        "black_or_african_american": true,
+        "native_hawaiian": true
+    }
+}


### PR DESCRIPTION
This adds the schema for allowing the Rally Core Add-on to send demographic pings. See mozilla-ion/ion-core-addon#182 (data review is [here](https://github.com/mozilla-ion/ion-core-addon/pull/139#issuecomment-736024232)).

Note that all of the sections and the fields are optional.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
