### PR TITLE
Update dockerfile to install jsonschema-transpiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             git fetch --all
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.7
+          version: 20.10.12
       - run:
           name: Build Docker image
           command: docker build --pull -t mps .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # debian bullseye provides rust >= 1.46 needed to build jsonschema-transpiler
 # --platform=linux/amd64 added to prevent pulling ARM images when run on Apple Silicon
-FROM --platform=linux/amd64 python:3.8-slim-bullseye
+FROM --platform=linux/amd64 debian:bookworm-slim
 LABEL maintainer="Mozilla Data Platform"
 
 # man directory is removed in upstream debian:slim, but needed by jdk install
@@ -17,7 +17,8 @@ RUN mkdir -p /usr/share/man/man1 && \
         git \
         openjdk-11-jdk-headless \
         maven \
-        cargo
+        cargo \
+        python3-pip
 
 # Install jsonschema-transpiler
 ENV PATH=$PATH:/root/.cargo/bin


### PR DESCRIPTION
Jsonschema-transpiler install is currently failing with:
  `feature `resolver` is required`

This is coming from cargo [0]. We need to use at least
cargo 0.57, but our docker image used Debian Bullseye,
which didn't have a backport and only supports
cargo 0.47 [1].

Luckily, Debian Bookworm has Cargo 0.57 available,
and also has Python 3.10. We have to manually install
pip3, and we're good to go.

[0] https://github.com/matthiaskrgr/cargo-cache/issues/107
[1] https://packages.debian.org/bookworm/cargo

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
