### PR TITLE
Fix #660: Add the rate metric type

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -303,9 +303,11 @@
               "additionalProperties": false,
               "properties": {
                 "denominator": {
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "numerator": {
+                  "minimum": 0,
                   "type": "integer"
                 }
               },
@@ -581,9 +583,11 @@
             "additionalProperties": false,
             "properties": {
               "denominator": {
+                "minimum": 0,
                 "type": "integer"
               },
               "numerator": {
+                "minimum": 0,
                 "type": "integer"
               }
             },

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -300,7 +300,20 @@
         "labeled_rate": {
           "additionalProperties": {
             "additionalProperties": {
-              "type": "integer"
+              "additionalProperties": false,
+              "properties": {
+                "denominator": {
+                  "type": "integer"
+                },
+                "numerator": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "numerator",
+                "denominator"
+              ],
+              "type": "object"
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
@@ -565,7 +578,20 @@
         },
         "rate": {
           "additionalProperties": {
-            "type": "integer"
+            "additionalProperties": false,
+            "properties": {
+              "denominator": {
+                "type": "integer"
+              },
+              "numerator": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "numerator",
+              "denominator"
+            ],
+            "type": "object"
           },
           "propertyNames": {
             "maxLength": 61,

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -69,3 +69,5 @@
 
 - Pull client_info definitions from the glean source code (see:
   `scripts/extract_glean_client_info_descriptions`)
+  
+- The `rate` metric type is an object with a `numerator` and `denominator`.

--- a/templates/include/glean/rate.1.schema.json
+++ b/templates/include/glean/rate.1.schema.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "numerator": {
-      "type": "integer"
+      "type": "integer",
+      "minimum": 0
     },
     "denominator": {
-      "type": "integer"
+      "type": "integer",
+      "minimum": 0
     }
   },
   "required": [

--- a/templates/include/glean/rate.1.schema.json
+++ b/templates/include/glean/rate.1.schema.json
@@ -1,3 +1,16 @@
 {
-  "type": "integer"
+  "type": "object",
+  "properties": {
+    "numerator": {
+      "type": "integer"
+    },
+    "denominator": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "numerator",
+    "denominator"
+  ],
+  "additionalProperties": false
 }

--- a/validation/glean/glean.1.baseline.pass.json
+++ b/validation/glean/glean.1.baseline.pass.json
@@ -240,7 +240,10 @@
       }
     },
     "rate": {
-      "examples.rate_example": 23
+      "examples.rate_example": {
+        "numerator": 2,
+        "denominator": 3
+      }
     },
     "labeled_rate": {
       "examples.labeled_rate_example": {

--- a/validation/glean/glean.1.baseline.pass.json
+++ b/validation/glean/glean.1.baseline.pass.json
@@ -247,8 +247,14 @@
     },
     "labeled_rate": {
       "examples.labeled_rate_example": {
-        "a": 12,
-        "b": 8
+        "a": {
+          "numerator": 1,
+          "denominator": 2
+        },
+        "b": {
+          "numerator": 1,
+          "denominator": 2
+        }
       }
     },
     "uuid": {

--- a/validation/glean/glean.1.invalid_use_counter.fail.json
+++ b/validation/glean/glean.1.invalid_use_counter.fail.json
@@ -110,7 +110,10 @@
       "examples.usage_example": true
     },
     "rate": {
-      "examples.rate_example": 23
+      "examples.rate_example": {
+        "numerator": 2,
+        "denominator": 3
+      }
     }
   },
   "events": [

--- a/validation/glean/glean.1.metrics.pass.json
+++ b/validation/glean/glean.1.metrics.pass.json
@@ -110,7 +110,10 @@
       "examples.usage_example": true
     },
     "rate": {
-      "examples.rate_example": 23
+      "examples.rate_example": {
+        "numerator": 2,
+        "denominator": 3
+      }
     }
   },
   "events": [


### PR DESCRIPTION
Technically this is a backward-incompatible change.  However, there is nothing in the wild sending a `rate` metric type yet, so I believe this is ok (and should be even when we get to the schema generator part of this).  But please check my assumption, @frank and @acmiyaguchi .

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`
