### PR TITLE
Add JSOutOfMemory to crash metadata

### DIFF
--- a/schemas/telemetry/crash/crash.4.schema.json
+++ b/schemas/telemetry/crash/crash.4.schema.json
@@ -1560,6 +1560,10 @@
               "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
               "type": "string"
             },
+            "JSOutOfMemory": {
+              "description": "A small allocation couldn't be satisfied, the annotation may contain the 'Reporting', 'Reported' or 'Recovered' value. The first one means that we crashed while responding to the OOM condition (possibly while running a memory-pressure observers), the second that we crashed after having tried to free some memory, and the last that the GC had managed to free enough memory to satisfy the allocation.",
+              "type": "string"
+            },
             "LastInteractionDuration": {
               "description": "How long the user had been inactive in seconds if the user was inactive at crash. The value is not set if the user state was active.",
               "type": "string"

--- a/templates/telemetry/crash/crash.4.schema.json
+++ b/templates/telemetry/crash/crash.4.schema.json
@@ -118,6 +118,10 @@
               "description": "1, Optional, if set indicates that the crash occurred while the garbage collector was running",
               "type": "string"
             },
+            "JSOutOfMemory": {
+              "description": "A small allocation couldn't be satisfied, the annotation may contain the 'Reporting', 'Reported' or 'Recovered' value. The first one means that we crashed while responding to the OOM condition (possibly while running a memory-pressure observers), the second that we crashed after having tried to free some memory, and the last that the GC had managed to free enough memory to satisfy the allocation.",
+              "type": "string"
+            },
             "LastInteractionDuration": {
               "description": "How long the user had been inactive in seconds if the user was inactive at crash. The value is not set if the user state was active.",
               "type": "string"


### PR DESCRIPTION
This field was [recently](https://bugzilla.mozilla.org/show_bug.cgi?id=1964092) added to the crash ping and showed up as [missing column in Bigeye](https://app.bigeye.com/w/463/issues/390512/metric?utm_medium=alert&utm_term=issue_390512&utm_source=slack)

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
