### PR TITLE
Bug 2020962 - Add session metadata to Glean events

### DIFF
--- a/schemas/glean/glean/glean-min.1.schema.json
+++ b/schemas/glean/glean/glean-min.1.schema.json
@@ -33,6 +33,43 @@
           "name": {
             "type": "string"
           },
+          "session": {
+            "additionalProperties": false,
+            "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+            "properties": {
+              "event_seq": {
+                "description": "Per-session event counter, reset at each new session.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_id": {
+                "description": "The unique UUID for this session.",
+                "type": "string"
+              },
+              "session_sample_rate": {
+                "description": "The sampling rate in effect for this session.",
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              "session_seq": {
+                "description": "Monotonically increasing session counter, persisted across restarts.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_start_time": {
+                "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "session_seq",
+              "event_seq",
+              "session_sample_rate"
+            ],
+            "type": "object"
+          },
           "timestamp": {
             "minimum": 0,
             "type": "integer"

--- a/schemas/glean/glean/glean-min.2.schema.json
+++ b/schemas/glean/glean/glean-min.2.schema.json
@@ -33,6 +33,43 @@
           "name": {
             "type": "string"
           },
+          "session": {
+            "additionalProperties": false,
+            "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+            "properties": {
+              "event_seq": {
+                "description": "Per-session event counter, reset at each new session.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_id": {
+                "description": "The unique UUID for this session.",
+                "type": "string"
+              },
+              "session_sample_rate": {
+                "description": "The sampling rate in effect for this session.",
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              "session_seq": {
+                "description": "Monotonically increasing session counter, persisted across restarts.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_start_time": {
+                "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "session_seq",
+              "event_seq",
+              "session_sample_rate"
+            ],
+            "type": "object"
+          },
           "timestamp": {
             "minimum": 0,
             "type": "integer"

--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -155,6 +155,43 @@
           "name": {
             "type": "string"
           },
+          "session": {
+            "additionalProperties": false,
+            "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+            "properties": {
+              "event_seq": {
+                "description": "Per-session event counter, reset at each new session.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_id": {
+                "description": "The unique UUID for this session.",
+                "type": "string"
+              },
+              "session_sample_rate": {
+                "description": "The sampling rate in effect for this session.",
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              "session_seq": {
+                "description": "Monotonically increasing session counter, persisted across restarts.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_start_time": {
+                "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "session_seq",
+              "event_seq",
+              "session_sample_rate"
+            ],
+            "type": "object"
+          },
           "timestamp": {
             "minimum": 0,
             "type": "integer"

--- a/schemas/glean/glean/glean.2.schema.json
+++ b/schemas/glean/glean/glean.2.schema.json
@@ -155,6 +155,43 @@
           "name": {
             "type": "string"
           },
+          "session": {
+            "additionalProperties": false,
+            "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+            "properties": {
+              "event_seq": {
+                "description": "Per-session event counter, reset at each new session.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_id": {
+                "description": "The unique UUID for this session.",
+                "type": "string"
+              },
+              "session_sample_rate": {
+                "description": "The sampling rate in effect for this session.",
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              "session_seq": {
+                "description": "Monotonically increasing session counter, persisted across restarts.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_start_time": {
+                "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "session_seq",
+              "event_seq",
+              "session_sample_rate"
+            ],
+            "type": "object"
+          },
           "timestamp": {
             "minimum": 0,
             "type": "integer"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -104,3 +104,5 @@
   `labeled_use_counter`, `usage`, `labeled_usage`, and `labeled_uuid`.
 
 - The `ping_info` section now includes a `server_knobs_config` field which contains the complete Server Knobs configuration applied via `applyServerKnobsConfig`. This includes the `metrics_enabled`, `pings_enabled`, and `event_threshold` settings.
+
+- Session metadata has been added for Glean events, in a `session_metadata` section.

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -105,4 +105,4 @@
 
 - The `ping_info` section now includes a `server_knobs_config` field which contains the complete Server Knobs configuration applied via `applyServerKnobsConfig`. This includes the `metrics_enabled`, `pings_enabled`, and `event_threshold` settings.
 
-- Session metadata has been added for Glean events, in a `session_metadata` section.
+- Session metadata has been added for Glean events, in a `session` field on each event.

--- a/templates/include/glean/event.1.schema.json
+++ b/templates/include/glean/event.1.schema.json
@@ -21,6 +21,43 @@
         "type": "string",
         "maxLength": 40
       }
+    },
+    "session": {
+      "type": "object",
+      "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+      "additionalProperties": false,
+      "required": [
+        "session_id",
+        "session_seq",
+        "event_seq",
+        "session_sample_rate"
+      ],
+      "properties": {
+        "session_id": {
+          "type": "string",
+          "description": "The unique UUID for this session."
+        },
+        "session_seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonically increasing session counter, persisted across restarts."
+        },
+        "event_seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Per-session event counter, reset at each new session."
+        },
+        "session_sample_rate": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "The sampling rate in effect for this session."
+        },
+        "session_start_time": {
+          "type": "string",
+          "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced."
+        }
+      }
     }
   },
   "required": [

--- a/validation/glean/glean.1.events_session_extra_properties.fail.json
+++ b/validation/glean/glean.1.events_session_extra_properties.fail.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "client_info": {
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "architecture": "arm",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "events",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25"
+  },
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "ui",
+      "name": "click",
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3,
+        "event_seq": 42,
+        "session_sample_rate": 1.0,
+        "unknown_field": "should_not_be_here"
+      }
+    }
+  ]
+}

--- a/validation/glean/glean.1.events_session_invalid_sample_rate.fail.json
+++ b/validation/glean/glean.1.events_session_invalid_sample_rate.fail.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "client_info": {
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "architecture": "arm",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "events",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25"
+  },
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "ui",
+      "name": "click",
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3,
+        "event_seq": 42,
+        "session_sample_rate": 1.5
+      }
+    }
+  ]
+}

--- a/validation/glean/glean.1.events_session_missing_required.fail.json
+++ b/validation/glean/glean.1.events_session_missing_required.fail.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "client_info": {
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "architecture": "arm",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "events",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25"
+  },
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "ui",
+      "name": "click",
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3
+      }
+    }
+  ]
+}

