### PR TITLE
[Bug 1929078] Increase maxLength for labeled groups to 71

### DIFF
--- a/schemas/glean/glean/glean-min.1.schema.json
+++ b/schemas/glean/glean/glean-min.1.schema.json
@@ -135,7 +135,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -154,7 +154,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -195,7 +195,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -235,7 +235,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -269,7 +269,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -288,7 +288,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -364,7 +364,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -221,7 +221,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -240,7 +240,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -281,7 +281,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -321,7 +321,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -355,7 +355,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -374,7 +374,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"
@@ -450,7 +450,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 61,
+              "maxLength": 71,
               "type": "string"
             },
             "type": "object"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Increase maximum character limit for metric labels from 61 to 71 [Bug 1929078](https://bugzilla.mozilla.org/show_bug.cgi?id=1929078)
+
 - New metric types `labeled_{custom|memory|timing}_distribution` [bug 1657947](https://bugzilla.mozilla.org/show_bug.cgi?id=1657947).
 
 - Added new schema "glean-min" which contains `metrics` and `events` but does not have `*_info` top level properties. Used to support pings that are configured to exclude the standard Glean `info` fields.

--- a/templates/include/glean/labeled_group.1.schema.json
+++ b/templates/include/glean/labeled_group.1.schema.json
@@ -2,5 +2,5 @@
 "propertyNames": {
   "type": "string",
   "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-  "maxLength": 61
+  "maxLength": 71
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1929078
This should fix the increase we are seeing in `org.everit.json.schema.ValidationException: #/metrics/labeled_boolean/browser.ui.mirror_for_toolbar_widgets/<some long label>: expected maxLength: 61, actual: <some number bigger than 61>`

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
