### PR TITLE
Bug 1745803 - Add new crash properties to schema

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1404,6 +1404,10 @@
               "description": "<size>, Windows-only, available virtual memory in bytes",
               "type": "string"
             },
+            "BackgroundTaskName": {
+              "description": "<string>, If the app was invoked in background task mode via `--backgroundtask <task name>`, the string \"task name\".",
+              "type": "string"
+            },
             "BlockedDllList": {
               "description": "<list>, Windows-only, see WindowsDllBlocklist.cpp for details",
               "type": "string"
@@ -1438,6 +1442,10 @@
             },
             "GPUProcessLaunchCount": {
               "description": "<integer>, Number of times the GPU process was launched.",
+              "type": "string"
+            },
+            "HeadlessMode": {
+              "description": "<boolean>, True if the app was invoked in headless mode via `--headless ...` or `--backgroundtask ...`, false otherwise.",
               "type": "string"
             },
             "IndexedDBShutdownTimeout": {
@@ -1558,6 +1566,10 @@
             },
             "WindowsErrorReporting": {
               "description": "<boolean>, Set to 1 if this crash was intercepted via the Windows Error Reporting runtime exception module.",
+              "type": "string"
+            },
+            "WindowsPackageFamilyName": {
+              "description": "<string>, If running in a Windows package context, the package family name, per https://docs.microsoft.com/en-us/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefamilyname.\nThe package family name is only included when it is likely to have been produced by Mozilla: it starts \"Mozilla.\" or \"MozillaCorporation.\".",
               "type": "string"
             },
             "ipc_channel_error": {

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -53,6 +53,10 @@
               "description": "<size>, Windows-only, available virtual memory in bytes",
               "type": "string"
             },
+            "BackgroundTaskName": {
+              "description": "<string>, If the app was invoked in background task mode via `--backgroundtask <task name>`, the string \"task name\".",
+              "type": "string"
+            },
             "BlockedDllList": {
               "description": "<list>, Windows-only, see WindowsDllBlocklist.cpp for details",
               "type": "string"
@@ -87,6 +91,10 @@
             },
             "GPUProcessLaunchCount": {
               "description": "<integer>, Number of times the GPU process was launched.",
+              "type": "string"
+            },
+            "HeadlessMode": {
+              "description": "<boolean>, True if the app was invoked in headless mode via `--headless ...` or `--backgroundtask ...`, false otherwise.",
               "type": "string"
             },
             "IndexedDBShutdownTimeout": {
@@ -207,6 +215,10 @@
             },
             "WindowsErrorReporting": {
               "description": "<boolean>, Set to 1 if this crash was intercepted via the Windows Error Reporting runtime exception module.",
+              "type": "string"
+            },
+            "WindowsPackageFamilyName": {
+              "description": "<string>, If running in a Windows package context, the package family name, per https://docs.microsoft.com/en-us/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefamilyname.\nThe package family name is only included when it is likely to have been produced by Mozilla: it starts \"Mozilla.\" or \"MozillaCorporation.\".",
               "type": "string"
             },
             "Version": {


### PR DESCRIPTION
Will resolve [Bug 1745803](https://bugzilla.mozilla.org/show_bug.cgi?id=1745803) "HeadlessMode and BackgroundTaskName being sent in crash pings but not ingested into their own columns in BigQuery".

In addition to the `HeadlessMode` and `BackgroundTaskName` properties mentioned, a `WindowsPackageFamilyName` property is also being added.

---
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
