### PR TITLE
Bug 1840381 - add  `TargetFrameRate` to `environment.system.gfx`

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -867,6 +867,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -883,6 +883,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -874,6 +874,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -883,6 +883,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -883,6 +883,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -867,6 +867,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -866,6 +866,10 @@
                 "LowEndMachine": {
                   "type": "boolean"
                 },
+                "TargetFrameRate": {
+                  "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+                  "type": "integer"
+                },
                 "adapters": {
                   "items": {
                     "properties": {

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -1075,6 +1075,10 @@
                   }
                 }
               }
+            },
+            "TargetFrameRate": {
+              "description": "Frame rate in Hz, typically 60 or more, see bug 1840381",
+              "type": "integer"
             }
           }
         },

--- a/validation/telemetry/bhr.4.sample.pass.json
+++ b/validation/telemetry/bhr.4.sample.pass.json
@@ -4909,7 +4909,8 @@
           "openglCompositing": {
             "status": "available"
           }
-        }
+        },
+        "TargetFrameRate": 60
       },
       "appleModelId": "MacBookPro16,1"
     },

--- a/validation/telemetry/crash.4.sample.pass.json
+++ b/validation/telemetry/crash.4.sample.pass.json
@@ -83,7 +83,8 @@
             "screenWidth": 1280,
             "pseudoDisplay": false
           }
-        ]
+        ],
+        "TargetFrameRate": 60
       },
       "os": {
         "name": "Windows_NT",

--- a/validation/telemetry/event.4.sample.pass.json
+++ b/validation/telemetry/event.4.sample.pass.json
@@ -159,7 +159,8 @@
           "gpuProcess": {
             "status": "unused"
           }
-        }
+        },
+        "TargetFrameRate": 65
       },
       "appleModelId": null
     },


### PR DESCRIPTION
New environment parameter `TargetFrameRate` in `environment.system.gfx`

https://bugzilla.mozilla.org/show_bug.cgi?id=1840381
https://bugzilla.mozilla.org/show_bug.cgi?id=1840398
https://bugzilla.mozilla.org/show_bug.cgi?id=1840395
https://bugzilla.mozilla.org/show_bug.cgi?id=1840378

Also showed up in the new `main_remainder` table where the schema seems to come from some different place, so not sure how to address that. 