### PR TITLE
Bug 1665381 - Added distribution fields to stub installer ping schema

### DIFF
--- a/schemas/firefox-installer/install/install.1.schema.json
+++ b/schemas/firefox-installer/install/install.1.schema.json
@@ -44,6 +44,14 @@
       "description": "True if the installation failed because the drive we're trying to install to does not have enough space",
       "type": "boolean"
     },
+    "distribution_id": {
+      "description": "ID of partner distribution, defaulting to 0 for Mozilla distributions",
+      "type": "string"
+    },
+    "distribution_version": {
+      "description": "Version of partner distribution, defaulting to 0 for Mozilla distributions",
+      "type": "string"
+    },
     "download_ip": {
       "description": "IP address of the server the full installer was downloaded from. May be either IPv4 or IPv6.",
       "type": "string"

--- a/templates/firefox-installer/install/install.1.schema.json
+++ b/templates/firefox-installer/install/install.1.schema.json
@@ -205,6 +205,14 @@
       "description": "True if either profile cleanup prompt was shown and the user accepted the prompt",
       "type": "boolean"
     },
+    "distribution_id": {
+      "description": "ID of partner distribution, defaulting to 0 for Mozilla distributions",
+      "type": "string"
+    },
+    "distribution_version": {
+      "description": "Version of partner distribution, defaulting to 0 for Mozilla distributions",
+      "type": "string"
+    },
     "funnelcake": {
       "description": "Funnelcake ID",
       "type": "string"


### PR DESCRIPTION
Added new schema fields for distribution ID and version to installer ping schema.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
