### PR TITLE
Bug 1751739 - Add enrollment_id to Glean experiments

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -546,6 +546,9 @@
                   },
                   {
                     "properties": {
+                      "enrollment_id": {
+                        "type": "string"
+                      },
                       "type": {
                         "type": "string"
                       }

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -46,6 +46,9 @@
                   {
                     "type": "object",
                     "properties": {
+                      "enrollment_id": {
+                        "type": "string"
+                      },
                       "type": {
                         "type": "string"
                       }


### PR DESCRIPTION
Glean experiment extras _should_ be `MAP<STRING, STRING>` types. Instead, they are incorrectly typed as a
`STRUCT<type STRING>`.

With this change, we will accomodate the `enrollmentId` field by updating the `extra` field to by:
`STRUCT<type STRING, enrollment_id STRING>`.

This should allow the `enrollmentId`s to propogate, and the experiments should not be included in
`additionalProperties` any longer.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
