### PR TITLE
Rally: update the demographic survey schema to take the new `exactIncome` field

### DIFF
--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -58,6 +58,9 @@
       },
       "type": "object"
     },
+    "exactIncome": {
+      "type": "number"
+    },
     "gender": {
       "additionalProperties": false,
       "properties": {
@@ -78,6 +81,7 @@
     },
     "income": {
       "additionalProperties": false,
+      "description": "this field is deprecated in favor of exactIncome",
       "properties": {
         "0_24999": {
           "type": "boolean"

--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
+  "$comment": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "bq_dataset_family": "pioneer_core",

--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey",
+  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "bq_dataset_family": "pioneer_core",
@@ -59,6 +59,7 @@
       "type": "object"
     },
     "exactIncome": {
+      "description": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey",
       "type": "number"
     },
     "gender": {

--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -81,7 +81,7 @@
     },
     "income": {
       "additionalProperties": false,
-      "description": "this field is deprecated in favor of exactIncome",
+      "description": "this field has been deprecated in favor of exactIncome",
       "properties": {
         "0_24999": {
           "type": "boolean"

--- a/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/schemas/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -150,6 +150,9 @@
         "native_hawaiian": {
           "type": "boolean"
         },
+        "other_asian": {
+          "type": "boolean"
+        },
         "other_pacific_islander": {
           "type": "boolean"
         },

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,11 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "title": "demographic-survey",
   "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "pioneer_core",
+    "bq_metadata_format": "pioneer",
+    "bq_table": "demographic_survey_v1"
+  },
   "properties": {
     "age": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "19_24": {
           "type": "boolean"
@@ -26,28 +29,83 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
+    },
+    "education": {
+      "additionalProperties": false,
+      "properties": {
+        "associates_degree": {
+          "type": "boolean"
+        },
+        "bachelors_degree": {
+          "type": "boolean"
+        },
+        "graduate_degree": {
+          "type": "boolean"
+        },
+        "high_school_graduate_or_equivalent": {
+          "type": "boolean"
+        },
+        "less_than_high_school": {
+          "type": "boolean"
+        },
+        "some_college_but_no_degree_or_in_progress": {
+          "type": "boolean"
+        },
+        "some_high_school": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
     "gender": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "male": {
+        "decline": {
           "type": "boolean"
         },
         "female": {
           "type": "boolean"
         },
-        "neither": {
+        "male": {
           "type": "boolean"
         },
-        "decline": {
+        "neither": {
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
+    },
+    "income": {
+      "description": "this field is deprecated in favor of exactIncome",
+      "additionalProperties": false,
+      "properties": {
+        "0_24999": {
+          "type": "boolean"
+        },
+        "100000_149999": {
+          "type": "boolean"
+        },
+        "25000_49999": {
+          "type": "boolean"
+        },
+        "50000_74999": {
+          "type": "boolean"
+        },
+        "75000_99999": {
+          "type": "boolean"
+        },
+        "ge_150000": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "exactIncome": {
+      "type": "number"
     },
     "origin": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "hispanicLatinoSpanish": {
           "description": "This field is deprecated in favour of hispanicLatinxSpanish",
@@ -60,66 +118,21 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": false
-    },
-    "education": {
-      "type": "object",
-      "properties": {
-        "less_than_high_school": {
-          "type": "boolean"
-        },
-        "some_high_school": {
-          "type": "boolean"
-        },
-        "high_school_graduate_or_equivalent": {
-          "type": "boolean"
-        },
-        "some_college_but_no_degree_or_in_progress": {
-          "type": "boolean"
-        },
-        "associates_degree": {
-          "type": "boolean"
-        },
-        "bachelors_degree": {
-          "type": "boolean"
-        },
-        "graduate_degree": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "income": {
-      "type": "object",
-      "properties": {
-        "0_24999": {
-          "type": "boolean"
-        },
-        "25000_49999": {
-          "type": "boolean"
-        },
-        "50000_74999": {
-          "type": "boolean"
-        },
-        "75000_99999": {
-          "type": "boolean"
-        },
-        "100000_149999": {
-          "type": "boolean"
-        },
-        "ge_150000": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
+      "type": "object"
     },
     "races": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "white": {
+        "american_indian_or_alaska_native": {
           "type": "boolean"
         },
-        "american_indian_or_alaska_native": {
+        "asian_indian": {
+          "type": "boolean"
+        },
+        "black_or_african_american": {
+          "type": "boolean"
+        },
+        "chamorro": {
           "type": "boolean"
         },
         "chinese": {
@@ -128,41 +141,37 @@
         "filipino": {
           "type": "boolean"
         },
-        "asian_indian": {
-          "type": "boolean"
-        },
-        "vietnamese": {
+        "japanese": {
           "type": "boolean"
         },
         "korean": {
           "type": "boolean"
         },
-        "japanese": {
-          "type": "boolean"
-        },
-        "black_or_african_american": {
-          "type": "boolean"
-        },
         "native_hawaiian": {
-          "type": "boolean"
-        },
-        "samoan": {
-          "type": "boolean"
-        },
-        "chamorro": {
           "type": "boolean"
         },
         "other_pacific_islander": {
           "type": "boolean"
         },
+        "samoan": {
+          "type": "boolean"
+        },
         "some_other_race": {
+          "type": "boolean"
+        },
+        "vietnamese": {
+          "type": "boolean"
+        },
+        "white": {
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "zipCode": {
       "type": "string"
     }
-  }
+  },
+  "title": "demographic-survey",
+  "type": "object"
 }

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -1,14 +1,11 @@
 {
-  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "mozPipelineMetadata": {
-    "bq_dataset_family": "pioneer_core",
-    "bq_metadata_format": "pioneer",
-    "bq_table": "demographic_survey_v1"
-  },
+  "type": "object",
+  "title": "demographic-survey",
+  "$comment": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey",
   "properties": {
     "age": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "19_24": {
           "type": "boolean"
@@ -29,83 +26,28 @@
           "type": "boolean"
         }
       },
-      "type": "object"
-    },
-    "education": {
-      "additionalProperties": false,
-      "properties": {
-        "associates_degree": {
-          "type": "boolean"
-        },
-        "bachelors_degree": {
-          "type": "boolean"
-        },
-        "graduate_degree": {
-          "type": "boolean"
-        },
-        "high_school_graduate_or_equivalent": {
-          "type": "boolean"
-        },
-        "less_than_high_school": {
-          "type": "boolean"
-        },
-        "some_college_but_no_degree_or_in_progress": {
-          "type": "boolean"
-        },
-        "some_high_school": {
-          "type": "boolean"
-        }
-      },
-      "type": "object"
+      "additionalProperties": false
     },
     "gender": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
-        "decline": {
+        "male": {
           "type": "boolean"
         },
         "female": {
           "type": "boolean"
         },
-        "male": {
-          "type": "boolean"
-        },
         "neither": {
           "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "income": {
-      "description": "this field is deprecated in favor of exactIncome",
-      "additionalProperties": false,
-      "properties": {
-        "0_24999": {
-          "type": "boolean"
         },
-        "100000_149999": {
-          "type": "boolean"
-        },
-        "25000_49999": {
-          "type": "boolean"
-        },
-        "50000_74999": {
-          "type": "boolean"
-        },
-        "75000_99999": {
-          "type": "boolean"
-        },
-        "ge_150000": {
+        "decline": {
           "type": "boolean"
         }
       },
-      "type": "object"
-    },
-    "exactIncome": {
-      "type": "number"
+      "additionalProperties": false
     },
     "origin": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "hispanicLatinoSpanish": {
           "description": "This field is deprecated in favour of hispanicLatinxSpanish",
@@ -118,21 +60,70 @@
           "type": "boolean"
         }
       },
-      "type": "object"
+      "additionalProperties": false
+    },
+    "education": {
+      "type": "object",
+      "properties": {
+        "less_than_high_school": {
+          "type": "boolean"
+        },
+        "some_high_school": {
+          "type": "boolean"
+        },
+        "high_school_graduate_or_equivalent": {
+          "type": "boolean"
+        },
+        "some_college_but_no_degree_or_in_progress": {
+          "type": "boolean"
+        },
+        "associates_degree": {
+          "type": "boolean"
+        },
+        "bachelors_degree": {
+          "type": "boolean"
+        },
+        "graduate_degree": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "income": {
+      "description": "this field has been deprecated in favor of exactIncome",
+      "type": "object",
+      "properties": {
+        "0_24999": {
+          "type": "boolean"
+        },
+        "25000_49999": {
+          "type": "boolean"
+        },
+        "50000_74999": {
+          "type": "boolean"
+        },
+        "75000_99999": {
+          "type": "boolean"
+        },
+        "100000_149999": {
+          "type": "boolean"
+        },
+        "ge_150000": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "exactIncome": {
+      "type": "number"
     },
     "races": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
+        "white": {
+          "type": "boolean"
+        },
         "american_indian_or_alaska_native": {
-          "type": "boolean"
-        },
-        "asian_indian": {
-          "type": "boolean"
-        },
-        "black_or_african_american": {
-          "type": "boolean"
-        },
-        "chamorro": {
           "type": "boolean"
         },
         "chinese": {
@@ -141,37 +132,41 @@
         "filipino": {
           "type": "boolean"
         },
-        "japanese": {
-          "type": "boolean"
-        },
-        "korean": {
-          "type": "boolean"
-        },
-        "native_hawaiian": {
-          "type": "boolean"
-        },
-        "other_pacific_islander": {
-          "type": "boolean"
-        },
-        "samoan": {
-          "type": "boolean"
-        },
-        "some_other_race": {
+        "asian_indian": {
           "type": "boolean"
         },
         "vietnamese": {
           "type": "boolean"
         },
-        "white": {
+        "korean": {
+          "type": "boolean"
+        },
+        "japanese": {
+          "type": "boolean"
+        },
+        "black_or_african_american": {
+          "type": "boolean"
+        },
+        "native_hawaiian": {
+          "type": "boolean"
+        },
+        "samoan": {
+          "type": "boolean"
+        },
+        "chamorro": {
+          "type": "boolean"
+        },
+        "other_pacific_islander": {
+          "type": "boolean"
+        },
+        "some_other_race": {
           "type": "boolean"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "zipCode": {
       "type": "string"
     }
-  },
-  "title": "demographic-survey",
-  "type": "object"
+  }
 }

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "demographic-survey",
-  "$comment": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey",
+  "$comment": "mozilla-ion/ion-core-addon#182 - Collect demographic information",
   "properties": {
     "age": {
       "type": "object",
@@ -115,7 +115,8 @@
       "additionalProperties": false
     },
     "exactIncome": {
-      "type": "number"
+      "type": "number",
+      "description": "https://github.com/mozilla-rally/rally-core-addon/pull/624 - new exactIncome field for Rally Core Add-On demographic survey"
     },
     "races": {
       "type": "object",

--- a/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
+++ b/templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json
@@ -156,6 +156,9 @@
         "chamorro": {
           "type": "boolean"
         },
+        "other_asian": {
+          "type": "boolean"
+        },
         "other_pacific_islander": {
           "type": "boolean"
         },

--- a/validation/pioneer-core/demographic-survey.1.deprecated-income-range.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.deprecated-income-range.pass.json
@@ -11,7 +11,9 @@
   "education": {
     "high_school_graduate_or_equivalent": true
   },
-  "exactIncome": 45000,
+  "income": {
+    "25000_49999": true
+  },
   "races": {
     "black_or_african_american": true,
     "native_hawaiian": true

--- a/validation/pioneer-core/demographic-survey.1.deprecated-income-range.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.deprecated-income-range.pass.json
@@ -2,14 +2,14 @@
   "age": {
     "25_34": true
   },
-  "gender": {
-    "decline": true
-  },
   "origin": {
     "other": true
   },
   "education": {
     "high_school_graduate_or_equivalent": true
+  },
+  "gender": {
+    "decline": true
   },
   "income": {
     "25000_49999": true

--- a/validation/pioneer-core/demographic-survey.1.full.pass.json
+++ b/validation/pioneer-core/demographic-survey.1.full.pass.json
@@ -15,5 +15,6 @@
   "races": {
     "black_or_african_american": true,
     "native_hawaiian": true
-  }
+  },
+  "zipCode": "11111"
 }


### PR DESCRIPTION
This deprecates the `income` field of `templates/pioneer-core/demographic-survey/demographic-survey.1.schema.json` in favor of a new field,`exactIncome`. Additionally, it adds `other_asian` as an option to the `race` entry.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
