### PR TITLE
Bug 1901263: Add `profileGroupId` to schemas.

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -1494,6 +1494,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "bhr"

--- a/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -306,6 +306,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "block-autoplay"

--- a/schemas/telemetry/core/core.1.schema.json
+++ b/schemas/telemetry/core/core.1.schema.json
@@ -34,6 +34,11 @@
     "osversion": {
       "type": "string"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"

--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -380,6 +380,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "searches": {
       "additionalProperties": {
         "type": "integer"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1813,6 +1813,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "crash"

--- a/schemas/telemetry/deletion-request/deletion-request.4.schema.json
+++ b/schemas/telemetry/deletion-request/deletion-request.4.schema.json
@@ -100,6 +100,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "deletion-request"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -4369,6 +4369,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "dnssec-study-v1"

--- a/schemas/telemetry/downgrade/downgrade.4.schema.json
+++ b/schemas/telemetry/downgrade/downgrade.4.schema.json
@@ -94,6 +94,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "downgrade"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -1693,6 +1693,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "event"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -3550,6 +3550,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "first-shutdown"

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -91,6 +91,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.json
@@ -115,6 +115,11 @@
         "study_addon_version"
       ]
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "frecency-update"

--- a/schemas/telemetry/health/health.4.schema.json
+++ b/schemas/telemetry/health/health.4.schema.json
@@ -132,6 +132,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "health"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -1512,6 +1512,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "heartbeat"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -3550,6 +3550,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "main",

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -91,6 +91,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"

--- a/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -185,6 +185,11 @@
     "profileDate": {
       "type": "integer"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "seq": {
       "minimum": 0,
       "type": "integer"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -1473,6 +1473,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "modules"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -1745,6 +1745,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "new-profile"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -3550,6 +3550,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "saved-session"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -1497,6 +1497,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "shield-icq-v1"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -1467,6 +1467,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "testpilot"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -1638,6 +1638,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "third-party-modules"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -1439,6 +1439,11 @@
       },
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "uninstall"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -1567,6 +1567,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "untrustedModules"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -1487,6 +1487,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "update"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -1652,6 +1652,11 @@
       ],
       "type": "object"
     },
+    "profileGroupId": {
+      "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
     "type": {
       "enum": [
         "voice"

--- a/templates/include/telemetry/clientId.1.schema.json
+++ b/templates/include/telemetry/clientId.1.schema.json
@@ -1,4 +1,9 @@
 "clientId": {
   "type": "string",
   @COMMON_PATTERN_UUID_1_JSON@
+},
+"profileGroupId": {
+  "type": "string",
+  "description": "A UUID identifying the profile's group on a single device and allowing user-oriented correlation of data",
+  @COMMON_PATTERN_UUID_1_JSON@
 }

--- a/validation/telemetry/main.4.bad-profile-group-id.fail.json
+++ b/validation/telemetry/main.4.bad-profile-group-id.fail.json
@@ -10,7 +10,7 @@
     "xpcomAbi": "x86_64-gcc3"
   },
   "clientId": "6fd3eb50-8bec-4b9c-8778-59406171312a",
-  "profileGroupId": "614b137c-e278-489b-b152-8dc28e82d3c9",
+  "profileGroupId": "badid",
   "creationDate": "2015-11-05T01:25:43.312Z",
   "type": "main",
   "id": "0fdac909-d2ec-454c-b625-261a3e5d5c9b",


### PR DESCRIPTION
This adds the `profileGroupId` being added to the client side in bug 1901263 to the schemas wherever the `clientId` is present. I believe that every ping including `clientId` will include `profileGroupId` however since the new property is not marked as required in any schema (as it cannot be to avoid breaking older versions of Firefox) if new pings are introduced that do not include the property then it should not break anything.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
