### PR TITLE
[Bug 1694254] Add environment.settings.attribution.dltoken field

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -493,6 +493,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -433,6 +433,10 @@
             "ua": {
               "type": "string",
               "description": "derived user agent, see bug 1595063"
+            },
+            "dltoken": {
+              "type": "string",
+              "description": "Unique token created at Firefox download time, see bug 1677497"
             }
           }
         },


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
