### PR TITLE
Bug 1910462 - Add msstoresignedin to legacy telemetry environment

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -529,6 +529,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -542,6 +542,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -536,6 +536,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -542,6 +542,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -542,6 +542,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -529,6 +529,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -525,6 +525,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -528,6 +528,10 @@
                   "description": "Category of the source, such as 'organic' for a search engine.",
                   "type": "string"
                 },
+                "msstoresignedin": {
+                  "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise.",
+                  "type": "boolean"
+                },
                 "source": {
                   "description": "Referring partner domain, when install happens via a known partner.",
                   "type": "string"

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -465,6 +465,10 @@
             "dlsource": {
               "type": "string",
               "description": "Identifier that indicates where installations of Firefox originate, see bug 1827233"
+            },
+            "msstoresignedin": {
+              "type": "boolean",
+              "description": " Optional, only present if the installation was done through the Microsoft Store, and was able to retrieve the \"campaign ID\" it was first installed with. This value is \"true\" if the user was signed into the Microsoft Store when they first installed, and false otherwise."
             }
           }
         },

--- a/validation/telemetry/event.4.sample.pass.json
+++ b/validation/telemetry/event.4.sample.pass.json
@@ -195,7 +195,10 @@
         "origin": "default",
         "submissionURL": "https://www.google.com/search?q=&ie=utf-8&oe=utf-8&client=firefox-b"
       },
-      "searchCohort": "nov17-2"
+      "searchCohort": "nov17-2",
+      "attribution": {
+        "msstoresignedin": false
+      }
     },
     "profile": {
       "creationDate": 17660


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1910462

This was added to firefox two years ago but never added to the schema and didn't have significant volume until now https://searchfox.org/mozilla-central/source/toolkit/components/telemetry/docs/data/environment.rst#88

Verified the path with

```sql
SELECT
  additional_properties
FROM
  `moz-fx-data-shared-prod.telemetry_stable.event_v4`
WHERE
  DATE(submission_timestamp) = '2024-07-29'
  AND additional_properties LIKE '%"msstoresignedin"%'
  AND sample_id = 5
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
