### PR TITLE
Rename the `hispanicLatinoSpanish` field in Rally pings

### DIFF
--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -104,6 +104,10 @@
       "additionalProperties": false,
       "properties": {
         "hispanicLatinoSpanish": {
+          "description": "This field is deprecated in favour of hispanicLatinxSpanish",
+          "type": "boolean"
+        },
+        "hispanicLatinxSpanish": {
           "type": "boolean"
         },
         "other": {

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -50,6 +50,10 @@
       "type": "object",
       "properties": {
         "hispanicLatinoSpanish": {
+          "description": "This field is deprecated in favour of hispanicLatinxSpanish",
+          "type": "boolean"
+        },
+        "hispanicLatinxSpanish": {
           "type": "boolean"
         },
         "other": {

--- a/validation/pioneer-core/demographic-survey.1.origin.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.origin.pass.json
@@ -1,0 +1,12 @@
+{
+    "age": {
+        "25_34": true
+    },
+    "origin": {
+        "hispanicLatinxSpanish": true
+    },
+    "races": {
+        "black_or_african_american": true,
+        "native_hawaiian": true
+    }
+}


### PR DESCRIPTION
The field is renamed from `hispanicLatinoSpanish` to `hispanicLatinxSpanish`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
