### PR TITLE
Bug 1955428 - Add missing type property to client_info.attribution and client_info.distribution

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -59,7 +59,8 @@
               "description": "The attribution term (e.g. 'browser with developer tools for android').",
               "type": "string"
             }
-          }
+          },
+          "type": "object"
         },
         "build_date": {
           "description": "The date & time the application was built",
@@ -86,7 +87,8 @@
               "description": "The distribution name (e.g. 'MozillaOnline').",
               "type": "string"
             }
-          }
+          },
+          "type": "object"
         },
         "first_run_date": {
           "description": "The date of the first run of the application.",

--- a/templates/include/glean/client_info.1.schema.json
+++ b/templates/include/glean/client_info.1.schema.json
@@ -95,7 +95,8 @@
           "type": "string",
           "description": "The attribution content (e.g. 'firefoxview')."
         }
-      }
+      },
+      "type": "object"
     },
     "distribution": {
       "additionalProperties": false,
@@ -104,7 +105,8 @@
           "type": "string",
           "description": "The distribution name (e.g. 'MozillaOnline')."
         }
-      }
+      },
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
Follow up to https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/841

Missing `type`s caused [schema generator to fail today](https://workflow.telemetry.mozilla.org/dags/probe_scraper/grid?search=probe_scraper&dag_run_id=scheduled__2025-03-31T00%3A00%3A00%2B00%3A00&task_id=mozilla_schema_generator&tab=logs) with:
```
[2025-04-01, 04:58:21 UTC] {pod_manager.py:496} INFO - [base] Exception: Missing type for schema element at key client_info/attribution
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
