### PR TITLE
Bug 2040744 - Fix Glean ping_info.server_knobs_config schema

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -869,8 +869,8 @@
               },
               "description": "Map of metric identifiers (category.name) to boolean values indicating whether the metric is enabled",
               "propertyNames": {
-                "maxLength": 61,
-                "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+                "maxLength": 111,
+                "pattern": "^[a-z_][a-z0-9_\\.]+$",
                 "type": "string"
               },
               "type": "object"

--- a/schemas/glean/glean/glean.2.schema.json
+++ b/schemas/glean/glean/glean.2.schema.json
@@ -773,8 +773,8 @@
               },
               "description": "Map of metric identifiers (category.name) to boolean values indicating whether the metric is enabled",
               "propertyNames": {
-                "maxLength": 61,
-                "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+                "maxLength": 111,
+                "pattern": "^[a-z_][a-z0-9_\\.]+$",
                 "type": "string"
               },
               "type": "object"

--- a/templates/include/glean/ping_info.1.schema.json
+++ b/templates/include/glean/ping_info.1.schema.json
@@ -60,11 +60,7 @@
         "metrics_enabled": {
           "type": "object",
           "description": "Map of metric identifiers (category.name) to boolean values indicating whether the metric is enabled",
-          "propertyNames": {
-            "maxLength": 61,
-            "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
-            "type": "string"
-          },
+          "propertyNames": @GLEAN_DOT_SEPARATED_SHORT_ID_1_JSON@,
           "additionalProperties": {
             "type": "boolean"
           }


### PR DESCRIPTION
This addresses the validation in the `ping_info.server_knobs_config` to match the validation applied to the category.name of the metrics.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
