### PR TITLE
Compare integration tests against previous commit on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,14 @@ jobs:
       - run:
           name: Generate diff artifacts for bigquery
           command: |
+            # compare a branch against the main branch, or against the previous
+            # commit if we're already on the main branch
+            base=upstream/main
+            if [[ "$CIRCLE_BRANCH" == "main" ]]; then
+              base=HEAD~1
+            fi
             docker run --name mps -w /app mps \
-              mps bigquery diff --base-ref upstream/main
+              mps bigquery diff --base-ref "$base"
             docker cp mps:/app/integration /tmp/integration
       - persist_to_workspace:
           root: /tmp


### PR DESCRIPTION
When PRs get merged into the main branch, CI is run and the bot will post an artifact comparing the contents of the PR to itself. An example: https://github.com/mozilla-services/mozilla-pipeline-schemas/commit/81ad27f4786bd3ba36f0e73fe2aa64de41dbf9cc You can infer the commits being checked by looking at the file names like `bq_schema_81ad27f4-81ad27f4.diff`.

A slightly more useful behavior is to compare against the previous commit when running CI on the main branch. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
