### PR TITLE
Bug 1862955 - add (optional) session_id & session_count to Glean client info

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -71,6 +71,14 @@
           "description": "The user-visible version of the operating system (e.g. \"1.2.3\"). If the version detection fails, this metric gets set to `Unknown`.",
           "type": "string"
         },
+        "session_count": {
+          "description": "An optional running counter of the number of sessions for a client.",
+          "type": "integer"
+        },
+        "session_id": {
+          "description": "An optional UUID uniquely identifying the client's current session.",
+          "type": "string"
+        },
         "telemetry_sdk_build": {
           "description": "The version of the Glean SDK",
           "type": "string"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added optional `session_id` and optional `session_count` client info field. See [Bug 1862955](https://bugzilla.mozilla.org/show_bug.cgi?id=1862955).
 
+- Add `enrollment_id` to Glean experiments. See [Bug 1751739](https://bugzilla.mozilla.org/show_bug.cgi?id=1751739).
+
 - Update pattern and increased length limit for `dot_separated_short_id`. See [Bug 1849615](https://bugzilla.mozilla.org/show_bug.cgi?id=1849615).
 
 - Added optional `windows_build_number` client info field. See [Bug 1802094](https://bugzilla.mozilla.org/show_bug.cgi?id=1802094).

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Added optional `session_id` and optional `session_count` client info field. See [Bug 1862955](https://bugzilla.mozilla.org/show_bug.cgi?id=1862955).
+
 - Update pattern and increased length limit for `dot_separated_short_id`. See [Bug 1849615](https://bugzilla.mozilla.org/show_bug.cgi?id=1849615).
 
 - Added optional `windows_build_number` client info field. See [Bug 1802094](https://bugzilla.mozilla.org/show_bug.cgi?id=1802094).

--- a/templates/include/glean/client_info.1.schema.json
+++ b/templates/include/glean/client_info.1.schema.json
@@ -51,6 +51,14 @@
       "description": "The user-visible version of the operating system (e.g. \"1.2.3\"). If the version detection fails, this metric gets set to `Unknown`.",
       "type": "string"
     },
+    "session_id": {
+      "description": "An optional UUID uniquely identifying the client's current session.",
+      "type": "string"
+    },
+    "session_count": {
+      "description": "An optional running counter of the number of sessions for a client.",
+      "type": "integer"
+    },
     "telemetry_sdk_build": {
       "type": "string",
       "description": "The version of the Glean SDK"

--- a/validation/glean/glean.1.metrics.pass.json
+++ b/validation/glean/glean.1.metrics.pass.json
@@ -13,7 +13,9 @@
     "os_version": "3.2.1",
     "android_sdk_version": "23",
     "telemetry_sdk_build": "abcdabcd",
-    "build_date": "2019-10-23T12:52:08+00:00"
+    "build_date": "2019-10-23T12:52:08+00:00",
+    "session_id": "16044baf-b881-45c8-860f-00f14f144e2e",
+    "session_count": 7
   },
   "ping_info": {
     "ping_type": "full",


### PR DESCRIPTION
Checklist for reviewer:

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] If adding a new field, the field should have a description (see #576 for an example)
- [x] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [x] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
