### PR TITLE
Bug 1719315 - Add the URL metric type to the Glean schema

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -467,6 +467,17 @@
           },
           "type": "object"
         },
+        "url": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "maxLength": 61,
+            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
         "uuid": {
           "additionalProperties": {
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -469,6 +469,7 @@
         },
         "url": {
           "additionalProperties": {
+            "pattern": "^((?!data)([a-zA-Z][a-zA-Z0-9-\\+\\.]*):(.*))$",
             "type": "string"
           },
           "propertyNames": {

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Added a `url` metric type. See [Bug 1719315](https://bugzilla.mozilla.org/show_bug.cgi?id=1719315).
+
 - Added `x_source_tags` field to header metadata fields. See [Bug 1655477](https://bugzilla.mozilla.org/show_bug.cgi?id=1655477).
 
 - Added `jwe` metric type to the metrics. See [Bug 1654809](https://bugzilla.mozilla.org/show_bug.cgi?id=1654809).

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -153,7 +153,7 @@
         },
         "url": {
           @GLEAN_BASE_OBJECT_1_JSON@,
-          "additionalProperties": @GLEAN_STRING_1_JSON@
+          "additionalProperties": @GLEAN_URL_1_JSON@
         },
         "jwe": {
           @GLEAN_BASE_OBJECT_1_JSON@,

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -151,6 +151,10 @@
           @GLEAN_BASE_OBJECT_1_JSON@,
           "additionalProperties": @GLEAN_UUID_1_JSON@
         },
+        "url": {
+          @GLEAN_BASE_OBJECT_1_JSON@,
+          "additionalProperties": @GLEAN_STRING_1_JSON@
+        },
         "jwe": {
           @GLEAN_BASE_OBJECT_1_JSON@,
           "additionalProperties": @GLEAN_STRING_1_JSON@

--- a/templates/include/glean/url.1.schema.json
+++ b/templates/include/glean/url.1.schema.json
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}

--- a/templates/include/glean/url.1.schema.json
+++ b/templates/include/glean/url.1.schema.json
@@ -1,3 +1,4 @@
 {
-  "type": "string"
+  "type": "string",
+  "pattern": "^((?!data)([a-zA-Z][a-zA-Z0-9-\\+\\.]*):(.*))$"
 }

--- a/validation/glean/glean.1.metrics.pass.json
+++ b/validation/glean/glean.1.metrics.pass.json
@@ -87,6 +87,9 @@
     "datetime": {
       "examples.datetime_example": "2018-09-13T19:08:00Z"
     },
+    "url": {
+      "examples.url_example": "glean://test"
+    },
     "rate": {
       "examples.rate_example": {
         "numerator": 2,

--- a/validation/glean/glean.1.metrics.pass.json
+++ b/validation/glean/glean.1.metrics.pass.json
@@ -88,7 +88,7 @@
       "examples.datetime_example": "2018-09-13T19:08:00Z"
     },
     "url": {
-      "examples.url_example": "glean://test"
+      "examples.url_example": "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
     },
     "rate": {
       "examples.rate_example": {


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
