### PR TITLE
Bug 1852630 - Rename main_remainder_v4 to main_v5

### DIFF
--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -9,16 +9,15 @@
       "preserve_original": true,
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "first-shutdown-remainder",
-        "document_version": "4"
+        "document_type": "first-shutdown",
+        "document_version": "5"
       },
       "subsets": [
         {
           "document_namespace": "telemetry",
           "document_type": "first-shutdown-use-counter",
           "document_version": "4",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ]
     }

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -9,16 +9,15 @@
       "preserve_original": true,
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "main-remainder",
-        "document_version": "4"
+        "document_type": "main",
+        "document_version": "5"
       },
       "subsets": [
         {
           "document_namespace": "telemetry",
           "document_type": "main-use-counter",
           "document_version": "4",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ]
     }

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -9,16 +9,15 @@
       "preserve_original": true,
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "saved-session-remainder",
-        "document_version": "4"
+        "document_type": "saved-session",
+        "document_version": "5"
       },
       "subsets": [
         {
           "document_namespace": "telemetry",
           "document_type": "saved-session-use-counter",
           "document_version": "4",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ]
     }

--- a/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/templates/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -9,14 +9,13 @@
           "document_namespace": "telemetry",
           "document_type": "first-shutdown-use-counter",
           "document_version": "4",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ],
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "first-shutdown-remainder",
-        "document_version": "4"
+        "document_type": "first-shutdown",
+        "document_version": "5"
       }
     }
   },

--- a/templates/telemetry/main/main.4.schema.json
+++ b/templates/telemetry/main/main.4.schema.json
@@ -9,14 +9,13 @@
           "document_namespace": "telemetry",
           "document_type": "main-use-counter",
           "document_version": "4",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ],
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "main-remainder",
-        "document_version": "4"
+        "document_type": "main",
+        "document_version": "5"
       }
     }
   },

--- a/templates/telemetry/saved-session/saved-session.4.schema.json
+++ b/templates/telemetry/saved-session/saved-session.4.schema.json
@@ -9,14 +9,13 @@
           "document_namespace": "telemetry",
           "document_type": "saved-session-use-counter",
           "document_version": "4",
-          "pattern": ".*[.]USE_COUNTER2_[^.]+",
-          "extra_pattern": ".*[.]((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED"
+          "pattern": ".*[.](USE_COUNTER2_[^.]+|((TOP_LEVEL_)?CONTENT_DOCUMENTS|[^.]+_WORKER)_DESTROYED)"
         }
       ],
       "remainder": {
         "document_namespace": "telemetry",
-        "document_type": "saved-session-remainder",
-        "document_version": "4"
+        "document_type": "saved-session",
+        "document_version": "5"
       }
     }
   },


### PR DESCRIPTION
[Bug 1852630](https://bugzilla.mozilla.org/show_bug.cgi?id=1852630)

requires https://github.com/mozilla/mozilla-schema-generator/pull/252 and blocks https://github.com/mozilla/bigquery-etl/pull/4276

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
