### PR TITLE
Bug 1799509 - Add description to Glean `_distribution` metrics' count field

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -151,6 +151,7 @@
           "additionalProperties": {
             "properties": {
               "count": {
+                "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
                 "type": "integer"
               },
               "sum": {
@@ -297,6 +298,7 @@
           "additionalProperties": {
             "properties": {
               "count": {
+                "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
                 "type": "integer"
               },
               "sum": {
@@ -437,6 +439,7 @@
                 "type": "integer"
               },
               "count": {
+                "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
                 "type": "integer"
               },
               "histogram_type": {

--- a/templates/include/glean/custom_distribution.1.schema.json
+++ b/templates/include/glean/custom_distribution.1.schema.json
@@ -2,6 +2,7 @@
   "type": "object",
   "properties": {
     "count": {
+      "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
       "type": "integer"
     },
     "values": {

--- a/templates/include/glean/memory_distribution.1.schema.json
+++ b/templates/include/glean/memory_distribution.1.schema.json
@@ -2,6 +2,7 @@
   "type": "object",
   "properties": {
     "count": {
+      "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
       "type": "integer"
     },
     "values": {

--- a/templates/include/glean/timing_distribution.1.schema.json
+++ b/templates/include/glean/timing_distribution.1.schema.json
@@ -13,6 +13,7 @@
       "type": "integer"
     },
     "count": {
+      "description": "This was accidentally sent in the past and is now deprecated. See https://bugzilla.mozilla.org/show_bug.cgi?id=1799509#c5",
       "type": "integer"
     },
     "histogram_type": {


### PR DESCRIPTION


This field might be confusing (see https://mozilla.slack.com/archives/C4D5ZA91B/p1693101626243669) and should not be used at analysis.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
