### PR TITLE
Bug 1827238 - Add dlsource to messaging_system.onboarding_v1.attribution

### DIFF
--- a/schemas/messaging-system/onboarding/onboarding.1.schema.json
+++ b/schemas/messaging-system/onboarding/onboarding.1.schema.json
@@ -26,6 +26,10 @@
           "description": "Identifier to indicate the particular link within a campaign.",
           "type": "string"
         },
+        "dlsource": {
+          "description": "Identifier that indicates where installations of Firefox originate, see bug 1827238",
+          "type": "string"
+        },
         "dltoken": {
           "description": "Unique token created at Firefox download time, see bug 1757451",
           "type": "string"

--- a/templates/messaging-system/onboarding/onboarding.1.schema.json
+++ b/templates/messaging-system/onboarding/onboarding.1.schema.json
@@ -76,6 +76,10 @@
         "dltoken": {
           "type": "string",
           "description": "Unique token created at Firefox download time, see bug 1757451"
+        },
+        "dlsource": {
+          "description": "Identifier that indicates where installations of Firefox originate, see bug 1827238",
+          "type": "string"
         }
       }
     }

--- a/validation/messaging-system/onboarding.1.attribution.pass.json
+++ b/validation/messaging-system/onboarding.1.attribution.pass.json
@@ -16,6 +16,7 @@
     "experiment": "(not set)",
     "variation": "(not set)",
     "ua": "chrome",
-    "dltoken": "(not set)"
+    "dltoken": "(not set)",
+    "dlsource": "(not set)"
   }
 }


### PR DESCRIPTION
[Bug 1827238](https://bugzilla.mozilla.org/show_bug.cgi?id=1827238)

Adding `dlsource` to `messaging_system.onboarding_v1.attribution`

I recently added `dlsource` to a lot of telemetry schemas as well (see  #768), but this looks to be the only other schema outside of telemetry that uses `dlsource` and `dltoken` 

It might be more elegant to move the attribution part out of the `templates/include/telemetry/environment.1.schema.json` into a common template that can be used here as well

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
<del> - [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`</del>

<del>For glean changes:</del>
<del>- [ ] Update `templates/include/glean/CHANGELOG.md` </del>

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
