### PR TITLE
Reduce max table expiration days from 10,000 to 9,985

### DIFF
--- a/schemas/coverage/coverage/coverage.1.schema.json
+++ b/schemas/coverage/coverage/coverage.1.schema.json
@@ -7,7 +7,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "coverage_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/schemas/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "default_browser_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     },
     "sample_id_source_uuid_attribute": "document_id"
   },

--- a/schemas/eng-workflow/bmobugs/bmobugs.1.schema.json
+++ b/schemas/eng-workflow/bmobugs/bmobugs.1.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "bmobugs_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/eng-workflow/build/build.1.schema.json
+++ b/schemas/eng-workflow/build/build.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "build_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/eng-workflow/hgpush/hgpush.1.schema.json
+++ b/schemas/eng-workflow/hgpush/hgpush.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "hgpush_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/schemas/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "activity_flow_metrics_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {},

--- a/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/schemas/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "amplitude_event_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/firefox-installer/install/install.1.schema.json
+++ b/schemas/firefox-installer/install/install.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "install_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     },
     "sample_id_source_uuid_attribute": "document_id"
   },

--- a/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/schemas/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "launcher_process_failure_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/mobile/activation/activation.1.schema.json
+++ b/schemas/mobile/activation/activation.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "activation_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "oneOf": [

--- a/schemas/pocket/fire-tv-events/fire-tv-events.1.schema.json
+++ b/schemas/pocket/fire-tv-events/fire-tv-events.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "fire_tv_events_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/anonymous/anonymous.4.schema.json
+++ b/schemas/telemetry/anonymous/anonymous.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "anonymous_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "bhr_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/schemas/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "block_autoplay_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.1.schema.json
+++ b/schemas/telemetry/core/core.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.10.schema.json
+++ b/schemas/telemetry/core/core.10.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v10",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.2.schema.json
+++ b/schemas/telemetry/core/core.2.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v2",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.3.schema.json
+++ b/schemas/telemetry/core/core.3.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v3",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.4.schema.json
+++ b/schemas/telemetry/core/core.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.5.schema.json
+++ b/schemas/telemetry/core/core.5.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v5",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.6.schema.json
+++ b/schemas/telemetry/core/core.6.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v6",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.7.schema.json
+++ b/schemas/telemetry/core/core.7.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v7",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.8.schema.json
+++ b/schemas/telemetry/core/core.8.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v8",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/core/core.9.schema.json
+++ b/schemas/telemetry/core/core.9.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "core_v9",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "crash_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/deletion-request/deletion-request.4.schema.json
+++ b/schemas/telemetry/deletion-request/deletion-request.4.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "deletion_request_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "dnssec_study_v1_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/downgrade/downgrade.4.schema.json
+++ b/schemas/telemetry/downgrade/downgrade.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "downgrade_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "event_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/focus-event/focus-event.1.schema.json
+++ b/schemas/telemetry/focus-event/focus-event.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "focus_event_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/schemas/telemetry/frecency-update/frecency-update.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "frecency_update_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/health/health.4.schema.json
+++ b/schemas/telemetry/health/health.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "health_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "heartbeat_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/installation/installation.1.schema.json
+++ b/schemas/telemetry/installation/installation.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "installation_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/schemas/telemetry/mobile-event/mobile-event.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "mobile_event_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/schemas/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "mobile_metrics_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "modules_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "new_profile_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/schemas/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "normandy_login_study_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/optout/optout.4.schema.json
+++ b/schemas/telemetry/optout/optout.4.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "optout_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/pre-account/pre-account.4.schema.json
+++ b/schemas/telemetry/pre-account/pre-account.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "pre_account_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/prio/prio.4.schema.json
+++ b/schemas/telemetry/prio/prio.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "prio_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "shield_icq_v1_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/shield-study-addon/shield-study-addon.3.schema.json
+++ b/schemas/telemetry/shield-study-addon/shield-study-addon.3.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "shield_study_addon_v3",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/shield-study-error/shield-study-error.3.schema.json
+++ b/schemas/telemetry/shield-study-error/shield-study-error.3.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "shield_study_error_v3",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/shield-study/shield-study.3.schema.json
+++ b/schemas/telemetry/shield-study/shield-study.3.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "shield_study_v3",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/sync/sync.4.schema.json
+++ b/schemas/telemetry/sync/sync.4.schema.json
@@ -7,7 +7,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "sync_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/sync/sync.5.schema.json
+++ b/schemas/telemetry/sync/sync.5.schema.json
@@ -7,7 +7,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "sync_v5",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "testpilot_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "third_party_modules_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "uninstall_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "untrusted_modules_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/voice-feedback/voice-feedback.4.schema.json
+++ b/schemas/telemetry/voice-feedback/voice-feedback.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "voice_feedback_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -5,7 +5,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "voice_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/schemas/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -6,7 +6,7 @@
     "bq_metadata_format": "telemetry",
     "bq_table": "xfocsp_error_report_v4",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/schemas/webpagetest/webpagetest-run/webpagetest-run.1.schema.json
