### PR TITLE
Pin setuptools version to 70.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ COPY --from=mozilla/ingestion-sink:latest /app/ingestion-sink/target /app/target
 
 # Install python dependencies
 COPY requirements.txt requirements-dev.txt ./
-RUN pip3 install --upgrade pip setuptools && \
+RUN pip3 install --upgrade pip setuptools==70.3.0 && \
     pip3 install -r requirements.txt -r requirements-dev.txt
 
 # Install Java dependencies


### PR DESCRIPTION
Recent releases of setuptools cause the build to fail. This fixes it and will unblock https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/822

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
