### PR TITLE
Bug 1719353 Add x_foxsec_ip_reputation metadata field

### DIFF
--- a/schemas/metadata/decoded/decoded.1.schema.json
+++ b/schemas/metadata/decoded/decoded.1.schema.json
@@ -61,6 +61,10 @@
               "description": "X-Debug-Id HTTP header",
               "type": "string"
             },
+            "x_foxsec_ip_reputation": {
+              "description": "X-Foxsec-IP-Reputation header",
+              "type": "string"
+            },
             "x_pingsender_version": {
               "description": "X-PingSender-Version HTTP header",
               "type": "string"

--- a/schemas/metadata/error/error.1.schema.json
+++ b/schemas/metadata/error/error.1.schema.json
@@ -135,6 +135,10 @@
       "description": "Deprecated; will always be null",
       "type": "string"
     },
+    "x_foxsec_ip_reputation": {
+      "description": "X-Foxsec-IP-Reputation header",
+      "type": "string"
+    },
     "x_pingsender_version": {
       "description": "X-Pingsender-Version header",
       "type": "string"

--- a/schemas/metadata/pioneer-decoded/pioneer-decoded.1.schema.json
+++ b/schemas/metadata/pioneer-decoded/pioneer-decoded.1.schema.json
@@ -61,6 +61,10 @@
               "description": "X-Debug-Id HTTP header",
               "type": "string"
             },
+            "x_foxsec_ip_reputation": {
+              "description": "X-Foxsec-IP-Reputation header",
+              "type": "string"
+            },
             "x_pingsender_version": {
               "description": "X-PingSender-Version HTTP header",
               "type": "string"

--- a/schemas/metadata/pioneer-error/pioneer-error.1.schema.json
+++ b/schemas/metadata/pioneer-error/pioneer-error.1.schema.json
@@ -152,6 +152,10 @@
       "description": "Deprecated; will always be null",
       "type": "string"
     },
+    "x_foxsec_ip_reputation": {
+      "description": "X-Foxsec-IP-Reputation header",
+      "type": "string"
+    },
     "x_pingsender_version": {
       "description": "X-Pingsender-Version header",
       "type": "string"

--- a/schemas/metadata/pioneer-ingestion/pioneer-ingestion.1.schema.json
+++ b/schemas/metadata/pioneer-ingestion/pioneer-ingestion.1.schema.json
@@ -53,6 +53,10 @@
               "description": "X-Debug-Id HTTP header",
               "type": "string"
             },
+            "x_foxsec_ip_reputation": {
+              "description": "X-Foxsec-IP-Reputation header",
+              "type": "string"
+            },
             "x_pingsender_version": {
               "description": "X-PingSender-Version HTTP header",
               "type": "string"

--- a/schemas/metadata/raw/raw.1.schema.json
+++ b/schemas/metadata/raw/raw.1.schema.json
@@ -60,6 +60,10 @@
       "description": "X-Forwarded-For header containing intermediate IP addresses",
       "type": "string"
     },
+    "x_foxsec_ip_reputation": {
+      "description": "X-Foxsec-IP-Reputation header",
+      "type": "string"
+    },
     "x_pingsender_version": {
       "description": "X-Pingsender-Version header",
       "type": "string"

--- a/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
+++ b/schemas/metadata/structured-ingestion/structured-ingestion.1.schema.json
@@ -52,6 +52,10 @@
               "description": "X-Debug-Id HTTP header",
               "type": "string"
             },
+            "x_foxsec_ip_reputation": {
+              "description": "X-Foxsec-IP-Reputation header",
+              "type": "string"
+            },
             "x_pingsender_version": {
               "description": "X-PingSender-Version HTTP header",
               "type": "string"

--- a/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
+++ b/schemas/metadata/telemetry-ingestion/telemetry-ingestion.1.schema.json
@@ -52,6 +52,10 @@
               "description": "X-Debug-Id HTTP header",
               "type": "string"
             },
+            "x_foxsec_ip_reputation": {
+              "description": "X-Foxsec-IP-Reputation header",
+              "type": "string"
+            },
             "x_pingsender_version": {
               "description": "X-PingSender-Version HTTP header",
               "type": "string"

--- a/templates/include/metadata/ingestionCommonMetadata.1.schema.json
+++ b/templates/include/metadata/ingestionCommonMetadata.1.schema.json
@@ -18,6 +18,10 @@
       "description": "X-Debug-Id HTTP header",
       "type": "string"
     },
+    "x_foxsec_ip_reputation": {
+      "description": "X-Foxsec-IP-Reputation header",
+      "type": "string"
+    },
     "x_source_tags": {
       "description": "X-Source-Tags HTTP header",
       "type": "string"

--- a/templates/include/metadata/raw.1.schema.json
+++ b/templates/include/metadata/raw.1.schema.json
@@ -48,6 +48,10 @@
   "type": "string",
   "description": "X-Debug-Id header"
 },
+"x_foxsec_ip_reputation": {
+  "type": "string",
+  "description": "X-Foxsec-IP-Reputation header"
+},
 "x_pingsender_version": {
   "type": "string",
   "description": "X-Pingsender-Version header"


### PR DESCRIPTION
Per the [Contextual Services Anti-Fraud System plan](https://docs.google.com/document/d/1Db3zxNNeEmJGUtuOYBWwk-DJvBknQDxA0AlfBcYp3RU/edit)

It's unfortunate that this will add a metadata field to all schemas, even though
we only expect this to be set for contextual-services documents.
We could consider folding this value into `x_source_tags` instead within the
Dataflow job to avoid making this schema change at all. We would lose the data
for `payload_bytes_raw` output, though.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