+++ b/schemas/webpagetest/webpagetest-run/webpagetest-run.1.schema.json
@@ -7,7 +7,7 @@
     "bq_metadata_format": "structured",
     "bq_table": "webpagetest_run_v1",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/templates/coverage/coverage/coverage.1.schema.json
+++ b/templates/coverage/coverage/coverage.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/default-browser-agent/default-browser/default-browser.1.schema.json
+++ b/templates/default-browser-agent/default-browser/default-browser.1.schema.json
@@ -3,7 +3,7 @@
   "mozPipelineMetadata": {
     "sample_id_source_uuid_attribute": "document_id",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/templates/eng-workflow/bmobugs/bmobugs.1.schema.json
+++ b/templates/eng-workflow/bmobugs/bmobugs.1.schema.json
@@ -2,7 +2,7 @@
    "$schema" : "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
    "additionalProperties" : false,

--- a/templates/eng-workflow/build/build.1.schema.json
+++ b/templates/eng-workflow/build/build.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/templates/eng-workflow/hgpush/hgpush.1.schema.json
+++ b/templates/eng-workflow/hgpush/hgpush.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "hgpush",

--- a/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
+++ b/templates/firefox-accounts/activity-flow-metrics/activity-flow-metrics.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
+++ b/templates/firefox-accounts/amplitude-event/amplitude-event.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/firefox-installer/install/install.1.schema.json
+++ b/templates/firefox-installer/install/install.1.schema.json
@@ -3,7 +3,7 @@
   "mozPipelineMetadata": {
     "sample_id_source_uuid_attribute": "document_id",
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "install",

--- a/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
+++ b/templates/firefox-launcher-process/launcher-process-failure/launcher-process-failure.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "properties": {

--- a/templates/mobile/activation/activation.1.schema.json
+++ b/templates/mobile/activation/activation.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/pocket/fire-tv-events/fire-tv-events.1.schema.json
+++ b/templates/pocket/fire-tv-events/fire-tv-events.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/anonymous/anonymous.4.schema.json
+++ b/templates/telemetry/anonymous/anonymous.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/bhr/bhr.4.schema.json
+++ b/templates/telemetry/bhr/bhr.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "$comment": "Bug 1675103 - Define the bhr ping schema.",

--- a/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
+++ b/templates/telemetry/block-autoplay/block-autoplay.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.1.schema.json
+++ b/templates/telemetry/core/core.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.10.schema.json
+++ b/templates/telemetry/core/core.10.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.2.schema.json
+++ b/templates/telemetry/core/core.2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.3.schema.json
+++ b/templates/telemetry/core/core.3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.4.schema.json
+++ b/templates/telemetry/core/core.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.5.schema.json
+++ b/templates/telemetry/core/core.5.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.6.schema.json
+++ b/templates/telemetry/core/core.6.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.7.schema.json
+++ b/templates/telemetry/core/core.7.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.8.schema.json
+++ b/templates/telemetry/core/core.8.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/core/core.9.schema.json
+++ b/templates/telemetry/core/core.9.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/deletion-request/deletion-request.4.schema.json
+++ b/templates/telemetry/deletion-request/deletion-request.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/templates/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/downgrade/downgrade.4.schema.json
+++ b/templates/telemetry/downgrade/downgrade.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/event/event.4.schema.json
+++ b/templates/telemetry/event/event.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/focus-event/focus-event.1.schema.json
+++ b/templates/telemetry/focus-event/focus-event.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/frecency-update/frecency-update.4.schema.json
+++ b/templates/telemetry/frecency-update/frecency-update.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "frecency-update",

--- a/templates/telemetry/health/health.4.schema.json
+++ b/templates/telemetry/health/health.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "health",

--- a/templates/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/templates/telemetry/heartbeat/heartbeat.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "heartbeat",

--- a/templates/telemetry/installation/installation.1.schema.json
+++ b/templates/telemetry/installation/installation.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/mobile-event/mobile-event.1.schema.json
+++ b/templates/telemetry/mobile-event/mobile-event.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/mobile-metrics/mobile-metrics.1.schema.json
+++ b/templates/telemetry/mobile-metrics/mobile-metrics.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/modules/modules.4.schema.json
+++ b/templates/telemetry/modules/modules.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/new-profile/new-profile.4.schema.json
+++ b/templates/telemetry/new-profile/new-profile.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
+++ b/templates/telemetry/normandy-login-study/normandy-login-study.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/optout/optout.4.schema.json
+++ b/templates/telemetry/optout/optout.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/pre-account/pre-account.4.schema.json
+++ b/templates/telemetry/pre-account/pre-account.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/prio/prio.4.schema.json
+++ b/templates/telemetry/prio/prio.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/templates/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/shield-study-addon/shield-study-addon.3.schema.json
+++ b/templates/telemetry/shield-study-addon/shield-study-addon.3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "shield-study-addon",

--- a/templates/telemetry/shield-study-error/shield-study-error.3.schema.json
+++ b/templates/telemetry/shield-study-error/shield-study-error.3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "shield-study-error",

--- a/templates/telemetry/shield-study/shield-study.3.schema.json
+++ b/templates/telemetry/shield-study/shield-study.3.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "title": "shield-study",

--- a/templates/telemetry/sync/sync.4.schema.json
+++ b/templates/telemetry/sync/sync.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/sync/sync.5.schema.json
+++ b/templates/telemetry/sync/sync.5.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/testpilot/testpilot.4.schema.json
+++ b/templates/telemetry/testpilot/testpilot.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/templates/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/uninstall/uninstall.4.schema.json
+++ b/templates/telemetry/uninstall/uninstall.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/templates/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/voice-feedback/voice-feedback.4.schema.json
+++ b/templates/telemetry/voice-feedback/voice-feedback.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/voice/voice.4.schema.json
+++ b/templates/telemetry/voice/voice.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
+++ b/templates/telemetry/xfocsp-error-report/xfocsp-error-report.4.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",

--- a/templates/webpagetest/webpagetest-run/webpagetest-run.1.schema.json
+++ b/templates/webpagetest/webpagetest-run/webpagetest-run.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "mozPipelineMetadata": {
     "expiration_policy": {
-      "delete_after_days": 10000
+      "delete_after_days": 9985
     }
   },
   "type": "object",


### PR DESCRIPTION
Tables can have a maximum of 10,000 partitions, but when partitions expire they apparently continue to count toward the table's partition quota for up to 14 days afterwards (7 days of time travel and 7 days of fail-safe), per the [BigQuery docs](https://cloud.google.com/bigquery/docs/managing-partitioned-tables#partition-expiration):
> When a partition expires, BigQuery deletes that partition. The partition data is retained in accordance with [time travel](https://cloud.google.com/bigquery/docs/time-travel) and [fail-safe](https://cloud.google.com/bigquery/docs/time-travel#fail-safe) policies, and can be charged for, depending on your billing model. Until then, the partition counts for purposes of [table quotas](https://cloud.google.com/bigquery/quotas#partitioned_tables).

And I subtracted one additional day just to make sure we don't hit the table partition limit.

This goes along with https://github.com/mozilla/probe-scraper/pull/840.

---
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
