### PR TITLE
chore(bug 1765415): added default_pdf_viewer_raw to the schema for default-browser-agent doc

### DIFF
--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -21,6 +21,10 @@
       "description": "The current default browser",
       "type": "string"
     },
+    "default_pdf_viewer_raw": {
+      "description": "The current default PDF viewer",
+      "type": "string"
+    },
     "notification_action": {
       "description": "What action was taken by the user then the toast notification was displayed",
       "type": "string"

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -47,6 +47,10 @@
     "notification_not_shown_reason": {
       "description": "If no notification was shown, this will indicate why it was not",
       "type": "string"
+    },
+    "default_pdf_viewer_raw": {
+      "description": "The current default PDF viewer",
+      "type": "string"
     }
   },
   "required": [

--- a/validation/default-browser-agent/default-browser.1.sample.pass.json
+++ b/validation/default-browser-agent/default-browser.1.sample.pass.json
@@ -4,5 +4,6 @@
   "os_version": "10.0.18363.592",
   "os_locale": "en-US",
   "default_browser": "firefox",
-  "previous_default_browser": "edge"
+  "previous_default_browser": "edge",
+  "default_pdf_viewer_raw": "firefox"
 }


### PR DESCRIPTION
# chore([bug 1765415](https://bugzilla.mozilla.org/show_bug.cgi?id=1765415)): added default_pdf_viewer_raw to the schema for default-browser-agent doc

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
