### PR TITLE
Set cmake minimum to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.18)
 project(mozilla-pipeline-schemas VERSION 0.0.9 LANGUAGES NONE)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Mozilla data ingestion and data lake schemas")
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ is a great resource.
 
 ### Prerequisites
 
-- [`CMake` (3.0+)](http://cmake.org/cmake/resources/software.html)
+- [`CMake` (3.18+)](http://cmake.org/cmake/resources/software.html)
 - [`jq` (1.5+)](https://github.com/stedolan/jq)
-- `python` (3.6+)
+- `python` (3.8+)
 - Optional: `java 11`, `maven`
 - Optional: [Docker](https://www.docker.com/get-started)
 


### PR DESCRIPTION
Cmake 4.0.0 removed compatibility for versions <[3.5](https://github.com/Kitware/CMake/releases/tag/v3.5.0): https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features.  I updated recently so build fails for me.  Setting to 3.18 which is the version in the debian docker image.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
