### PR TITLE
Bug 1686229 - Add loadStatus to the third-party-modules ping

### DIFF
--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1444,6 +1444,10 @@
                       "description": "Time spent loading this module, in milliseconds.",
                       "type": "number"
                     },
+                    "loadStatus": {
+                      "description": "The status of DLL load. This corresponds to enum ModuleLoadInfo::Status.",
+                      "type": "integer"
+                    },
                     "moduleIndex": {
                       "description": "Index of the element in the modules array that contains details about the module that was loaded during this event.",
                       "minimum": 0,

--- a/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -113,6 +113,10 @@
                     "isDependent": {
                       "description": "True if the module is included in the executable's Import Directory Table.",
                       "type": "boolean"
+                    },
+                    "loadStatus": {
+                      "description": "The status of DLL load. This corresponds to enum ModuleLoadInfo::Status.",
+                      "type": "integer"
                     }
                   },
                   "required": [

--- a/validation/telemetry/third-party-modules.4.sample.pass.json
+++ b/validation/telemetry/third-party-modules.4.sample.pass.json
@@ -412,7 +412,8 @@
                         "processUptimeMS": 1844676547,
                         "baseAddress": "0x7ffed1330000",
                         "moduleIndex": 0,
-                        "isDependent": false
+                        "isDependent": false,
+                        "loadStatus": 0
                     }
                 ]
             }


### PR DESCRIPTION
This patch adds a new optional integer field `loadStatus`
in the existing third-party-modules ping.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
