### PR TITLE
Bug 1754622 - Add match_type to QuickSuggest doctypes

### DIFF
--- a/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -45,6 +45,14 @@
       "description": "User's current locale",
       "type": "string"
     },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "enum": [
+        "firefox-suggest",
+        "best-match"
+      ],
+      "type": "string"
+    },
     "position": {
       "description": "The placement of the QuickSuggest link (1-based)",
       "type": "integer"

--- a/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -49,6 +49,14 @@
       "description": "User's current locale",
       "type": "string"
     },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "enum": [
+        "firefox-suggest",
+        "best-match"
+      ],
+      "type": "string"
+    },
     "matched_keywords": {
       "description": "The matched keywords when a QuickSuggest link is shown",
       "type": "string"

--- a/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -45,6 +45,11 @@
     "request_id": {
       "description": "The request identfier for every Merino API request made by Firefox",
       "type": "string"
+    },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "type": "string",
+      "enum": ["firefox-suggest", "best-match"]
     }
   },
   "required": [

--- a/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -62,6 +62,11 @@
     "request_id": {
       "description": "The request identfier for every Merino API request made by Firefox",
       "type": "string"
+    },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "type": "string",
+      "enum": ["firefox-suggest", "best-match"]
     }
   },
   "required": [

--- a/validation/contextual-services/quicksuggest-click.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-click.1.event.pass.json
@@ -9,6 +9,7 @@
   "release_channel": "release",
   "scenario": "offline",
   "request_id": "test-request-id",
+  "match_type": "best-match",
   "experiments": {
     "exp_id_foo": {
       "branch": "control"

--- a/validation/contextual-services/quicksuggest-impression.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-impression.1.event.pass.json
@@ -12,6 +12,7 @@
   "release_channel": "release",
   "scenario": "offline",
   "request_id": "test-request-id",
+  "match_type": "firefox-suggest",
   "experiments": {
     "exp_id_foo": {
       "branch": "control"


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

r? @jklukas 

