### PR TITLE
[Bug 1928441] Add pcount, mcount, ecount to cpu environment

### DIFF
--- a/schemas/telemetry/bhr/bhr.4.schema.json
+++ b/schemas/telemetry/bhr/bhr.4.schema.json
@@ -775,6 +775,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -807,6 +814,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -818,6 +832,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
+++ b/schemas/telemetry/dnssec-study-v1/dnssec-study-v1.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/event/event.4.schema.json
+++ b/schemas/telemetry/event/event.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
+++ b/schemas/telemetry/first-shutdown/first-shutdown.4.schema.json
@@ -791,6 +791,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -823,6 +830,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -834,6 +848,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/heartbeat/heartbeat.4.schema.json
+++ b/schemas/telemetry/heartbeat/heartbeat.4.schema.json
@@ -782,6 +782,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -814,6 +821,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -825,6 +839,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/main/main.4.schema.json
+++ b/schemas/telemetry/main/main.4.schema.json
@@ -791,6 +791,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -823,6 +830,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -834,6 +848,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/modules/modules.4.schema.json
+++ b/schemas/telemetry/modules/modules.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/new-profile/new-profile.4.schema.json
+++ b/schemas/telemetry/new-profile/new-profile.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/saved-session/saved-session.4.schema.json
+++ b/schemas/telemetry/saved-session/saved-session.4.schema.json
@@ -791,6 +791,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -823,6 +830,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -834,6 +848,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
+++ b/schemas/telemetry/shield-icq-v1/shield-icq-v1.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/testpilot/testpilot.4.schema.json
+++ b/schemas/telemetry/testpilot/testpilot.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
+++ b/schemas/telemetry/third-party-modules/third-party-modules.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/uninstall/uninstall.4.schema.json
+++ b/schemas/telemetry/uninstall/uninstall.4.schema.json
@@ -775,6 +775,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -807,6 +814,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -818,6 +832,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
+++ b/schemas/telemetry/untrusted-modules/untrusted-modules.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/update/update.4.schema.json
+++ b/schemas/telemetry/update/update.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/schemas/telemetry/voice/voice.4.schema.json
+++ b/schemas/telemetry/voice/voice.4.schema.json
@@ -774,6 +774,13 @@
                   "minimum": 1,
                   "type": "integer"
                 },
+                "ecount": {
+                  "description": "Heterogeneous CPU info for little CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "extensions": {
                   "description": "This lists the avaible CPU extensions as strings. E.g.: 'hasMMX', 'hasSSE', 'hasSSE2', 'hasSSE3', 'hasSSSE3', 'hasSSE4A', 'hasSSE4_1', 'hasSSE4_2', 'hasAVX', 'hasAVX2', 'hasAES', 'hasEDSP', 'hasARMv6', 'hasARMv7', 'hasNEON'.",
                   "items": {
@@ -806,6 +813,13 @@
                     "null"
                   ]
                 },
+                "mcount": {
+                  "description": "Heterogeneous CPU info for medium CPUs.",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "model": {
                   "description": "The CPU model, `null` on failure. Desktop only.",
                   "type": [
@@ -817,6 +831,13 @@
                   "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only.",
                   "type": [
                     "string",
+                    "null"
+                  ]
+                },
+                "pcount": {
+                  "description": "Heterogeneous CPU info for big CPUs.",
+                  "type": [
+                    "integer",
                     "null"
                   ]
                 },

--- a/templates/include/telemetry/environment.1.schema.json
+++ b/templates/include/telemetry/environment.1.schema.json
@@ -711,6 +711,13 @@
               "maximum": 1024,
               "description": "The number of logical CPUs. Desktop only, e.g. 8, or `null` on failure."
             },
+            "ecount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Heterogeneous CPU info for little CPUs."
+            },
             "extensions": {
               "type": "array",
               "items": {
@@ -743,6 +750,13 @@
               ],
               "description": "The CPU L3 cache size in KB. `null` on failure. Desktop only."
             },
+            "mcount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Heterogeneous CPU info for medium CPUs."
+            },
             "model": {
               "type": [
                 "integer",
@@ -756,6 +770,13 @@
                 "null"
               ],
               "description": "The CPU name, e.g. 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz', or `null` on failure. Desktop only."
+            },
+            "pcount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Heterogeneous CPU info for big CPUs."
             },
             "speedMHz": {
               "type": [


### PR DESCRIPTION
Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1926292

`ecount`, `pcount`, `mcount` got never added to the schemas and is showing up as missing column. I'm not sure if the description is accurate here since it also wasn't added to the docs in `environment.rst`. Maybe @Bas-moz or @chutten, can you check if the description makes sense?


https://bugzilla.mozilla.org/show_bug.cgi?id=1928441


Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
