### PR TITLE
Set allowed Glean label maxLength to 111

### DIFF
--- a/schemas/glean/glean/glean-min.1.schema.json
+++ b/schemas/glean/glean/glean-min.1.schema.json
@@ -135,7 +135,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -154,7 +154,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -195,7 +195,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -235,7 +235,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -254,7 +254,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -288,7 +288,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -307,7 +307,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -383,7 +383,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -257,7 +257,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -276,7 +276,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -317,7 +317,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -357,7 +357,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -376,7 +376,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -410,7 +410,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -429,7 +429,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"
@@ -505,7 +505,7 @@
             },
             "propertyNames": {
               "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-              "maxLength": 71,
+              "maxLength": 111,
               "type": "string"
             },
             "type": "object"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version 1
 
+- Glean label `maxLength` increased from 71 to 111 
+
 - New client_info sections `attribution` and `distribution`, and their fields [Bug 1955428](https://bugzilla.mozilla.org/show_bug.cgi?id=1955428)
 
 - New metric type `labeled_quantity` [Bug 1932210](https://bugzilla.mozilla.org/show_bug.cgi?id=1932210)

--- a/templates/include/glean/labeled_group.1.schema.json
+++ b/templates/include/glean/labeled_group.1.schema.json
@@ -2,5 +2,5 @@
 "propertyNames": {
   "type": "string",
   "comment": "This must be at least the length of 'category.name' metric names to support error reporting",
-  "maxLength": 71
+  "maxLength": 111
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1965335 and https://bugzilla.mozilla.org/show_bug.cgi?id=1965337

The allowed label length is 111 after it got upped in https://bugzilla.mozilla.org/show_bug.cgi?id=1959696

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
