### PR TITLE
Bug 1682364 - Add missing fields to Messaging System schema

### DIFF
--- a/schemas/messaging-system/snippets/snippets.1.schema.json
+++ b/schemas/messaging-system/snippets/snippets.1.schema.json
@@ -52,6 +52,14 @@
       "description": "[DEPRECATED]: use `experiments` instead. A semicolon separated string to store a list of Shield study IDs",
       "type": "string"
     },
+    "source": {
+      "description": "A string describing the source of this event",
+      "enum": [
+        "NEWTAB_FOOTER_BAR",
+        "NEWTAB_FOOTER_BAR_CONTENT"
+      ],
+      "type": "string"
+    },
     "version": {
       "type": "string"
     }

--- a/schemas/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
+++ b/schemas/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
@@ -12,6 +12,10 @@
     "addon_version": {
       "type": "string"
     },
+    "browser_session_id": {
+      "description": "A mirror of the browser sessionId, as defined in https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/main/main.4.schema.json",
+      "type": "string"
+    },
     "client_id": {
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
       "type": "string"

--- a/templates/messaging-system/snippets/snippets.1.schema.json
+++ b/templates/messaging-system/snippets/snippets.1.schema.json
@@ -37,6 +37,11 @@
     },
     "profile_creation_date": {
       "type": "integer"
+    },
+    "source": {
+      "description": "A string describing the source of this event",
+      "type": "string",
+      "enum": [ "NEWTAB_FOOTER_BAR", "NEWTAB_FOOTER_BAR_CONTENT" ]
     }
   },
   "required": [

--- a/templates/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
+++ b/templates/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
@@ -33,6 +33,10 @@
     },
     "profile_creation_date": {
       "type": "integer"
+    },
+    "browser_session_id": {
+      "description": "A mirror of the browser sessionId, as defined in https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/main/main.4.schema.json",
+      "type": "string"
     }
   },
   "required": [

--- a/validation/messaging-system/snippets.1.source.fail.json
+++ b/validation/messaging-system/snippets.1.source.fail.json
@@ -1,0 +1,20 @@
+{
+  "client_id": "94642acb-4996-034b-916c-147da723cc41",
+  "event": "IMPRESSION",
+  "event_context": "n/a",
+  "message_id": "TRAILHEAD_CARD_1",
+  "locale": "en-US",
+  "version": "71.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "profile_creation_date": 17817,
+  "experiments": {
+    "exp_id_foo": {
+      "branch": "control"
+    },
+    "exp_id_bar": {
+      "branch": "treatment"
+    }
+  },
+  "source": "UNKNOWN_SOURCE"
+}

--- a/validation/messaging-system/snippets.1.source.pass.json
+++ b/validation/messaging-system/snippets.1.source.pass.json
@@ -1,0 +1,20 @@
+{
+  "client_id": "94642acb-4996-034b-916c-147da723cc41",
+  "event": "IMPRESSION",
+  "event_context": "n/a",
+  "message_id": "TRAILHEAD_CARD_1",
+  "locale": "en-US",
+  "version": "71.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "profile_creation_date": 17817,
+  "experiments": {
+    "exp_id_foo": {
+      "branch": "control"
+    },
+    "exp_id_bar": {
+      "branch": "treatment"
+    }
+  },
+  "source": "NEWTAB_FOOTER_BAR"
+}

--- a/validation/messaging-system/whats-new-panel.1.browser_session_id.pass.json
+++ b/validation/messaging-system/whats-new-panel.1.browser_session_id.pass.json
@@ -1,0 +1,12 @@
+{
+  "client_id": "94642acb-4996-034b-916c-147da723cc41",
+  "event": "IMPRESSION",
+  "event_context": "n/a",
+  "message_id": "WNP_MESSAGE",
+  "locale": "en-US",
+  "version": "71.0a1",
+  "release_channel": "nightly",
+  "addon_version": "20181206092619",
+  "profile_creation_date": 17817,
+  "browser_session_id": "e7e52665-7db3-f348-9918-e93160eb2ef3"
+}


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

This adds two missing fields to the Messaging System schema as described in this [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1682364#c5).