### PR TITLE
Update readme to reflect Java 11 being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that Pioneer studies have a [slightly amended](README.pioneer.md) process.
 - [`CMake` (3.0+)](http://cmake.org/cmake/resources/software.html)
 - [`jq` (1.5+)](https://github.com/stedolan/jq)
 - `python` (3.6+)
-- Optional: `java 8`, `maven`
+- Optional: `java 11`, `maven`
 - Optional: [Docker](https://www.docker.com/get-started)
 
 On MacOS, these prerequisites can be installed using [homebrew](https://brew.sh/):


### PR DESCRIPTION
#698 switched from Java 8 to Java 11, but the readme still refers to Java 8.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
