### PR TITLE
Update remote Docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
             git fetch --all
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.7
+          # `default` is recommended by CircleCI: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176#what-do-i-need-to-do-2
+          version: default
       - run:
           name: Build Docker image
           command: docker build --pull -t mps .


### PR DESCRIPTION
We need to get out of deprecated image: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
