### PR TITLE
Bug 1827234 - Add debugID to telemetry.third_party_modules_v4

### DIFF
--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1402,6 +1402,10 @@
                 "description": "The value of the CompanyName field as extracted from the DLL's version information. This property is only present when such version info is present, and when the 'signedBy' property is absent.",
                 "type": "string"
               },
+              "debugID": {
+                "description": "An identifier to allow for debugging.",
+                "type": "string"
+              },
               "fileVersion": {
                 "description": "Version of the DLL as contained in its resources's fixed version information.",
                 "type": "string"

--- a/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -47,6 +47,10 @@
                 "description": "Flags that indicate this module's level of trustworthiness. This corresponds to one or more mozilla::ModuleTrustFlags OR'd together.",
                 "type": "integer",
                 "minimum": 0
+              },
+              "debugID": {
+                "description": "An identifier to allow for debugging.",
+                "type": "string"
               }
             },
             "required": [


### PR DESCRIPTION
[Bug 1827234](https://bugzilla.mozilla.org/show_bug.cgi?id=1827234)

Adding `debugID` to `telemetry.third_party_modules_v4.payload.modules` after seeing a 4000% increase in missing column errors over the last week in the weekly platform health check.

Super open suggestions on a better description for this column. Could not find anything on the new column anywhere and therefor nothing to copy a good description from. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
