### PR TITLE
Add some missing crash annotations

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1418,6 +1418,10 @@
               "description": "<string>, Comma-separated list of enabled experimental features from about:preferences#experimental.",
               "type": "string"
             },
+            "GPUProcessLaunchCount": {
+              "description": "<integer>, Number of times the GPU process was launched.",
+              "type": "string"
+            },
             "IndexedDBShutdownTimeout": {
               "description": "<json>, This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
@@ -1460,6 +1464,10 @@
             },
             "ProductName": {
               "description": "Firefox",
+              "type": "string"
+            },
+            "ProfilerChildShutdownPhase": {
+              "description": "<string>, When a child process shuts down, this describes if the profiler is running, and the point the profiler shutdown sequence has reached.",
               "type": "string"
             },
             "PurgeablePhysicalMemory": {

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -85,6 +85,10 @@
               "description": "<string>, Comma-separated list of enabled experimental features from about:preferences#experimental.",
               "type": "string"
             },
+            "GPUProcessLaunchCount": {
+              "description": "<integer>, Number of times the GPU process was launched.",
+              "type": "string"
+            },
             "IndexedDBShutdownTimeout": {
               "description": "<json>, This annotation is present if IndexedDB shutdown was not finished in time and the browser was crashed instead of waiting for IndexedDB shutdown to finish. The condition that caused the hang is contained in the annotation. The condition is constructed by stringifying status of objects which blocked IndexedDB shutdown. Objects are divided into three groups: FactoryOperations, LiveDatabases and DatabaseMaintenances. Each group is reported separately and contains the number of objects in the group and status of individual objects in the group (duplicit entries are removed): \"GroupName: N (objectStatus1, objectStatus2, ...)\" where N is the number of objects in the group. Status of individual objects is constructed by taking selected object properties. Properties which contain origin strings are anonymized.",
               "type": "string"
@@ -135,6 +139,10 @@
             },
             "ProductName": {
               "description": "Firefox",
+              "type": "string"
+            },
+            "ProfilerChildShutdownPhase": {
+              "description": "<string>, When a child process shuts down, this describes if the profiler is running, and the point the profiler shutdown sequence has reached.",
               "type": "string"
             },
             "QuotaManagerShutdownTimeout": {


### PR DESCRIPTION
GPUProcessLaunchCount and ProfilerChildShutdownPhase were added to
crash pings in https://bugzilla.mozilla.org/show_bug.cgi?id=1710448
and https://bugzilla.mozilla.org/show_bug.cgi?id=1704680, need to
update schemas to match
