### PR TITLE
Bug 1729576 - Add scenario to QuickSuggest pings

### DIFF
--- a/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -50,6 +50,15 @@
       "description": "The reporting URL of the ad, normally pointing to the ad partner's reporting endpoint. It's URL encoded",
       "type": "string"
     },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "enum": [
+        "history",
+        "offline",
+        "online"
+      ],
+      "type": "string"
+    },
     "version": {
       "description": "Firefox version",
       "type": "string"

--- a/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -58,6 +58,15 @@
       "description": "The reporting URL of the ad, normally pointing to the ad partner's reporting endpoint. It's URL encoded",
       "type": "string"
     },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "enum": [
+        "history",
+        "offline",
+        "online"
+      ],
+      "type": "string"
+    },
     "search_query": {
       "description": "The user's typed-in search query in the AwesomeBar. Note that this ping is only sent when a QuickSuggest ad is shown for the current search query, so we don't have to limit its size here",
       "type": "string"

--- a/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -36,6 +36,11 @@
     "locale": {
       "description": "User's current locale",
       "type": "string"
+    },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "type": "string",
+      "enum": ["history", "offline", "online"]
     }
   },
   "required": [

--- a/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -48,6 +48,11 @@
     "locale": {
       "description": "User's current locale",
       "type": "string"
+    },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "type": "string",
+      "enum": ["history", "offline", "online"]
     }
   },
   "required": [

--- a/validation/contextual-services/quicksuggest-click.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-click.1.event.pass.json
@@ -7,6 +7,7 @@
   "locale": "en-US",
   "version": "87.0",
   "release_channel": "release",
+  "scenario": "offline",
   "experiments": {
     "exp_id_foo": {
       "branch": "control"

--- a/validation/contextual-services/quicksuggest-impression.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-impression.1.event.pass.json
@@ -10,6 +10,7 @@
   "locale": "en-US",
   "version": "87.0",
   "release_channel": "release",
+  "scenario": "offline",
   "experiments": {
     "exp_id_foo": {
       "branch": "control"


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] If the PR comes from a fork, trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional) and review the report posted in the comments.

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`

This adds a `scenario` field to all the QuickSuggest pings. The pipeline side of change for [bug 1729576](https://bugzilla.mozilla.org/show_bug.cgi?id=1729576).

r? @jklukas 
