### PR TITLE
DENG-45 Reduce quicksuggest-impression retention to 2 days

### DIFF
--- a/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "quicksuggest_impression_v1",
     "expiration_policy": {
-      "delete_after_days": 15
+      "delete_after_days": 2
     }
   },
   "properties": {

--- a/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -4,7 +4,7 @@
   "title": "quicksuggest-impression",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 15
+      "delete_after_days": 2
     }
   },
   "properties": {


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-45

Note: this should not be merged until https://github.com/mozilla/bigquery-etl/pull/2438 is in place so that we don't interrupt general contextual-services monitoring.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
