### PR TITLE
Bug 1767448 - Add window_inner_height and window_inner_width to impression-stats ping.

### DIFF
--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -99,12 +99,12 @@
     "version": {
       "type": "string"
     },
-    "window_available_height": {
-      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+    "window_inner_height": {
+      "description": "The interior height of the window in pixels, including the height of the horizontal scroll bar, if present",
       "type": "integer"
     },
-    "window_available_width": {
-      "description": "Returns the amount of horizontal space in pixels available to the window",
+    "window_inner_width": {
+      "description": "The interior width of the window in pixels. This includes the width of the vertical scroll bar, if one is present.",
       "type": "integer"
     }
   },

--- a/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -98,6 +98,14 @@
     },
     "version": {
       "type": "string"
+    },
+    "window_available_height": {
+      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+      "type": "integer"
+    },
+    "window_available_width": {
+      "description": "Returns the amount of horizontal space in pixels available to the window",
+      "type": "integer"
     }
   },
   "required": [

--- a/schemas/activity-stream/impression-stats/impression-stats.2.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.2.schema.json
@@ -96,12 +96,12 @@
     "version": {
       "type": "string"
     },
-    "window_available_height": {
-      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+    "window_inner_height": {
+      "description": "The interior height of the window in pixels, including the height of the horizontal scroll bar, if present",
       "type": "integer"
     },
-    "window_available_width": {
-      "description": "Returns the amount of horizontal space in pixels available to the window",
+    "window_inner_width": {
+      "description": "The interior width of the window in pixels. This includes the width of the vertical scroll bar, if one is present.",
       "type": "integer"
     }
   },

--- a/schemas/activity-stream/impression-stats/impression-stats.2.schema.json
+++ b/schemas/activity-stream/impression-stats/impression-stats.2.schema.json
@@ -95,6 +95,14 @@
     },
     "version": {
       "type": "string"
+    },
+    "window_available_height": {
+      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+      "type": "integer"
+    },
+    "window_available_width": {
+      "description": "Returns the amount of horizontal space in pixels available to the window",
+      "type": "integer"
     }
   },
   "required": [

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -65,12 +65,12 @@
       "description": "An integer to record the size of the loaded 'tiles' list",
       "type": "integer"
     },
-    "window_available_height": {
-      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+    "window_inner_height": {
+      "description": "The interior height of the window in pixels, including the height of the horizontal scroll bar, if present",
       "type": "integer"
     },
-    "window_available_width": {
-      "description": "Returns the amount of horizontal space in pixels available to the window",
+    "window_inner_width": {
+      "description": "The interior width of the window in pixels. This includes the width of the vertical scroll bar, if one is present.",
       "type": "integer"
     }
   },

--- a/templates/activity-stream/impression-stats/impression-stats.1.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.1.schema.json
@@ -64,6 +64,14 @@
     "loaded": {
       "description": "An integer to record the size of the loaded 'tiles' list",
       "type": "integer"
+    },
+    "window_available_height": {
+      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+      "type": "integer"
+    },
+    "window_available_width": {
+      "description": "Returns the amount of horizontal space in pixels available to the window",
+      "type": "integer"
     }
   },
   "required": [

--- a/templates/activity-stream/impression-stats/impression-stats.2.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.2.schema.json
@@ -62,12 +62,12 @@
       "description": "An integer to record the size of the loaded 'tiles' list",
       "type": "integer"
     },
-    "window_available_height": {
-      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+    "window_inner_height": {
+      "description": "The interior height of the window in pixels, including the height of the horizontal scroll bar, if present",
       "type": "integer"
     },
-    "window_available_width": {
-      "description": "Returns the amount of horizontal space in pixels available to the window",
+    "window_inner_width": {
+      "description": "The interior width of the window in pixels. This includes the width of the vertical scroll bar, if one is present.",
       "type": "integer"
     }
   },

--- a/templates/activity-stream/impression-stats/impression-stats.2.schema.json
+++ b/templates/activity-stream/impression-stats/impression-stats.2.schema.json
@@ -61,6 +61,14 @@
     "loaded": {
       "description": "An integer to record the size of the loaded 'tiles' list",
       "type": "integer"
+    },
+    "window_available_height": {
+      "description": "Specifies the height of the screen, in pixels, minus permanent or semipermanent user interface features displayed by the operating system, such as the Taskbar on Windows",
+      "type": "integer"
+    },
+    "window_available_width": {
+      "description": "Returns the amount of horizontal space in pixels available to the window",
+      "type": "integer"
     }
   },
   "required": [

--- a/validation/activity-stream/impression-stats.1.sample.pass.json
+++ b/validation/activity-stream/impression-stats.1.sample.pass.json
@@ -19,5 +19,7 @@
   ],
   "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
   "profile_creation_date": 17817,
-  "region": "US"
+  "region": "US",
+  "window_inner_height": 1408,
+  "window_inner_width": 3440
 }

--- a/validation/activity-stream/impression-stats.2.sample.pass.json
+++ b/validation/activity-stream/impression-stats.2.sample.pass.json
@@ -19,5 +19,7 @@
   ],
   "impression_id": "{94642acb-4996-034b-916c-147da723cc41}",
   "profile_creation_date": 17817,
-  "region": "US"
+  "region": "US",
+  "window_inner_height": 1408,
+  "window_inner_width": 3440
 }


### PR DESCRIPTION
Scott Downe and I would like to start tracking on the impression-stats ping. I updated both the v1 and v2 schemas to support the new fields. I did not update any sample events in the /validation subfolder since the new fields are not required.

Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
