### PR TITLE
Remove `bq_dataset_family` and `bq_table` metadata from `glean.1` schema

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -4,9 +4,6 @@
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "mozPipelineMetadata": {
-    "bq_dataset_family": "glean",
-    "bq_metadata_format": "structured",
-    "bq_table": "glean_v1",
     "json_object_path_regex": "metrics\\.object\\..*"
   },
   "properties": {

--- a/scripts/inject-metadata
+++ b/scripts/inject-metadata
@@ -54,17 +54,20 @@ if __name__ == "__main__":
             else:
                 merge_where_empty(meta, namespace_defaults)
 
-    # Prepare some default metadata if not overridden in the template schema.
-    bq_dataset_family = namespace.replace("-", "_")
-    bq_doctype = doctype.replace("-", "_")
-    version = schema_basename.split(".")[1]
-    bq_table = "{}_v{}".format(bq_doctype, version)
-    defaults = {
-        "bq_dataset_family": bq_dataset_family,
-        "bq_table": bq_table,
-        "bq_metadata_format": "structured",
-    }
-    merge_where_empty(meta, defaults)
+    # Prepare some default metadata if not overridden in the template schema,
+    # except for the core `glean/glean` schema.
+    if not (namespace == "glean" and doctype == "glean"):
+        bq_dataset_family = namespace.replace("-", "_")
+        bq_doctype = doctype.replace("-", "_")
+        version = schema_basename.split(".")[1]
+        bq_table = "{}_v{}".format(bq_doctype, version)
+        defaults = {
+            "bq_dataset_family": bq_dataset_family,
+            "bq_table": bq_table,
+            "bq_metadata_format": "structured",
+        }
+        merge_where_empty(meta, defaults)
+
     if inject_metadata:
         schema[MOZ_PIPELINE_METADATA] = meta
     else:


### PR DESCRIPTION
That metadata was added by #793, but it only makes sense when there's an actual target BigQuery table, and its presence is confusing the `bqetl` tooling.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
