### PR TITLE
Add `previous_os_version` to `default-browser-agent/default-browser`.

### DIFF
--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -28,7 +28,11 @@
       "type": "string"
     },
     "os_version": {
-      "description": "Windows version numnber in major.minor.build.UBR format (UBR is optional, only available on Win10)",
+      "description": "Windows version number in major.minor.build.UBR format (UBR is optional, only available on Win10)",
+      "type": "string"
+    },
+    "previous_os_version": {
+      "description": "The Windows OS version before it was changed to the current setting. The possible values are the same as for ``os_version``. The OS does not keep track of the previous OS version, so the agent records this information itself. That means that it will be inaccurate until the first time the default is changed after the agent task begins running. Before then, the value of ``previous_os_version`` will be the same as ``os_version``. This value is updated every time the Default Agent runs, so when the default browser is first changed the values for ``os_version`` and ``previous_os_version`` will be different. But on subsequent executions of the Default Agent, the two values will be the same.",
       "type": "string"
     },
     "os_locale": {


### PR DESCRIPTION
This completes https://bugzilla.mozilla.org/show_bug.cgi?id=1850149 for Legacy telemetry.  (Glad I realized this was necessary before it made it to release channel!)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
