### PR TITLE
Bug 1764669: Add quicksuggest-block to Contextual Services

### DIFF
--- a/schemas/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "mozPipelineMetadata": {
+    "bq_dataset_family": "contextual_services",
+    "bq_metadata_format": "structured",
+    "bq_table": "quicksuggest_block_v1",
+    "expiration_policy": {
+      "delete_after_days": 30
+    },
+    "override_attributes": [
+      {
+        "name": "geo_city",
+        "value": null
+      }
+    ],
+    "submission_timestamp_granularity": "seconds"
+  },
+  "properties": {
+    "advertiser": {
+      "description": "Name of the advertiser, e.g. amazon, ebay, bestbuy etc",
+      "type": "string"
+    },
+    "block_id": {
+      "description": "A unique identifier for the QuickSuggest link",
+      "type": "integer"
+    },
+    "context_id": {
+      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$",
+      "type": "string"
+    },
+    "experiments": {
+      "additionalProperties": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "description": "An object to record all active experiments, experiments IDs are stored as keys, and the value object stores the branch information. Example: {\"experiment_1\": {\"branch\": \"control\"}, \"experiment_2\": {\"branch\": \"treatment\"}}. This deprecates the \"shield_id\" used in activity-stream and messaging-system.",
+      "type": "object"
+    },
+    "iab_category": {
+      "description": "The IAB category of the suggestion",
+      "enum": [
+        "5 - Education",
+        "22 - Shopping"
+      ],
+      "type": "string"
+    },
+    "locale": {
+      "description": "User's current locale",
+      "type": "string"
+    },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "enum": [
+        "firefox-suggest",
+        "best-match"
+      ],
+      "type": "string"
+    },
+    "position": {
+      "description": "The placement of the QuickSuggest link (1-based)",
+      "type": "integer"
+    },
+    "release_channel": {
+      "description": "Firefox release channel",
+      "type": "string"
+    },
+    "request_id": {
+      "description": "The request identifier for every Merino API request made by Firefox",
+      "type": "string"
+    },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "enum": [
+        "history",
+        "offline",
+        "online"
+      ],
+      "type": "string"
+    },
+    "version": {
+      "description": "Firefox version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "context_id",
+    "block_id",
+    "version"
+  ],
+  "title": "quicksuggest-block",
+  "type": "object"
+}

--- a/templates/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
+++ b/templates/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "quicksuggest-block",
+  "properties": {
+    @ACTIVITY-STREAM_EXPERIMENTS_1_JSON@,
+    "advertiser": {
+        "description": "Name of the advertiser, e.g. amazon, ebay, bestbuy etc",
+        "type": "string"
+    },
+    "block_id": {
+        "description": "A unique identifier for the QuickSuggest link",
+        "type": "integer"
+    },
+    "context_id": {
+      "description": "A UUID representing this user. Note that it's not client_id, nor can it be used to link to a client_id",
+      "type": "string",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    },
+    "iab_category": {
+      "description": "The IAB category of the suggestion",
+      "type": "string",
+      "enum": ["5 - Education", "22 - Shopping"]
+    },
+    "locale": {
+      "description": "User's current locale",
+      "type": "string"
+    },
+    "match_type": {
+      "description": "The match type of the suggestion",
+      "type": "string",
+      "enum": ["firefox-suggest", "best-match"]
+    },
+    "position": {
+      "description": "The placement of the QuickSuggest link (1-based)",
+      "type": "integer"
+    },
+    "release_channel": {
+      "description": "Firefox release channel",
+      "type": "string"
+    },
+    "request_id": {
+      "description": "The request identifier for every Merino API request made by Firefox",
+      "type": "string"
+    },
+    "scenario": {
+      "description": "The scenario of the QuickSuggest user experience",
+      "type": "string",
+      "enum": ["history", "offline", "online"]
+    },
+    "version": {
+      "description": "Firefox version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "context_id",
+    "block_id",
+    "version"
+  ]
+}

--- a/validation/contextual-services/quicksuggest-block.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-block.1.event.pass.json
@@ -1,0 +1,21 @@
+{
+  "context_id": "{94642acb-4996-034b-916c-147da723cc41}",
+  "advertiser": "test-advertiser",
+  "block_id": 42,
+  "position": 9,
+  "iab_category": "22 - Shopping",
+  "locale": "en-US",
+  "version": "87.0",
+  "release_channel": "release",
+  "scenario": "offline",
+  "request_id": "test-request-id",
+  "match_type": "best-match",
+  "experiments": {
+    "exp_id_foo": {
+      "branch": "control"
+    },
+    "exp_id_bar": {
+      "branch": "treatment"
+    }
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

See [Bug 1764669](https://bugzilla.mozilla.org/show_bug.cgi?id=1764669) for the client side patch and data review.

r? @jklukas 
