### PR TITLE
Bug 2028223 - Add more info to downgrade ping

### DIFF
--- a/schemas/telemetry/downgrade/downgrade.4.schema.json
+++ b/schemas/telemetry/downgrade/downgrade.4.schema.json
@@ -75,7 +75,28 @@
           "minimum": 0,
           "type": "number"
         },
+        "hasRestartPidParameter": {
+          "type": "boolean"
+        },
         "hasSync": {
+          "type": "boolean"
+        },
+        "isBackgroundTaskMode": {
+          "type": "boolean"
+        },
+        "isBackgroundTaskModeRequested": {
+          "type": "boolean"
+        },
+        "isMSIX": {
+          "type": "boolean"
+        },
+        "isRestartPidFailure": {
+          "type": "boolean"
+        },
+        "isRestartPidNotInteger": {
+          "type": "boolean"
+        },
+        "isRestartPidWaitTimeout": {
           "type": "boolean"
         },
         "lastBuildId": {

--- a/templates/telemetry/downgrade/downgrade.4.schema.json
+++ b/templates/telemetry/downgrade/downgrade.4.schema.json
@@ -39,6 +39,27 @@
           "type": "number",
           "minimum": 0,
           "maximum": 2
+        },
+        "isMSIX": {
+          "type": "boolean"
+        },
+        "isBackgroundTaskModeRequested": {
+          "type": "boolean"
+        },
+        "isBackgroundTaskMode": {
+          "type": "boolean"
+        },
+        "hasRestartPidParameter": {
+          "type": "boolean"
+        },
+        "isRestartPidNotInteger": {
+          "type": "boolean"
+        },
+        "isRestartPidWaitTimeout": {
+          "type": "boolean"
+        },
+        "isRestartPidFailure": {
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
Add metrics to the downgrade ping to show:

    Is this an MSIX install (on Windows)
    Is this downgrade ping shown as part of the update experience?
    Is this downgrade ping related to a background task?

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
