### PR TITLE
Use fastestmirror for dnf packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
       - run: &checkout_upstream
           name: Checkout upstream
           command: |
-            git remote add upstream git@github.com:mozilla-services/mozilla-pipeline-schemas.git
+            git remote add upstream https://github.com/mozilla-services/mozilla-pipeline-schemas.git
             git fetch --all
       - setup_remote_docker:
           docker_layer_caching: true
           version: 19.03.13
       - run:
           name: Build Docker image
-          command: docker build -t mps .
+          command: docker build --pull -t mps .
       - run:
           name: Test Code
           command: docker run mps

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM centos:centos8.1.1911
 LABEL maintainer="Mozilla Data Platform"
 
 # Install the appropriate software
-RUN dnf -y update && \
+RUN echo 'fastestmirror=1' >> /etc/dnf/dnf.conf && \
+    dnf -y update && \
     dnf -y install epel-release && \
     dnf -y install \
         cmake \


### PR DESCRIPTION
and use `--pull` when building docker image
and use https remote url to avoid ssh host key verification bug (running test locally via `circleci build --job test` stalls on asking for host key verification when using the ssh url)