### PR TITLE
[Bug 1709182] Add environment.settings.update.background column in ping table schemas

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -678,6 +678,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -678,6 +678,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -685,6 +685,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -678,6 +678,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -678,6 +678,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -677,6 +677,10 @@
                   "description": "The state of the `app.update.auto` pref.",
                   "type": "boolean"
                 },
+                "background": {
+                  "description": "Indicates whether updates may be installed when Firefox is not running.",
+                  "type": "boolean"
+                },
                 "channel": {
                   "description": "The update channel from the defaults only. Does not include the partner bits.",
                   "type": "string"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -601,6 +601,10 @@
             "enabled": {
               "type": "boolean",
               "description": "The state of the `app.update.enabled` pref."
+            },
+            "background": {
+              "type": "boolean",
+              "description": "Indicates whether updates may be installed when Firefox is not running."
             }
           }
         },

--- a/validation/telemetry/event.4.sample.pass.json
+++ b/validation/telemetry/event.4.sample.pass.json
@@ -154,7 +154,8 @@
       "update": {
         "channel": "default",
         "enabled": true,
-        "autoDownload": true
+        "autoDownload": true,
+        "background": true
       },
       "userPrefs": {
         "browser.cache.disk.capacity": 358400,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1709182

The field was added in https://hg.mozilla.org/mozilla-central/rev/eb40719c0827ea6c5a06bcf497bedc2a7df9d7be

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
