### PR TITLE
Bug 1820011 - Start tracking reasons individual records failed to sync

### DIFF
--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -403,6 +403,11 @@
                           "required": [
                             "reconciled"
                           ]
+                        },
+                        {
+                          "required": [
+                            "failedReasons"
+                          ]
                         }
                       ],
                       "properties": {
@@ -413,6 +418,26 @@
                         "failed": {
                           "minimum": 0,
                           "type": "integer"
+                        },
+                        "failedReasons": {
+                          "description": "A named count for the most commonly occuring reasons an incoming record failed to sync",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "count"
+                            ],
+                            "type": "object"
+                          },
+                          "minItems": 1,
+                          "type": "array"
                         },
                         "newFailed": {
                           "minimum": 0,
@@ -439,6 +464,26 @@
                           "failed": {
                             "minimum": 0,
                             "type": "integer"
+                          },
+                          "failedReasons": {
+                            "description": "A named count for the most commonly occuring reasons an outgoing record failed to sync",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "count"
+                              ],
+                              "type": "object"
+                            },
+                            "minItems": 1,
+                            "type": "array"
                           },
                           "sent": {
                             "minimum": 1,

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -417,6 +417,11 @@
                           "required": [
                             "reconciled"
                           ]
+                        },
+                        {
+                          "required": [
+                            "failedReasons"
+                          ]
                         }
                       ],
                       "properties": {
@@ -427,6 +432,26 @@
                         "failed": {
                           "minimum": 0,
                           "type": "integer"
+                        },
+                        "failedReasons": {
+                          "description": "A named count for the most commonly occuring reasons an incoming record failed to sync",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "count"
+                            ],
+                            "type": "object"
+                          },
+                          "minItems": 1,
+                          "type": "array"
                         },
                         "newFailed": {
                           "minimum": 0,
@@ -453,6 +478,26 @@
                           "failed": {
                             "minimum": 0,
                             "type": "integer"
+                          },
+                          "failedReasons": {
+                            "description": "A named count for the most commonly occuring reasons an outgoing record failed to sync",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "count"
+                              ],
+                              "type": "object"
+                            },
+                            "minItems": 1,
+                            "type": "array"
                           },
                           "sent": {
                             "minimum": 1,

--- a/templates/include/telemetry/syncItem.1.schema.json
+++ b/templates/include/telemetry/syncItem.1.schema.json
@@ -48,14 +48,21 @@
               {"required": ["applied"]},
               {"required": ["failed"]},
               {"required": ["newFailed"]},
-              {"required": ["reconciled"]}
+              {"required": ["reconciled"]},
+              {"required": ["failedReasons"]}
             ],
             "properties": {
               "applied": { "type": "integer", "minimum": 0 },
               "failed": { "type": "integer", "minimum": 0 },
               "newFailed": { "type": "integer", "minimum": 0 },
               "reconciled": { "type": "integer", "minimum": 0 },
-              "succeeded": { "type": "integer", "minimum": 0 }
+              "succeeded": { "type": "integer", "minimum": 0 },
+              "failedReasons": { 
+                "description": "A named count for the most commonly occuring reasons an incoming record failed to sync",
+                "type": "array", 
+                "minItems": 1, 
+                "items": @TELEMETRY_SYNCNAMEDCOUNT_1_JSON@
+              }
             }
           },
           "outgoing": {
@@ -66,7 +73,13 @@
               "additionalProperties": false,
               "properties": {
                 "sent": { "type": "integer", "minimum": 1 },
-                "failed": { "type": "integer", "minimum": 0 }
+                "failed": { "type": "integer", "minimum": 0 },
+                "failedReasons": {
+                  "description": "A named count for the most commonly occuring reasons an outgoing record failed to sync", 
+                  "type": "array", 
+                  "minItems": 1, 
+                  "items": @TELEMETRY_SYNCNAMEDCOUNT_1_JSON@
+                }
               }
             }
           },


### PR DESCRIPTION
This is a followup to the patch that landed in m-c: [Start tracking reasons individual records failed to sync](https://bugzilla.mozilla.org/show_bug.cgi?id=1820011).


Checklist for reviewer:

- [X] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [X] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`



For glean changes:
~~- [ ] Update templates/include/glean/CHANGELOG.md~~

For modifications to schemas in restricted namespaces (see [CODEOWNERS](https://github.com/CODEOWNERS)):
~~- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)~~
