### PR TITLE
feat: add generated branch pushes to GAR

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -1,0 +1,89 @@
+name: Build & publish mozilla-pipeline-schemas artifact
+
+on:
+  push:
+    branches:
+      - generated-schemas
+
+concurrency:
+  group: deploy-schemas-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT: moz-fx-data-artifacts-prod
+  GAR_LOCATION: us
+  GAR_REPOSITORY: mozilla-pipeline-schemas-oci-artifacts
+  GAR_IMAGE: schemas
+  GENERIC_REPOSITORY: mozilla-pipeline-schemas-generic-artifacts
+  SERVICE_ACCOUNT_NAME: mozilla-pipeline-schemas-artif
+
+jobs:
+  deploy:
+    name: Build artifact, push OCI image and generic tarball to GAR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Authenticate to GCP via OIDC
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          service_account: ${{ env.SERVICE_ACCOUNT_NAME }}@${{ env.GCP_PROJECT }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Build schemas tarball and image build context
+        id: archive
+        run: |
+          set -euo pipefail
+          SHORT_REF="$(git rev-parse --short=10 HEAD)"
+          mkdir -p image-context
+          git archive --format tgz --prefix mozilla-pipeline-schemas/ \
+            -o image-context/schemas.tar.gz HEAD schemas/
+          cat > image-context/Dockerfile <<'EOF'
+          FROM scratch
+          COPY schemas.tar.gz /schemas.tar.gz
+          EOF
+          echo "short_ref=${SHORT_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tarball to generic Artifact Registry repo
+        env:
+          SHORT_REF: ${{ steps.archive.outputs.short_ref }}
+        run: |
+          set -euo pipefail
+          gcloud artifacts generic upload \
+            --location="${GAR_LOCATION}" \
+            --project="${GCP_PROJECT}" \
+            --repository="${GENERIC_REPOSITORY}" \
+            --package="${GAR_IMAGE}" \
+            --version="${SHORT_REF}" \
+            --source=image-context/schemas.tar.gz
+
+      - name: Build schemas image
+        id: build
+        uses: mozilla/deploy-actions/docker-build@20256256ac0d19735926dc7975a86dbbb7a06e5f # v6.6.3
+        with:
+          image_name: ${{ env.GAR_IMAGE }}
+          gar_name: ${{ env.GAR_REPOSITORY }}
+          gar_location: ${{ env.GAR_LOCATION }}
+          project_id: ${{ env.GCP_PROJECT }}
+          image_build_context: ./image-context
+          dockerfile_path: ./image-context/Dockerfile
+          should_tag_latest: "true"
+
+      - name: Push schemas image
+        uses: mozilla/deploy-actions/docker-push@20256256ac0d19735926dc7975a86dbbb7a06e5f # v6.6.3
+        with:
+          image_tags: ${{ steps.build.outputs.image_tags }}
+          gar_location: ${{ env.GAR_LOCATION }}
+          project_id: ${{ env.GCP_PROJECT }}
+          service_account_name: ${{ env.SERVICE_ACCOUNT_NAME }}
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}


### PR DESCRIPTION
Checklist for reviewer:

See https://github.com/mozilla/dataservices-infra/pull/2037 for most of the relevant context. You can see test runs via https://github.com/mozilla-services/mozilla-pipeline-schemas/actions/workflows/deploy-schemas.yml that were targeting https://console.cloud.google.com/artifacts/generic/moz-fx-dev-whd-svcse-4252/us/mozilla-pipeline-schemas-generic-artifacts/schemas?project=moz-fx-dev-whd-svcse-4252 and https://console.cloud.google.com/artifacts/docker/moz-fx-dev-whd-svcse-4252/us/mozilla-pipeline-schemas-oci-artifacts/schemas?project=moz-fx-dev-whd-svcse-4252

Another way to handle to push this artifact to GAR is via https://github.com/mozilla/telemetry-airflow/blob/main/dags/probe_scraper.py. That would require granting airflow-gke access to write to the GAR repo, which is currently scoped via OIDC to just GHA on the `generated-schemas` branch.

- [x] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
