### PR TITLE
Add `include_client_id` and `include_info_sections` to metaschema

### DIFF
--- a/schemas/metadata/metaschema/metaschema.1.schema.json
+++ b/schemas/metadata/metaschema/metaschema.1.schema.json
@@ -48,6 +48,14 @@
           "description": "If present, how many additional entries (beyond two) to skip in x_forwarded_for when performing geoip decoding, useful when submissions are ingested from trusted proxies; if there are fewer entries in x_forwarded_for than (N+1) the last entry is used instead of (N+3)rd-to-last",
           "type": "integer"
         },
+        "include_client_id": {
+          "description": "Glean ping property that determines whether a client id is sent in the ping.",
+          "type": "boolean"
+        },
+        "include_info_sections": {
+          "description": "Glean ping property that determines whether info sections are sent, e.g. client_info, ping_info.",
+          "type": "boolean"
+        },
         "json_object_path_regex": {
           "description": "The path for which a JSON column will be enforced. This should be a regular expression which is used by the jsonschema-transpiler to match against the fully qualified name of a metric",
           "type": "string"

--- a/templates/metadata/metaschema/metaschema.1.schema.json
+++ b/templates/metadata/metaschema/metaschema.1.schema.json
@@ -47,6 +47,14 @@
             }
           }
         },
+        "include_info_sections": {
+          "type": "boolean",
+          "description": "Glean ping property that determines whether info sections are sent, e.g. client_info, ping_info."
+        },
+        "include_client_id": {
+          "type": "boolean",
+          "description": "Glean ping property that determines whether a client id is sent in the ping."
+        },
         "override_attributes": {
           "type": "array",
           "description": "Mappings of Pub/Sub attribute names to static values; these are applied in the Decoder immediately before incorporating metadata into the payload, so can be used to overwrite values calculated in the pipeline; a null value will cause the pipeline to drop the named attribute; some attribute names differ from the nested metadata format in BigQuery, so for example you must use \"geo_city\" here in order to manipulate the value that shows up as metadata.geo.city; implemented for bug 1742172",


### PR DESCRIPTION
Adding/documenting two new fields that were added for glean pings in https://github.com/mozilla/mozilla-schema-generator/pull/261 and https://github.com/mozilla/mozilla-schema-generator/pull/268

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
