### PR TITLE
Bug 1833201 - Adding ShutdownReason to telemtry.crash_v4

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1546,6 +1546,10 @@
               "description": "<phase>, Optional, contains a string describing the shutdown phase in which the crash occurred",
               "type": "string"
             },
+            "ShutdownReason": {
+              "description": "Optional, contains a string describing the reason the crash occurred",
+              "type": "string"
+            },
             "StartupCrash": {
               "description": "1, Optional, if set indicates that Firefox crashed during startup",
               "type": "string"

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -181,6 +181,10 @@
               "description": "<phase>, Optional, contains a string describing the shutdown phase in which the crash occurred",
               "type": "string"
             },
+            "ShutdownReason": {
+              "description": "Optional, contains a string describing the reason the crash occurred",
+              "type": "string"
+            },
             "StartupCrash": {
               "description": "1, Optional, if set indicates that Firefox crashed during startup",
               "type": "string"


### PR DESCRIPTION
[Bug 1833201](https://bugzilla.mozilla.org/show_bug.cgi?id=1833201)

Adding `ShutdownReason` to `telemetry.crash_v4.payload.metadata` after seeing a 700% increase in missing column errors over the last week in the weekly platform health check.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
