### PR TITLE
Add geoip skip to metaschema

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -44,6 +44,10 @@
           },
           "type": "object"
         },
+        "geoip_skip_entries": {
+          "description": "If present, how many additional entries (beyond two) to skip in x_forwarded_for when performing geoip decoding, useful when submissions are ingested from trusted proxies; if there are fewer entries in x_forwarded_for than (N+1) the last entry is used instead of (N+3)rd-to-last",
+          "type": "integer"
+        },
         "jwe_mappings": {
           "description": "Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; initial use case is Account Ecosystem Telemetry; paths must be in [JSON Pointer format](https://tools.ietf.org/html/rfc6901) like '/payload/ecosystemAnonId'",
           "items": {

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -73,6 +73,10 @@
             ]
           }
         },
+        "geoip_skip_entries": {
+          "description": "If present, how many additional entries (beyond two) to skip in x_forwarded_for when performing geoip decoding, useful when submissions are ingested from trusted proxies; if there are fewer entries in x_forwarded_for than (N+1) the last entry is used instead of (N+3)rd-to-last",
+          "type": "integer"
+        },
         "jwe_mappings": {
           "type": "array",
           "description": "Mappings of encrypted JWE field paths to destinations where the value decrypted by the pipeline should be placed; initial use case is Account Ecosystem Telemetry; paths must be in [JSON Pointer format](https://tools.ietf.org/html/rfc6901) like '/payload/ecosystemAnonId'",


### PR DESCRIPTION
/CC @Dexterp37 

There's got to be a better natural language description or name for this.

Another option might be to make this e.g. `geoip_index`, with negative values being from the end (the default would be `-3`). The expected value for trusted proxies configuration would be `-4` or `-5` (I can't remember but it's all written down in the Jira ticket).

I'm trying to be explicit about the fact that it's very possible to receive submissions that don't have the expected number of entries when dealing with namespaces that have trusted proxy metadata configured and that there is fallback behavior as a result.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
