### PR TITLE
Bug 1932210 - Add labeled_quantity glean metric type

### DIFF
--- a/schemas/glean/glean/glean-min.1.schema.json
+++ b/schemas/glean/glean/glean-min.1.schema.json
@@ -247,6 +247,25 @@
           },
           "type": "object"
         },
+        "labeled_quantity": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 71,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 111,
+            "pattern": "^[a-z_][a-z0-9_\\.]+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
         "labeled_rate": {
           "additionalProperties": {
             "additionalProperties": {

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -333,6 +333,25 @@
           },
           "type": "object"
         },
+        "labeled_quantity": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
+              "maxLength": 71,
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "propertyNames": {
+            "maxLength": 111,
+            "pattern": "^[a-z_][a-z0-9_\\.]+$",
+            "type": "string"
+          },
+          "type": "object"
+        },
         "labeled_rate": {
           "additionalProperties": {
             "additionalProperties": {

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- New metric type `labeled_quantity` [Bug 1932210](https://bugzilla.mozilla.org/show_bug.cgi?id=1932210)
+
 - Increase maximum character limit for metric labels from 61 to 71 [Bug 1929078](https://bugzilla.mozilla.org/show_bug.cgi?id=1929078)
 
 - New metric types `labeled_{custom|memory|timing}_distribution` [bug 1657947](https://bugzilla.mozilla.org/show_bug.cgi?id=1657947).

--- a/templates/include/glean/metrics.1.schema.json
+++ b/templates/include/glean/metrics.1.schema.json
@@ -42,6 +42,13 @@
         @GLEAN_BASE_OBJECT_1_JSON@,
       "additionalProperties": @GLEAN_QUANTITY_1_JSON@
     },
+    "labeled_quantity": {
+        @GLEAN_BASE_OBJECT_1_JSON@,
+      "additionalProperties": {
+        @GLEAN_LABELED_GROUP_1_JSON@,
+        "additionalProperties": @GLEAN_QUANTITY_1_JSON@
+      }
+    },
     "timespan": {
         @GLEAN_BASE_OBJECT_1_JSON@,
       "additionalProperties": @GLEAN_TIMESPAN_1_JSON@


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1932210

Goes with https://github.com/mozilla/mozilla-schema-generator/pull/281

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
