### PR TITLE
Bug 1690637 - Set citp-new-disinfo table retention to 180 days

### DIFF
--- a/schemas/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
+++ b/schemas/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "pioneer",
     "bq_table": "measurements_v1",
     "expiration_policy": {
-      "delete_after_days": 90
+      "delete_after_days": 180
     }
   },
   "properties": {

--- a/templates/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
+++ b/templates/pioneer-citp-news-disinfo/measurements/measurements.1.schema.json
@@ -4,7 +4,7 @@
   "mozPipelineMetadata": {
     "bq_metadata_format": "pioneer",
     "expiration_policy": {
-      "delete_after_days": 90
+      "delete_after_days": 180
     }
   },
   "properties": {


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1690637)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
