### PR TITLE
Bug 1875874 - Allow null distro and distroVersion in legacy telemetry

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -1276,11 +1276,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -1292,11 +1292,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -1283,11 +1283,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -1292,11 +1292,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -1292,11 +1292,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -269,10 +269,16 @@
         "os": {
           "properties": {
             "distro": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "distroVersion": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hasPrefetch": {
               "type": "boolean"

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -283,10 +283,16 @@
         "os": {
           "properties": {
             "distro": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "distroVersion": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "hasPrefetch": {
               "type": "boolean"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -1276,11 +1276,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1275,11 +1275,17 @@
               "properties": {
                 "distro": {
                   "description": "The name of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "distroVersion": {
                   "description": "The version of the Linux distribution. This is Linux only. `null` on failure.",
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "hasPrefetch": {
                   "description": "Whether or not the OS-based prefetch application start-up optimization is set. This is Windows-only. `null` on failure.",

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -1231,11 +1231,17 @@
               "description": "The version of the OS, e.g. '6.1'. This is `null` on failure."
             },
             "distro": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "The name of the Linux distribution. This is Linux only. `null` on failure."
             },
             "distroVersion": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "The version of the Linux distribution. This is Linux only. `null` on failure."
             },
             "kernelVersion": {

--- a/templates/include/telemetry/syncPayload.1.schema.json
+++ b/templates/include/telemetry/syncPayload.1.schema.json
@@ -11,10 +11,16 @@
         "version": { "type": "string" },
         "locale": { "type": "string" },
         "distro": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "distroVersion": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kernelVersion": {
           "type": "string"


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/799 to address https://bugzilla.mozilla.org/show_bug.cgi?id=1875874 and https://bugzilla.mozilla.org/show_bug.cgi?id=1877339.

Related incident doc: https://docs.google.com/document/d/1M7ageyDdS8sha0vYTbWwJrsRylrJgUYArjogCpHeL2Q/edit

This change allows distro and distroVersion to be present and null instead of either not present or present and non-null.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
