### PR TITLE
Move histograms related to use counters to the correct subset pings

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -154,6 +154,10 @@
                   "document_version": {
                     "type": "string"
                   },
+                  "extra_pattern": {
+                    "description": "Like pattern, except the schema of matched properties must also be present in the remainder, because schemas cannot delete fields. Data for matched properties will only go to this subset ping.",
+                    "type": "string"
+                  },
                   "pattern": {
                     "description": "Regular expression matching .-delimited property names that should be moved to this subset ping. Only properties explictly defined in the non-generic json schema of the original ping are supported, because property names are matched during schema generation.",
                     "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -17,6 +17,7 @@
           "document_namespace": "telemetry",
           "document_type": "first-shutdown-use-counter",
           "document_version": "4",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
           "pattern": ".*[.]USE_COUNTER2_[^.]+"
         }
       ]

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -17,6 +17,7 @@
           "document_namespace": "telemetry",
           "document_type": "main-use-counter",
           "document_version": "4",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
           "pattern": ".*[.]USE_COUNTER2_[^.]+"
         }
       ]

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -17,6 +17,7 @@
           "document_namespace": "telemetry",
           "document_type": "saved-session-use-counter",
           "document_version": "4",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
           "pattern": ".*[.]USE_COUNTER2_[^.]+"
         }
       ]

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -160,6 +160,10 @@
                   "pattern": {
                     "type": "string",
                     "description": "Regular expression matching .-delimited property names that should be moved to this subset ping. Only properties explictly defined in the non-generic json schema of the original ping are supported, because property names are matched during schema generation."
+                  },
+                  "extra_pattern": {
+                    "type": "string",
+                    "description": "Like pattern, except the schema of matched properties must also be present in the remainder, because schemas cannot delete fields. Data for matched properties will only go to this subset ping."
                   }
                 },
                 "required": [

--- a/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1,48 +1,49 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    @TELEMETRY_MAINSCHEMAID_1_JSON@,
-    "mozPipelineMetadata": {
-        "split_config": {
-            "preserve_original": true,
-            "subsets": [
-                {
-                    "document_namespace": "telemetry",
-                    "document_type": "first-shutdown-use-counter",
-                    "document_version": "4",
-                    "pattern": ".*[.]USE_COUNTER2_[^.]+"
-                }
-            ],
-            "remainder": {
-                "document_namespace": "telemetry",
-                "document_type": "first-shutdown-remainder",
-                "document_version": "4"
-            }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  @TELEMETRY_MAINSCHEMAID_1_JSON@,
+  "mozPipelineMetadata": {
+    "split_config": {
+      "preserve_original": true,
+      "subsets": [
+        {
+          "document_namespace": "telemetry",
+          "document_type": "first-shutdown-use-counter",
+          "document_version": "4",
+          "pattern": ".*[.]USE_COUNTER2_[^.]+",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
         }
-    },
-    "type": "object",
-    "title": "first-shutdown",
-    "properties": {
-      @TELEMETRY_APPLICATION_1_JSON@,
-      @TELEMETRY_CLIENTID_1_JSON@,
-      @TELEMETRY_CREATIONDATE_1_JSON@,
-      @TELEMETRY_ENVIRONMENT_1_JSON@,
-      @TELEMETRY_ID_1_JSON@,
-      @TELEMETRY_MAINPAYLOAD_1_JSON@,
-      "type": {
-        "type": "string",
-        "enum": [ "first-shutdown" ]
-      },
-      "version": {
-        "type": "number",
-        "minimum": 4,
-        "maximum": 4
+      ],
+      "remainder": {
+        "document_namespace": "telemetry",
+        "document_type": "first-shutdown-remainder",
+        "document_version": "4"
       }
+    }
+  },
+  "type": "object",
+  "title": "first-shutdown",
+  "properties": {
+    @TELEMETRY_APPLICATION_1_JSON@,
+    @TELEMETRY_CLIENTID_1_JSON@,
+    @TELEMETRY_CREATIONDATE_1_JSON@,
+    @TELEMETRY_ENVIRONMENT_1_JSON@,
+    @TELEMETRY_ID_1_JSON@,
+    @TELEMETRY_MAINPAYLOAD_1_JSON@,
+    "type": {
+      "type": "string",
+      "enum": [ "first-shutdown" ]
     },
-    "required": [
-      "application",
-      "creationDate",
-      "id",
-      "type",
-      "version"
-    ]
+    "version": {
+      "type": "number",
+      "minimum": 4,
+      "maximum": 4
+    }
+  },
+  "required": [
+    "application",
+    "creationDate",
+    "id",
+    "type",
+    "version"
+  ]
 }

--- a/templates/telemetry/main/main.4.schema.json
+++ b/templates/telemetry/main/main.4.schema.json
@@ -9,7 +9,8 @@
           "document_namespace": "telemetry",
           "document_type": "main-use-counter",
           "document_version": "4",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+"
+          "pattern": ".*[.]USE_COUNTER2_[^.]+",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
         }
       ],
       "remainder": {

--- a/templates/telemetry/saved-session/saved-session.4.schema.json
+++ b/templates/telemetry/saved-session/saved-session.4.schema.json
@@ -9,7 +9,8 @@
           "document_namespace": "telemetry",
           "document_type": "saved-session-use-counter",
           "document_version": "4",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+"
+          "pattern": ".*[.]USE_COUNTER2_[^.]+",
+          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
         }
       ],
       "remainder": {


### PR DESCRIPTION
requires https://github.com/mozilla/mozilla-schema-generator/pull/250
fixes [bug 1851057](https://bugzilla.mozilla.org/show_bug.cgi?id=1851057)

context: I missed some histograms when splitting out use counter pings, and now they need to be moved, but their schema needs to be preserved in the remainder pings because schemas are not allowed to delete fields.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
