### PR TITLE
Bug 1742448 - Add (optional) build date field to client info

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -33,6 +33,11 @@
           "description": "The architecture of the device, (e.g. \"arm\", \"x86\").",
           "type": "string"
         },
+        "build_date": {
+          "description": "The date & time the application was built",
+          "format": "datetime",
+          "type": "string"
+        },
         "client_id": {
           "description": "A UUID uniquely identifying the client.",
           "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Added optional `build_date` client info field. See [Bug 1742448](https://bugzilla.mozilla.org/show_bug.cgi?id=1742448).
+
 - Added a `text` metric type. See [Bug 1712783](https://bugzilla.mozilla.org/show_bug.cgi?id=1712783).
 
 - Added a `url` metric type. See [Bug 1719315](https://bugzilla.mozilla.org/show_bug.cgi?id=1719315).

--- a/templates/include/glean/client_info.1.schema.json
+++ b/templates/include/glean/client_info.1.schema.json
@@ -54,6 +54,11 @@
     "telemetry_sdk_build": {
       "type": "string",
       "description": "The version of the Glean SDK"
+    },
+    "build_date": {
+      "type": "string",
+      "format": "datetime",
+      "description": "The date & time the application was built"
     }
   },
   "required": [

--- a/validation/glean/glean.1.metrics.pass.json
+++ b/validation/glean/glean.1.metrics.pass.json
@@ -12,7 +12,8 @@
     "os": "Android",
     "os_version": "3.2.1",
     "android_sdk_version": "23",
-    "telemetry_sdk_build": "abcdabcd"
+    "telemetry_sdk_build": "abcdabcd",
+    "build_date": "2019-10-23T12:52:08+00:00"
   },
   "ping_info": {
     "ping_type": "full",


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`
