### PR TITLE
Bug 1797587 - Add environment.system.cpu.name to ping table schemas.

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -779,6 +779,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -779,6 +779,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -786,6 +786,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -779,6 +779,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -779,6 +779,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -779,6 +779,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -778,6 +778,13 @@
                     "null"
                   ]
                 },
+                "name": {
+                  "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "speedMHz": {
                   "description": "Only available on Firefox desktop. The CPU clock speed in MHz.",
                   "type": [

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -718,6 +718,13 @@
               ],
               "description": "The CPU model, `null` on failure. Desktop only."
             },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only."
+            },
             "speedMHz": {
               "type": [
                 "number",


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [x] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
