### PR TITLE
Bug 1689758 - Set citp-news-disinfo study table to 90 day expiration

### DIFF
--- a/schemas/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
+++ b/schemas/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
@@ -3,7 +3,10 @@
   "mozPipelineMetadata": {
     "bq_dataset_family": "pioneer_citp_news_disinfo",
     "bq_metadata_format": "pioneer",
-    "bq_table": "measurements_v1"
+    "bq_table": "measurements_v1",
+    "expiration_policy": {
+      "delete_after_days": 90
+    }
   },
   "properties": {
     "WebScience.Measurements.LinkExposure": {

--- a/templates/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
+++ b/templates/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
@@ -1,6 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "mozPipelineMetadata": {
+    "bq_metadata_format": "pioneer",
+    "expiration_policy": {
+      "delete_after_days": 90
+    }
+  },
   "properties": {
     "WebScience.SurveyId": {
         "type": "string",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1689758)

It's likely that this gets extended by another 90 days within the next few days, but I rather set this policy now to ensure that something like [bug 1690126](https://bugzilla.mozilla.org/show_bug.cgi?id=1690126) doesn't creep up on us again. It was oversight on my part that we didn't have this policy set up on study launch. 

cc @akohlbre 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