--- a/validation/glean/glean.1.events_session_negative_sample_rate.fail.json
+++ b/validation/glean/glean.1.events_session_negative_sample_rate.fail.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "client_info": {
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "architecture": "arm",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "events",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25"
+  },
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "ui",
+      "name": "click",
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3,
+        "event_seq": 42,
+        "session_sample_rate": -0.1
+      }
+    }
+  ]
+}

--- a/validation/glean/glean.1.events_with_session.pass.json
+++ b/validation/glean/glean.1.events_with_session.pass.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "moz://mozilla.org/schemas/glean/ping/1",
+  "client_info": {
+    "app_build": "59f330e5",
+    "app_display_version": "1.0.0",
+    "architecture": "arm",
+    "client_id": "6ff20eb7-e80d-4452-b45f-2ea7e63547aa",
+    "device_manufacturer": "Mozilla",
+    "device_model": "phone123",
+    "first_run_date": "2018-10-23-04:25",
+    "os": "Android",
+    "os_version": "3.2.1",
+    "telemetry_sdk_build": "abcdabcd"
+  },
+  "ping_info": {
+    "ping_type": "events",
+    "seq": 1,
+    "start_time": "2018-10-23 11:23:15-04:00",
+    "end_time": "2018-10-23 11:23:15-04:25"
+  },
+  "events": [
+    {
+      "timestamp": 123456789,
+      "category": "ui",
+      "name": "click",
+      "extra": {
+        "button": "submit"
+      },
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3,
+        "event_seq": 42,
+        "session_sample_rate": 1.0,
+        "session_start_time": "2025-11-10T15:42:00.000Z"
+      }
+    },
+    {
+      "timestamp": 123456791,
+      "category": "glean",
+      "name": "session_start",
+      "extra": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": "3",
+        "session_start_time": "2025-11-10T15:42:00.000Z",
+        "sampled_in": "true"
+      }
+    },
+    {
+      "timestamp": 123456800,
+      "category": "ui",
+      "name": "click",
+      "session": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": 3,
+        "event_seq": 43,
+        "session_sample_rate": 0.5
+      }
+    }
+  ]
+}

--- a/validation/glean/glean.1.events_with_session.pass.json
+++ b/validation/glean/glean.1.events_with_session.pass.json
@@ -55,6 +55,16 @@
         "event_seq": 43,
         "session_sample_rate": 0.5
       }
+    },
+    {
+      "timestamp": 123456900,
+      "category": "glean",
+      "name": "session_end",
+      "extra": {
+        "session_id": "9f9eae08-00b0-4a91-9b08-2287d86d8353",
+        "session_seq": "3",
+        "reason": "inactive"
+      }
     }
   ]
 }


### PR DESCRIPTION
This adds necessary schema for including session metadata recorded by Glean

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
