### PR TITLE
Bug 1687027 - Add a schema for InfoBar of Messaging System

### DIFF
--- a/schemas/messaging-system/infobar/infobar.1.schema.json
+++ b/schemas/messaging-system/infobar/infobar.1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "messaging_system",
+    "bq_metadata_format": "structured",
+    "bq_table": "infobar_v1",
+    "expiration_policy": {
+      "delete_after_days": 180
+    }
+  },
+  "properties": {
+    "addon_version": {
+      "type": "string"
+    },
+    "browser_session_id": {
+      "description": "A mirror of the browser sessionId, as defined in https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/main/main.4.schema.json",
+      "type": "string"
+    },
+    "client_id": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "event": {
+      "description": "An event identifier",
+      "type": "string"
+    },
+    "event_context": {
+      "description": "A string that describes the context about this event",
+      "type": "string"
+    },
+    "experiments": {
+      "additionalProperties": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "description": "An object to record all active experiments, experiments IDs are stored as keys, and the value object stores the branch information. Example: {\"experiment_1\": {\"branch\": \"control\"}, \"experiment_2\": {\"branch\": \"treatment\"}}. This deprecates the \"shield_id\" used in activity-stream and messaging-system.",
+      "type": "object"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "message_id": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "client_id",
+    "event",
+    "message_id",
+    "addon_version",
+    "version",
+    "locale"
+  ],
+  "title": "infobar",
+  "type": "object"
+}

--- a/templates/messaging-system/infobar/infobar.1.schema.json
+++ b/templates/messaging-system/infobar/infobar.1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "infobar",
+  "properties": {
+    @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
+    "client_id": {
+      "type": "string",
+      @COMMON_PATTERN_UUID_1_JSON@
+    },
+    "event": {
+        "description": "An event identifier",
+        "type": "string"
+    },
+    "event_context": {
+        "description": "A string that describes the context about this event",
+        "type": "string"
+    },
+    "message_id": {
+        "type": "string"
+    },
+    "addon_version": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "browser_session_id": {
+      "description": "A mirror of the browser sessionId, as defined in https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/main/main.4.schema.json",
+      "type": "string"
+    }
+  },
+  "required": [
+    "client_id",
+    "event",
+    "message_id",
+    "addon_version",
+    "version",
+    "locale"
+  ]
+}

--- a/validation/messaging-system/infobar.1.event.pass.json
+++ b/validation/messaging-system/infobar.1.event.pass.json
@@ -1,0 +1,15 @@
+{
+  "experiments": {
+    "exp1": {
+      "branch": "treatment-a"
+    }
+  },
+  "addon_version": "20210115035053",
+  "release_channel": "release",
+  "locale": "en-US",
+  "event": "IMPRESSION",
+  "client_id": "c4beb4bf-4feb-9c4e-9587-9323b28c2e50",
+  "version": "86",
+  "message_id": "INFOBAR_ACTION_86",
+  "browser_session_id": "93714e76-9919-ca49-b697-5e7c09a1394f"
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`


r? @jklukas

The traffic volume for this ping type is estimated to be similar to `messaging_system.onboarding`.

Strangely, the local tests failed to run,`./scripts/mps-test` hung with the following logging:

```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.6.8, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /app
plugins: xdist-2.1.0, forked-1.3.0
collecting 0 items  
```

