### PR TITLE
[Bug 1952961] Add NimbusEnrollments to crash schema

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1567,6 +1567,10 @@
               "description": "<reason>, Optional, contains the string passed to MOZ_CRASH()",
               "type": "string"
             },
+            "NimbusEnrollments": {
+              "description": "Optional, a omma-separated string that specifies the active Nimbus experiments and rollouts, as well as their branches",
+              "type": "string"
+            },
             "OOMAllocationSize": {
               "description": "<size>, Size of the allocation that caused an OOM",
               "type": "string"

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -146,6 +146,10 @@
               "description": "<reason>, Optional, contains the string passed to MOZ_CRASH()",
               "type": "string"
             },
+            "NimbusEnrollments": {
+              "description": "Optional, a omma-separated string that specifies the active Nimbus experiments and rollouts, as well as their branches",
+              "type": "string"
+            },
             "OOMAllocationSize": {
               "description": "<size>, Size of the allocation that caused an OOM",
               "type": "string"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1952961

Add missing field `payload`.`metadata`.`NimbusEnrollments`


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
