### PR TITLE
Bug 1745800 - Add `environment.system.winPackageFamilyName` to ping table schemas

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -1349,6 +1349,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1349,6 +1349,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -1356,6 +1356,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1349,6 +1349,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1349,6 +1349,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1348,6 +1348,13 @@
                 "number",
                 "null"
               ]
+            },
+            "winPackageFamilyName": {
+              "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -1281,6 +1281,13 @@
               "description": "The name of the registered firewall software. Windows only."
             }
           }
+        },
+        "winPackageFamilyName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Windows package family name. This is only sent for Mozilla produced MSIX packages."
         }
       }
     }


### PR DESCRIPTION
Fixes bug [1745800](https://bugzilla.mozilla.org/show_bug.cgi?id=1745800). 

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`
