### PR TITLE
Remove glean1 bq table metadata alternate

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -4,9 +4,6 @@
   "additionalProperties": false,
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "mozPipelineMetadata": {
-    "bq_dataset_family": "glean",
-    "bq_metadata_format": "structured",
-    "bq_table": "glean_v1",
     "json_object_path_regex": "metrics\\.object\\..*"
   },
   "properties": {

--- a/scripts/inject-metadata
+++ b/scripts/inject-metadata
@@ -40,7 +40,8 @@ if __name__ == "__main__":
     # Parse the schema and extract metadata.
     schema = json.load(sys.stdin)
     meta = schema.get(MOZ_PIPELINE_METADATA, {})
-    inject_metadata = True
+    propagate_metadata = bool(meta)
+    inject_default_metadata = True
 
     # Namespace-level defaults.
     defaults_path = TEMPLATES_DIR / namespace / "defaults.schema.json"
@@ -50,22 +51,26 @@ if __name__ == "__main__":
             if namespace_defaults is False:
                 # A namespace defaults file that sets '"mozPipelineMetadata" = false'
                 # is a special flag to exempt the namespace from metadata injection.
-                inject_metadata = False
+                inject_default_metadata = False
             else:
+                propagate_metadata = True
                 merge_where_empty(meta, namespace_defaults)
+    else:
+        propagate_metadata = True
 
     # Prepare some default metadata if not overridden in the template schema.
-    bq_dataset_family = namespace.replace("-", "_")
-    bq_doctype = doctype.replace("-", "_")
-    version = schema_basename.split(".")[1]
-    bq_table = "{}_v{}".format(bq_doctype, version)
-    defaults = {
-        "bq_dataset_family": bq_dataset_family,
-        "bq_table": bq_table,
-        "bq_metadata_format": "structured",
-    }
-    merge_where_empty(meta, defaults)
-    if inject_metadata:
+    if inject_default_metadata:
+        bq_dataset_family = namespace.replace("-", "_")
+        bq_doctype = doctype.replace("-", "_")
+        version = schema_basename.split(".")[1]
+        bq_table = "{}_v{}".format(bq_doctype, version)
+        defaults = {
+            "bq_dataset_family": bq_dataset_family,
+            "bq_table": bq_table,
+            "bq_metadata_format": "structured",
+        }
+        merge_where_empty(meta, defaults)
+    if propagate_metadata:
         schema[MOZ_PIPELINE_METADATA] = meta
     else:
         schema.pop(MOZ_PIPELINE_METADATA, None)

--- a/templates/glean/defaults.schema.json
+++ b/templates/glean/defaults.schema.json
@@ -1,5 +1,3 @@
 {
-  "mozPipelineMetadata": {
-    "json_object_path_regex": "metrics\\.object\\..*"
-  }
+  "mozPipelineMetadata": false
 }

--- a/templates/include/glean/glean.1.schema.json
+++ b/templates/include/glean/glean.1.schema.json
@@ -4,6 +4,9 @@
   "description": "Schema for the ping content sent by Mozilla's glean telemetry SDK\n",
   "$id": "moz://mozilla.org/schemas/glean/ping/1",
   "type": "object",
+  "mozPipelineMetadata": {
+    "json_object_path_regex": "metrics\\.object\\..*"
+  },
   "properties": {
     "$schema": {
       "type": "string",


### PR DESCRIPTION
Alternate to https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/805 that allows omission of default metadata while still propagating any explicitly set `mozPipelineMetadata`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
