### PR TITLE
Bug 1839487 Missing column for quicksuggest block source

### DIFF
--- a/schemas/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
@@ -86,6 +86,10 @@
       ],
       "type": "string"
     },
+    "source": {
+      "description": "The source of the suggestion, either “remote-settings” or “merino”. See bug 1839487",
+      "type": "string"
+    },
     "version": {
       "description": "Firefox version",
       "type": "string"

--- a/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -82,6 +82,10 @@
       ],
       "type": "string"
     },
+    "source": {
+      "description": "The source of the suggestion, either “remote-settings” or “merino”. See bug 1779049",
+      "type": "string"
+    },
     "version": {
       "description": "Firefox version",
       "type": "string"

--- a/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/schemas/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -94,6 +94,10 @@
       "description": "The user's typed-in search query in the AwesomeBar. Note that this ping is only sent when a QuickSuggest ad is shown for the current search query, so we don't have to limit its size here",
       "type": "string"
     },
+    "source": {
+      "description": "The source of the suggestion, either “remote-settings” or “merino”. See bug 1779049",
+      "type": "string"
+    },
     "version": {
       "description": "Firefox version",
       "type": "string"

--- a/templates/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
+++ b/templates/contextual-services/quicksuggest-block/quicksuggest-block.1.schema.json
@@ -55,6 +55,10 @@
     "improve_suggest_experience_checked": {
       "description": "A boolean indicating whether the user has opted in to improving the Firefox Suggest experience",
       "type": "boolean"
+    },
+    "source": {
+      "description":"The source of the suggestion, either “remote-settings” or “merino”. See bug 1839487",
+      "type": "string"
     }
   },
   "required": [

--- a/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
+++ b/templates/contextual-services/quicksuggest-click/quicksuggest-click.1.schema.json
@@ -54,6 +54,10 @@
     "improve_suggest_experience_checked": {
       "description": "A boolean indicating whether the user has opted in to improving the Firefox Suggest experience",
       "type": "boolean"
+    },
+    "source": {
+      "description":"The source of the suggestion, either “remote-settings” or “merino”. See bug 1779049",
+      "type": "string"
     }
   },
   "required": [

--- a/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
+++ b/templates/contextual-services/quicksuggest-impression/quicksuggest-impression.1.schema.json
@@ -66,6 +66,10 @@
     "improve_suggest_experience_checked": {
       "description": "A boolean indicating whether the user has opted in to improving the Firefox Suggest experience",
       "type": "boolean"
+    },
+    "source": {
+      "description":"The source of the suggestion, either “remote-settings” or “merino”. See bug 1779049",
+      "type": "string"
     }
   },
   "required": [

--- a/validation/contextual-services/quicksuggest-block.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-block.1.event.pass.json
@@ -17,5 +17,6 @@
     "exp_id_bar": {
       "branch": "treatment"
     }
-  }
+  },
+  "source": "somesource"
 }

--- a/validation/contextual-services/quicksuggest-click.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-click.1.event.pass.json
@@ -17,5 +17,6 @@
     "exp_id_bar": {
       "branch": "treatment"
     }
-  }
+  },
+  "source": "some source"
 }

--- a/validation/contextual-services/quicksuggest-impression.1.event.pass.json
+++ b/validation/contextual-services/quicksuggest-impression.1.event.pass.json
@@ -20,5 +20,6 @@
     "exp_id_bar": {
       "branch": "treatment"
     }
-  }
+  },
+  "source": "some source"
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1839487

https://bugzilla.mozilla.org/show_bug.cgi?id=1779049

adding missing columns "source" for three quicksuggest schemas

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
