### PR TITLE
add dlsource to schema for telemetry.environment

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -490,6 +490,10 @@
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -486,12 +486,12 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
-                "dltoken": {
-                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
                   "type": "string"
                 },
-                "dlsource": {
-                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
                 "experiment": {

--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -487,7 +487,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -487,7 +487,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -493,6 +493,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -494,7 +494,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -487,7 +487,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -489,6 +489,10 @@
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -485,12 +485,12 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
-                "dltoken": {
-                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
                   "type": "string"
                 },
-                "dlsource": {
-                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
                 "experiment": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -489,6 +489,10 @@
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -485,12 +485,12 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
-                "dltoken": {
-                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
                   "type": "string"
                 },
-                "dlsource": {
-                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
                 "experiment": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -487,7 +487,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -489,6 +489,10 @@
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -485,12 +485,12 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
-                "dltoken": {
-                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
                   "type": "string"
                 },
-                "dlsource": {
-                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
                 "experiment": {

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -486,6 +486,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -487,7 +487,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -489,6 +489,10 @@
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                  "type": "string"
+                },
                 "experiment": {
                   "description": "funnel experiment parameters, see bug 1567339",
                   "type": "string"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -485,12 +485,12 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
-                "dltoken": {
-                  "description": "Unique token created at Firefox download time, see bug 1677497",
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
                   "type": "string"
                 },
-                "dlsource": {
-                  "description": "Identifier that indicate where installations of Firefox originate, see bug 1827233",
+                "dltoken": {
+                  "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"
                 },
                 "experiment": {

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -485,6 +485,10 @@
                   "description": "Identifier to indicate the particular link within a campaign.",
                   "type": "string"
                 },
+                "dlsource": {
+                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "type": "string"
+                },
                 "dltoken": {
                   "description": "Unique token created at Firefox download time, see bug 1677497",
                   "type": "string"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -486,7 +486,7 @@
                   "type": "string"
                 },
                 "dlsource": {
-                  "description": "Identifier that indicates where installations of Firefox originate, see big 1827233",
+                  "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233",
                   "type": "string"
                 },
                 "dltoken": {

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -437,6 +437,10 @@
             "dltoken": {
               "type": "string",
               "description": "Unique token created at Firefox download time, see bug 1677497"
+            },
+            "dlsource": {
+              "type": "string",
+              "description": "Identifier that indicates where installations of Firefox originate, see big 1827233"
             }
           }
         },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -440,7 +440,7 @@
             },
             "dlsource": {
               "type": "string",
-              "description": "Identifier that indicates where installations of Firefox originate, see big 1827233"
+              "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233"
             }
           }
         },


### PR DESCRIPTION
[Bug 1827233](https://bugzilla.mozilla.org/show_bug.cgi?id=1827233)

adding the `dlsource` column to the tables listed in the bug

There are other tables that have a `dltoken` field and those might also need this `dlsource` column? 

Do I need to trigger something to add those schema changes or will that run automatically? 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
