### PR TITLE
Use jsonschema-transpiler's pinned dependencies on install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /usr/share/man/man1 && \
 
 # Install jsonschema-transpiler
 ENV PATH=$PATH:/root/.cargo/bin
-RUN cargo install jsonschema-transpiler --version 1.9.0
+RUN cargo install jsonschema-transpiler --version 1.9.0 --locked
 
 # Configure git for testing
 RUN git config --global user.email "mozilla-pipeline-schemas@mozilla.com"


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile `--locked` will use the bundled Cargo.lock file with pinned dependencies, instead of recalculating dependency versions. This allows reproducible builds and avoids issues when any dependency releases a new version that contains incompatible changes.

cc @relud 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
