### PR TITLE
Add session_sample_rate field to ping_info.server_knobs_config

### DIFF
--- a/schemas/glean/glean/glean.1.schema.json
+++ b/schemas/glean/glean/glean.1.schema.json
@@ -923,6 +923,15 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "session_sample_rate": {
+              "description": "Remote override for the session sampling rate (0.0–1.0).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/schemas/glean/glean/glean.2.schema.json
+++ b/schemas/glean/glean/glean.2.schema.json
@@ -827,6 +827,15 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "session_sample_rate": {
+              "description": "Remote override for the session sampling rate (0.0–1.0).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/templates/include/glean/CHANGELOG.md
+++ b/templates/include/glean/CHANGELOG.md
@@ -106,3 +106,5 @@
 - The `ping_info` section now includes a `server_knobs_config` field which contains the complete Server Knobs configuration applied via `applyServerKnobsConfig`. This includes the `metrics_enabled`, `pings_enabled`, and `event_threshold` settings.
 
 - Session metadata has been added for Glean events, in a `session` field on each event.
+
+- `session_sample_rate` setting added to `ping_info.server_knobs_config`.

--- a/templates/include/glean/ping_info.1.schema.json
+++ b/templates/include/glean/ping_info.1.schema.json
@@ -81,6 +81,12 @@
           "type": ["integer", "null"],
           "description": "Optional threshold for event buffering before an events ping is collected and submitted",
           "minimum": 0
+        },
+        "session_sample_rate": {
+          "type": ["number", "null"],
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Remote override for the session sampling rate (0.0–1.0)."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=2050567

To resolve `org.everit.json.schema.ValidationException: #/ping_info/server_knobs_config: extraneous key [session_sample_rate] is not permitted` schema errors

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [ ] If adding a new field, the field should have a description (see #576 for an example)
- [ ] If coming from a fork, run integration tests: `./.github/push-to-trigger-integration <username>:<branchname>`

For glean changes:
- [ ] Update `templates/include/glean/CHANGELOG.md`

For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](/CODEOWNERS)):
- [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)
