### PR TITLE
Bug 1754044 - Deprecate cfr and whats-new-panel schemas

### DIFF
--- a/schemas/messaging-system/cfr/cfr.1.schema.json
+++ b/schemas/messaging-system/cfr/cfr.1.schema.json
@@ -17,6 +17,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "cfr_v1",
     "expiration_policy": {
+      "collect_through_date": "2022-01-01",
       "delete_after_days": 180
     }
   },

--- a/schemas/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
+++ b/schemas/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
@@ -5,6 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "whats_new_panel_v1",
     "expiration_policy": {
+      "collect_through_date": "2022-01-01",
       "delete_after_days": 180
     }
   },

--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -33,7 +33,7 @@
           "description": "Various options controlling data lifecycle",
           "properties": {
             "collect_through_date": {
-              "description": "NOT YET IMPLEMENTED: If present, the pipeline will reject new data with submission_timestamp after the given date, sending it to error output",
+              "description": "If present, the pipeline will reject new data with submission_timestamp after the given date, sending it to error output",
               "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
               "type": "string"
             },

--- a/templates/messaging-system/cfr/cfr.1.schema.json
+++ b/templates/messaging-system/cfr/cfr.1.schema.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "cfr",
+  "mozPipelineMetadata": {
+    "expiration_policy": {
+      "collect_through_date": "2022-01-01"
+    }
+  },
   "properties": {
     @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
     "client_id": {

--- a/templates/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
+++ b/templates/messaging-system/whats-new-panel/whats-new-panel.1.schema.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "whats-new-panel",
+  "mozPipelineMetadata": {
+    "expiration_policy": {
+      "collect_through_date": "2022-01-01"
+    }
+  },
   "properties": {
     @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
     "client_id": {

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -43,7 +43,7 @@
             "collect_through_date": {
               "type": "string",
               "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-              "description": "NOT YET IMPLEMENTED: If present, the pipeline will reject new data with submission_timestamp after the given date, sending it to error output"
+              "description": "If present, the pipeline will reject new data with submission_timestamp after the given date, sending it to error output"
             }
           }
         },


### PR DESCRIPTION
In https://github.com/mozilla/gcp-ingestion/pull/2024 I added some code to drop messages when the schema defines a "do not collect after" date.

This updates the schemas for the pings in https://bugzilla.mozilla.org/show_bug.cgi?id=1754044 and sets the `collect_through_date` property to the first of 2022. This will only affect future data in the pipeline so the date is somewhat arbitrary.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
